### PR TITLE
fix: Correct JOIN syntax in playlist-items API

### DIFF
--- a/packages/web-app-vercel/app/api/playlist-items/[itemId]/playlists/route.ts
+++ b/packages/web-app-vercel/app/api/playlist-items/[itemId]/playlists/route.ts
@@ -15,7 +15,7 @@ export async function GET(
         // itemIdからarticle_idを取得し、同時に所有権を確認
         const { data: itemData, error: itemError } = await supabase
             .from('playlist_items')
-            .select('article_id, playlists(owner_email)')
+            .select('article_id, playlist_id')
             .eq('id', itemId)
             .single()
 
@@ -23,9 +23,14 @@ export async function GET(
             return NextResponse.json({ error: 'Item not found' }, { status: 404 })
         }
 
-        const playlistsData = itemData.playlists as { owner_email?: string } | null
+        // playlist_idから所有権を確認
+        const { data: playlistData, error: playlistError } = await supabase
+            .from('playlists')
+            .select('owner_email')
+            .eq('id', itemData.playlist_id)
+            .single()
 
-        if (!playlistsData || playlistsData.owner_email !== userEmail) {
+        if (playlistError || !playlistData || playlistData.owner_email !== userEmail) {
             return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
         }
 


### PR DESCRIPTION
- Remove invalid 'playlists(owner_email)' JOIN syntax
- Split ownership verification into two separate queries
- Resolves 500 error in /api/playlist-items/[itemId]/playlists