### PR TITLE
Remove debug console logs from useAutoScroll hook

### DIFF
--- a/packages/web-app-vercel/convert-icons.js
+++ b/packages/web-app-vercel/convert-icons.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const { createCanvas, loadImage } = require("canvas");
+const { createCanvas } = require("canvas");
 
 // SVGをPNGに変換する関数
 async function convertSvgToPng(svgPath, pngPath, size) {

--- a/packages/web-app-vercel/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web-app-vercel/hooks/__tests__/useAutoScroll.test.ts
@@ -1,0 +1,163 @@
+import { renderHook, act } from "@testing-library/react";
+import { useAutoScroll } from "../useAutoScroll";
+
+describe("useAutoScroll", () => {
+  let scrollIntoViewMock: jest.Mock;
+  let scrollToMock: jest.Mock;
+  let consoleLogMock: jest.Mock;
+  let consoleWarnMock: jest.Mock;
+
+  beforeEach(() => {
+    // Mock scroll methods
+    scrollIntoViewMock = jest.fn();
+    scrollToMock = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    Element.prototype.scrollTo = scrollToMock;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    HTMLElement.prototype.scrollTo = scrollToMock;
+
+    // Mock console methods to avoid cluttering test output and to verify calls
+    consoleLogMock = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Setup DOM
+    document.body.innerHTML = `
+      <div id="container" style="height: 500px; overflow: auto;">
+        <div data-audicle-id="chunk-1" style="height: 100px;">Chunk 1</div>
+        <div data-audicle-id="chunk-2" style="height: 100px;">Chunk 2</div>
+        <div data-audicle-id="chunk-3" style="height: 100px;">Chunk 3</div>
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+    jest.useRealTimers();
+  });
+
+  it("should scroll element into view when currentChunkId changes (window scroll)", () => {
+    jest.useFakeTimers();
+
+    renderHook(() =>
+      useAutoScroll({
+        currentChunkId: "chunk-1",
+        enabled: true,
+        delay: 0,
+      })
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+
+    // Verify console.log was NOT called
+    expect(consoleLogMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("[useAutoScroll] ウィンドウスクロール")
+    );
+  });
+
+  it("should scroll container when containerRef is provided", () => {
+    jest.useFakeTimers();
+
+    const container = document.getElementById("container") as HTMLDivElement;
+    const containerRef = { current: container };
+
+    // Mock getBoundingClientRect for calculations
+    jest.spyOn(container, "getBoundingClientRect").mockReturnValue({
+        top: 0,
+        height: 500,
+        left: 0,
+        width: 500,
+        right: 500,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+    });
+
+    const element = document.querySelector('[data-audicle-id="chunk-2"]') as HTMLElement;
+    jest.spyOn(element, "getBoundingClientRect").mockReturnValue({
+        top: 200, // 200px down
+        height: 100,
+        left: 0,
+        width: 100,
+        right: 100,
+        bottom: 300,
+        x: 0,
+        y: 200,
+        toJSON: () => {}
+    });
+
+    renderHook(() =>
+      useAutoScroll({
+        currentChunkId: "chunk-2",
+        containerRef,
+        enabled: true,
+        delay: 0,
+      })
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+            behavior: "smooth",
+            left: 0,
+        })
+    );
+
+    // Verify console.log was NOT called
+    expect(consoleLogMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("[useAutoScroll] コンテナ内スクロール")
+    );
+  });
+
+  it("should not scroll when enabled is false", () => {
+    jest.useFakeTimers();
+
+    renderHook(() =>
+      useAutoScroll({
+        currentChunkId: "chunk-1",
+        enabled: false,
+        delay: 0,
+      })
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(scrollToMock).not.toHaveBeenCalled();
+  });
+
+  it("should warn when chunk element is not found", () => {
+    jest.useFakeTimers();
+
+    renderHook(() =>
+      useAutoScroll({
+        currentChunkId: "non-existent-chunk",
+        enabled: true,
+        delay: 0,
+      })
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("[useAutoScroll] チャンクが見つかりません")
+    );
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-app-vercel/hooks/useAutoScroll.ts
+++ b/packages/web-app-vercel/hooks/useAutoScroll.ts
@@ -67,9 +67,6 @@ function scrollElementIntoView(
                 left: 0,
             });
 
-            console.log(
-                `[useAutoScroll] コンテナ内スクロール: chunkId=${chunkId}, scrollTop=${Math.round(scrollTop)}`
-            );
         } else {
             // windowをスクロール対象とする場合
             // scrollIntoViewを使用（Chrome拡張版と同等）
@@ -79,9 +76,6 @@ function scrollElementIntoView(
                 inline: "nearest",
             });
 
-            console.log(
-                `[useAutoScroll] ウィンドウスクロール: chunkId=${chunkId}`
-            );
         }
     } catch (error) {
         console.warn(`[useAutoScroll] スクロール失敗:`, error);


### PR DESCRIPTION
- Removed `console.log` statements for "コンテナ内スクロール" and "ウィンドウスクロール" in `packages/web-app-vercel/hooks/useAutoScroll.ts`.
- Created `packages/web-app-vercel/hooks/__tests__/useAutoScroll.test.ts` to verify hook functionality.
- Mocked `scrollIntoView` and `scrollTo` in tests as JSDOM does not implement them.
- Verified that `console.log` is not called, while `console.warn` is preserved for errors.

Verification:
- `npm test packages/web-app-vercel/hooks/__tests__/useAutoScroll.test.ts` passes.
- Tests explicitly check that `console.log` is not invoked during scrolling.

---
*PR created automatically by Jules for task [15460306816493971450](https://jules.google.com/task/15460306816493971450) started by @is0692vs*