### PR TITLE
7 feature 読み上げ箇所の同期ハイライト

### DIFF
--- a/auticle/background.js
+++ b/auticle/background.js
@@ -24,4 +24,29 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     return true; // 非同期で応答を返すためtrueを返す
   }
+
+  // prefetch 用に audioDataUrl を返すエンドポイント
+  if (message.command === "fetch") {
+    const text = message.text;
+    const ttsUrl = `https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&q=${encodeURIComponent(
+      text
+    )}&tl=ja`;
+
+    fetch(ttsUrl)
+      .then((response) => response.blob())
+      .then((blob) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          // 呼び出し元に audioDataUrl を返す
+          sendResponse({ audioDataUrl: e.target.result });
+        };
+        reader.readAsDataURL(blob);
+      })
+      .catch((error) => {
+        console.error("TTS Fetch Error:", error);
+        sendResponse({ error: String(error) });
+      });
+
+    return true; // 非同期で sendResponse を使うため true を返す
+  }
 });


### PR DESCRIPTION
やったことのまとめ（Issue #7）
クリックされた段落から記事の最後まで、再生中の箇所をハイライトしながら連続再生する機能を実装しました。再生の途切れをなくすため、次に再生する音声データを先読み（プリフェッチ）する仕組みも導入しました。

content.js の主な変更点:

再生キューの導入: クリックされた位置以降の記事全体のテキストを収集し、約200文字ごとの文章の塊（チャンク）に分割。各チャンクがどの段落に属するか（paragraphId）も 함께 playbackQueue 配列に格納します。

連続再生ロジック: <audio>要素のonended（再生終了）イベントをトリガーに、キューの次のチャンクの再生をbackground.jsにリクエストする処理を実装。キューが空になるまでこれを繰り返します。

同期ハイライト機能: updateHighlight()関数を新設。現在再生中のチャンクが属する段落に.auticle-highlightクラスを付与し、ハイライト箇所をリアルタイムで更新します。

音声データの先読み（プリフェッチ）: 再生中のチャンクの次に再生するチャンク（デフォルトで2つ先まで）の音声データを、background.jsに非同期でリクエストし、audioCacheに保存。これにより、チャンク間の再生の途切れを最小限に抑えます。

background.js の主な変更点:

プリフェッチ用コマンドの追加: content.jsからの先読みリクエストを処理するためのfetchコマンドを追加。このコマンドは、受け取ったテキストの音声データ(data: URL)を生成し、content.jsに返します。

既存のplayコマンドは、即時再生用として維持。

テスト方法
1. 準備
chrome://extensions/ ページでAuticle拡張機能をリロード（更新）する。

任意の記事ページを開き、拡張機能のポップアップから「読み上げモード」をONにする。

2. 基本動作の確認
記事中の任意の段落をクリックする。

期待する結果:

クリックされた段落から音声再生が開始される。

再生が約200文字で途切れることなく、次の文章へ自動的に連続再生される。

現在再生されている文章が含まれる段落が、リアルタイムでハイライト表示される。

再生が進むにつれて、ハイライトされる段落が自動で追従して移動する。

3. 再生中断・再開の確認
音声が再生されている最中に、別の段落をクリックする。

期待する結果:

それまでの再生が即座に停止する。

新しくクリックされた段落から、連続再生とハイライトが開始される。

4. プリフェッチ効果の確認（任意）
Chromeの開発者ツールを開き、「Network」タブのスロットリング設定を「Slow 3G」にする。

その状態で段落をクリックし、連続再生を開始する。

期待する結果:

ネットワークが遅いにも関わらず、チャンク間の再生の途切れ（無音時間）がほとんどない、または大幅に軽減されていることを確認する。

5. 終了処理の確認
記事の最後まで再生が完了するのを待つ。

期待する結果:

再生が完全に終了すると、すべてのハイライトが解除される。