### PR TITLE
Fix 500 error by removing invalid position column sort

### DIFF
--- a/packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts
+++ b/packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts
@@ -39,7 +39,6 @@ export async function GET(
             .select('*')
             .eq('owner_email', userEmail)
             .in('id', playlistIds)
-            .order('position', { ascending: true })
             .order('is_default', { ascending: false })
             .order('created_at', { ascending: false })
 


### PR DESCRIPTION
- Remove .order('position') since position column doesn't exist in playlists table
- Keep is_default and created_at sorting for proper playlist ordering
- This resolves the Supabase column does not exist error