### PR TITLE
feat(web-app-vercel): NextAuth 設定を lib/auth に集約して認証を共通化

### DIFF
--- a/packages/web-app-vercel/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web-app-vercel/app/api/auth/[...nextauth]/route.ts
@@ -1,26 +1,3 @@
-import NextAuth from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
+import { handlers } from "@/lib/auth";
 
-const allowedUsers = process.env.ALLOWED_USERS?.split(',') || [];
-
-const handler = NextAuth({
-    providers: [
-        GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID!,
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-        }),
-    ],
-    callbacks: {
-        async signIn({ user }) {
-            const email = user.email;
-            if (!email) return false;
-            return allowedUsers.includes(email);
-        },
-    },
-    pages: {
-        signIn: '/auth/signin',
-        error: '/auth/error',
-    },
-});
-
-export { handler as GET, handler as POST };
+export const { GET, POST } = handlers;

--- a/packages/web-app-vercel/app/auth/signin/page.tsx
+++ b/packages/web-app-vercel/app/auth/signin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { signIn } from "next-auth/react";
+import { signIn } from "@/lib/auth";
 
 export default function SignIn() {
   return (

--- a/packages/web-app-vercel/lib/auth.ts
+++ b/packages/web-app-vercel/lib/auth.ts
@@ -1,0 +1,27 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+const allowedUsers = process.env.ALLOWED_USERS?.split(',').map(email => email.trim()) || [];
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+    providers: [
+        GoogleProvider({
+            clientId: process.env.GOOGLE_CLIENT_ID!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+        }),
+    ],
+    callbacks: {
+        async signIn({ user }) {
+            const email = user.email;
+            if (!email) return false;
+            const isAllowed = allowedUsers.includes(email);
+            console.log('SignIn attempt:', email, 'Allowed:', isAllowed);
+            return isAllowed;
+        },
+    },
+    pages: {
+        signIn: '/auth/signin',
+        error: '/auth/error',
+    },
+    trustHost: true,
+});

--- a/packages/web-app-vercel/middleware.ts
+++ b/packages/web-app-vercel/middleware.ts
@@ -1,15 +1,12 @@
-export { default } from 'next-auth/middleware';
+import { auth } from "@/lib/auth";
+
+export default auth((req) => {
+    if (!req.auth && !req.nextUrl.pathname.startsWith('/auth')) {
+        const newUrl = new URL('/auth/signin', req.nextUrl.origin);
+        return Response.redirect(newUrl);
+    }
+});
 
 export const config = {
-    matcher: [
-        /*
-         * 以下のパスを除外:
-         * - api (API routes)
-         * - auth (認証ページ)
-         * - _next/static (静的ファイル)
-         * - _next/image (画像最適化)
-         * - favicon.ico (ファビコン)
-         */
-        '/((?!api|auth|_next/static|_next/image|favicon.ico).*)',
-    ],
+    matcher: ['/((?!api|auth|_next/static|_next/image|favicon.ico).*)'],
 };

--- a/packages/web-app-vercel/package.json
+++ b/packages/web-app-vercel/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "next": "15.5.4",
-    "next-auth": "^4.24.10",
+    "next-auth": "^5.0.0-beta.30",
     "next-pwa": "^5.6.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"


### PR DESCRIPTION
- packages/web-app-vercel/lib/auth.ts を追加し NextAuth の handlers/auth/signIn/ signOut をエクスポート
- API route (/app/api/auth/[...nextauth]/route.ts) を共通 handlers を利用するよう置換
- サインインページ (app/auth/signin/page.tsx) と middleware.ts を共通 signIn/auth に差し替え
- next-auth を v5.0.0-beta に更新