### PR TITLE
変更内容:

### DIFF
--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -716,13 +716,7 @@ export default function ReaderPageClient() {
           <ReaderView
             chunks={chunks}
             currentChunkId={currentChunkId}
-            articleUrl={
-              url ||
-              (articleId
-                ? articleStorage.getById(articleId)?.url
-                : undefined) ||
-              ""
-            }
+            articleUrl={url}
             voiceModel={settings.voice_model}
             speed={playbackRate}
             onChunkClick={seekToChunk}

--- a/packages/web-app-vercel/lib/api.ts
+++ b/packages/web-app-vercel/lib/api.ts
@@ -66,7 +66,7 @@ async function fetchTTSFromAPI(
   if (voiceModel) {
     request.voice_model = voiceModel;
   }
-  if (articleUrl !== undefined) {
+  if (articleUrl) {
     request.articleUrl = articleUrl;
   }
   // playbackSpeedはフロントエンドでの再生速度制御用なのでAPIには渡さない


### PR DESCRIPTION
- `setChunks(chunksWithId);` の後に `setUrl(articleUrl);` を挿入

これで、記事読み込み時に url も適切に設定されるようになり、API リクエストで articleUrl が送信される問題が解決されます。