### PR TITLE
Change TTS default speed to 1.0x and enable PWA in production

### DIFF
--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -186,7 +186,7 @@ export async function POST(request: NextRequest) {
         }
 
         const voiceToUse = voice || 'ja-JP-Neural2-B';
-        const speakingRate = speed || 2.0;
+        const speakingRate = speed || 1.0;
 
         // テキストを分割
         const textChunks = splitText(text);

--- a/packages/web-app-vercel/next.config.ts
+++ b/packages/web-app-vercel/next.config.ts
@@ -19,19 +19,30 @@ export default withPWA({
   dest: "public",
   register: true,
   skipWaiting: true,
-  disable: process.env.NODE_ENV === "development",
+  disable: false,
   // PWAがAPI Routesをキャッシュしないように設定
   runtimeCaching: [
     {
-      urlPattern: /^https?.*/,
+      urlPattern: /^https?.*(?!\/api\/).*/ ,
+      handler: 'CacheFirst',
+      options: {
+        cacheName: 'staticCache',
+        expiration: {
+          maxEntries: 60,
+          maxAgeSeconds: 24 * 60 * 60,
+        },
+      },
+    },
+    {
+      urlPattern: /\/api\/.*/,
       handler: 'NetworkFirst',
       options: {
-        cacheName: 'offlineCache',
+        cacheName: 'apiCache',
         expiration: {
-          maxEntries: 200,
+          maxEntries: 50,
+          maxAgeSeconds: 60 * 60,
         },
-        // API Routesを除外
-        networkTimeoutSeconds: 10,
+        networkTimeoutSeconds: 5,
       },
     },
   ],


### PR DESCRIPTION
Adjust the default text-to-speech playback speed from 2.0x to 1.0x and enable the PWA configuration for the production environment.