### PR TITLE
fix: プレイリスト並び替え後のクリック遷移で旧順序が使われる不具合を修正

### DIFF
--- a/packages/web-app-vercel/app/playlists/[id]/page.tsx
+++ b/packages/web-app-vercel/app/playlists/[id]/page.tsx
@@ -276,7 +276,7 @@ export default function PlaylistDetailPage() {
                   onValueChange={(value) => {
                     if (isSortOption(value)) {
                       setSortOption(value);
-                      // 追加: 並び替え変更時に即座にlocalStorageに保存
+                      // 即座にlocalStorageに保存（useEffectによる保存より前にナビゲーションが発生する可能性があるため）
                       setPlaylistSortKey(playlistId, value);
                     }
                   }}

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -722,10 +722,10 @@ export default function ReaderPageClient() {
     // Initialize playlist from query if either:
     //  - playlistState is not already in playlist mode
     //  - OR we are in playlist mode but the playlistId does not match the query
+    //  - OR sortKey does not match (sort order has changed)
     if (
       playlistIdFromQuery &&
-      (!playlistState.isPlaylistMode ||
-        playlistState.playlistId !== playlistIdFromQuery) &&
+      !isPlaylistContextReady &&
       session?.user?.email
     ) {
       logger.info("Reader opened with playlist query, initializing playlist", {
@@ -740,7 +740,7 @@ export default function ReaderPageClient() {
     }
   }, [
     playlistIdFromQuery,
-    playlistState.isPlaylistMode,
+    isPlaylistContextReady,
     initializeFromPlaylist,
     indexFromQuery,
     session,

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -162,6 +162,7 @@ export function PlaylistPlaybackProvider({
         isPlaylistMode: true,
         sortField: null,
         sortOrder: null,
+        sortKey: null,
       });
 
       // 最初の記事に遷移（自動再生フラグ付き）
@@ -278,6 +279,7 @@ export function PlaylistPlaybackProvider({
       isPlaylistMode: false,
       sortField: null,
       sortOrder: null,
+      sortKey: null,
     });
   }, []);
 

--- a/packages/web-app-vercel/lib/playlist-utils.ts
+++ b/packages/web-app-vercel/lib/playlist-utils.ts
@@ -27,7 +27,11 @@ export function getPlaylistSortKey(playlistId: string): string {
 export function setPlaylistSortKey(playlistId: string, sortKey: string): void {
     if (typeof window === "undefined") return;
     const storageKey = `${STORAGE_KEYS.PLAYLIST_SORT_PREFIX}${playlistId}`;
-    localStorage.setItem(storageKey, sortKey);
+    try {
+        localStorage.setItem(storageKey, sortKey);
+    } catch (e) {
+        console.warn("Failed to save playlist sort key:", e);
+    }
 }
 
 /**


### PR DESCRIPTION
## 概要
プレイリスト画面で並び替えを変更した後に、表示順は変わるのにクリック遷移が旧順序（追加順）になる問題を修正しました。

## 問題
- プレイリスト画面で並び替えを「タイトル順」などに変更
- 表示は正しく並び替えられる
- アイテムをクリックしてReaderに遷移
- **Readerでは旧順序（追加順）のプレイリストアイテムが使われていた**

## 根本原因
- `PlaylistPlaybackContext`がlocalStorageから読み込んだプレイリスト状態に`sortKey`が含まれていなかった
- `ReaderClient`の`isPlaylistContextReady`チェックが`playlistId`の一致のみで判定
- sortKeyが変更されても、同じplaylistIdなら古いitemsを再利用していた

## 修正内容

### 1. sortKey管理のユーティリティ関数追加 ([lib/playlist-utils.ts](https://github.com/is0692vs/Audicle/blob/416-vercelプレイリスト並び替え後クリック遷移が旧順序になる不具合/packages/web-app-vercel/lib/playlist-utils.ts))
```typescript
export function getPlaylistSortKey(playlistId: string): string
export function setPlaylistSortKey(playlistId: string, sortKey: string): void
```

### 2. PlaylistPlaybackStateにsortKeyフィールド追加 ([contexts/PlaylistPlaybackContext.tsx](https://github.com/is0692vs/Audicle/blob/416-vercelプレイリスト並び替え後クリック遷移が旧順序になる不具合/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx))
- `sortKey: string | null`を追加
- `savePlaybackState`でsortKeyも保存
- `initializeFromArticle`と`initializeFromPlaylist`でsortKeyを設定

### 3. ReaderClientでsortKey一致チェック追加 ([app/reader/ReaderClient.tsx](https://github.com/is0692vs/Audicle/blob/416-vercelプレイリスト並び替え後クリック遷移が旧順序になる不具合/packages/web-app-vercel/app/reader/ReaderClient.tsx))
```typescript
const currentSortKey = playlistIdFromQuery
  ? getPlaylistSortKey(playlistIdFromQuery)
  : null;
const isPlaylistContextReady =
  !!playlistIdFromQuery &&
  playlistState.isPlaylistMode &&
  playlistState.playlistId === playlistIdFromQuery &&
  playlistState.items.length > 0 &&
  playlistState.sortKey === currentSortKey; // 追加
```

### 4. playlists画面でsort変更を即座に保存 ([app/playlists/[id]/page.tsx](https://github.com/is0692vs/Audicle/blob/416-vercelプレイリスト並び替え後クリック遷移が旧順序になる不具合/packages/web-app-vercel/app/playlists/[id]/page.tsx))
- `Select`の`onValueChange`内で`setPlaylistSortKey`を即座に呼び出し

## テスト手順
1. プレイリスト画面で並び替えを「タイトル順」に変更
2. すぐにアイテムをクリックしてReader画面に遷移
3. 前へ/次へボタンで移動した時に、タイトル順で移動することを確認

## 影響範囲
- プレイリスト再生機能のコンテキスト管理
- localStorageの永続化データ構造（後方互換性あり）

Closes #416