### PR TITLE
Remove playback completion handler and streamline KV metadata updates

### DIFF
--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -336,7 +336,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       // 記事の再生が終了したときのコールバック
       onArticleEndRef.current?.();
     }
-  }, [chunks, setIsPlaying, setCurrentIndex, playFromIndex, articleUrl, voiceModel, handlePlaybackComplete]);
+  }, [chunks, setIsPlaying, setCurrentIndex, playFromIndex, articleUrl, voiceModel]);
 
   // 再生開始
   const play = useCallback(() => {


### PR DESCRIPTION
Eliminate the `handlePlaybackComplete` function to simplify the playback completion process and enhance the handling of KV metadata updates.