### PR TITLE
Fix index calculation and improve playback speed change behavior in PlaybackSpeedDial component

### DIFF
--- a/packages/web-app-vercel/components/PlaybackSpeedDial.tsx
+++ b/packages/web-app-vercel/components/PlaybackSpeedDial.tsx
@@ -95,10 +95,9 @@ export function PlaybackSpeedDial({
     }
 
     const roundedIndex = Math.round(previewIndex);
-    const clampedIndex = Math.max(0, Math.min(speeds.length - 1, roundedIndex));
-    setSelectedIndex(clampedIndex);
-    setPreviewIndex(clampedIndex);
-    onValueChange(speeds[clampedIndex]);
+    setSelectedIndex(roundedIndex);
+    setPreviewIndex(roundedIndex);
+    onValueChange(speeds[roundedIndex]);
     setDragOffset(0);
   }, [previewIndex, totalItemWidth, speeds, onValueChange]);
 


### PR DESCRIPTION
Correct the preview index calculation during drag operations and enhance the behavior when changing playback speed. Simplify the index calculation for better readability.