### PR TITLE
feat: 連続再生 - リピート・シャッフルモード追加

### DIFF
--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -38,6 +38,14 @@ import {
   Repeat1,
   Shuffle,
 } from "lucide-react";
+import type { RepeatMode } from "@/contexts/PlaylistPlaybackContext";
+
+// リピートモードのラベルマップ
+const repeatModeLabels: Record<RepeatMode, string> = {
+  off: "リピート: オフ",
+  one: "リピート: 1曲",
+  all: "リピート: 全曲",
+};
 
 function convertParagraphsToChunks(htmlContent: string): {
   chunks: Chunk[];
@@ -164,18 +172,27 @@ export default function ReaderPageClient() {
 
   const handleArticleEnd = useCallback(() => {
     if (isPlaylistMode && playlistState.isPlaylistMode) {
-      // リピートoff + 最後の記事 → 完了画面
-      if (
-        playlistState.repeatMode === "off" &&
-        currentPlaylistIndex >= playlistState.totalCount - 1 &&
-        !playlistState.shuffle
-      ) {
-        setShowCompletionScreen(true);
-        logger.info("プレイリスト完了", {
-          playlistId: playlistState.playlistId,
-          totalCount: playlistState.totalCount,
-        });
-        return;
+      // リピートoff時の完了判定
+      if (playlistState.repeatMode === "off") {
+        let isAtEnd = false;
+        if (playlistState.shuffle) {
+          // シャッフルモード: シャッフルキューの最後かどうか確認
+          const shuffledIndices = playlistState.shuffledIndices;
+          const currentShufflePos = shuffledIndices.indexOf(currentPlaylistIndex);
+          isAtEnd = currentShufflePos >= shuffledIndices.length - 1;
+        } else {
+          isAtEnd = currentPlaylistIndex >= playlistState.totalCount - 1;
+        }
+
+        if (isAtEnd) {
+          setShowCompletionScreen(true);
+          logger.info("プレイリスト完了", {
+            playlistId: playlistState.playlistId,
+            totalCount: playlistState.totalCount,
+            shuffle: playlistState.shuffle,
+          });
+          return;
+        }
       }
 
       // onArticleEndがrepeatMode/shuffleに応じて適切に処理する
@@ -194,6 +211,7 @@ export default function ReaderPageClient() {
     playlistState.playlistId,
     playlistState.repeatMode,
     playlistState.shuffle,
+    playlistState.shuffledIndices,
     currentPlaylistIndex,
     onArticleEnd,
   ]);
@@ -1075,20 +1093,8 @@ export default function ReaderPageClient() {
                             : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
                         }`}
                         data-testid="desktop-repeat-button"
-                        title={
-                          playlistState.repeatMode === "off"
-                            ? "リピート: オフ"
-                            : playlistState.repeatMode === "one"
-                              ? "リピート: 1曲"
-                              : "リピート: 全曲"
-                        }
-                        aria-label={
-                          playlistState.repeatMode === "off"
-                            ? "リピート: オフ"
-                            : playlistState.repeatMode === "one"
-                              ? "リピート: 1曲"
-                              : "リピート: 全曲"
-                        }
+                        title={repeatModeLabels[playlistState.repeatMode]}
+                        aria-label={repeatModeLabels[playlistState.repeatMode]}
                       >
                         {playlistState.repeatMode === "one" ? (
                           <Repeat1 className="size-5" />
@@ -1295,20 +1301,8 @@ export default function ReaderPageClient() {
                       : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
                   }`}
                   data-testid="mobile-repeat-button"
-                  title={
-                    playlistState.repeatMode === "off"
-                      ? "リピート: オフ"
-                      : playlistState.repeatMode === "one"
-                        ? "リピート: 1曲"
-                        : "リピート: 全曲"
-                  }
-                  aria-label={
-                    playlistState.repeatMode === "off"
-                      ? "リピート: オフ"
-                      : playlistState.repeatMode === "one"
-                        ? "リピート: 1曲"
-                        : "リピート: 全曲"
-                  }
+                  title={repeatModeLabels[playlistState.repeatMode]}
+                  aria-label={repeatModeLabels[playlistState.repeatMode]}
                 >
                   {playlistState.repeatMode === "one" ? (
                     <Repeat1 className="size-4" />

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -34,6 +34,9 @@ import {
   ListPlus,
   ExternalLink,
   Download,
+  Repeat,
+  Repeat1,
+  Shuffle,
 } from "lucide-react";
 
 function convertParagraphsToChunks(htmlContent: string): {
@@ -74,6 +77,8 @@ export default function ReaderPageClient() {
     initializeFromPlaylist,
     canMovePrevious,
     canMoveNext,
+    toggleRepeatMode,
+    toggleShuffle,
   } = usePlaylistPlayback();
 
   const [url, setUrl] = useState("");
@@ -159,8 +164,12 @@ export default function ReaderPageClient() {
 
   const handleArticleEnd = useCallback(() => {
     if (isPlaylistMode && playlistState.isPlaylistMode) {
-      // プレイリストの最後の記事の場合は完了画面を表示
-      if (currentPlaylistIndex >= playlistState.totalCount - 1) {
+      // リピートoff + 最後の記事 → 完了画面
+      if (
+        playlistState.repeatMode === "off" &&
+        currentPlaylistIndex >= playlistState.totalCount - 1 &&
+        !playlistState.shuffle
+      ) {
         setShowCompletionScreen(true);
         logger.info("プレイリスト完了", {
           playlistId: playlistState.playlistId,
@@ -169,10 +178,12 @@ export default function ReaderPageClient() {
         return;
       }
 
-      // そうでなければ次の記事へ進む
+      // onArticleEndがrepeatMode/shuffleに応じて適切に処理する
       logger.info("次の記事へ進む", {
         currentIndex: currentPlaylistIndex,
         totalCount: playlistState.totalCount,
+        repeatMode: playlistState.repeatMode,
+        shuffle: playlistState.shuffle,
       });
       onArticleEnd();
     }
@@ -181,6 +192,8 @@ export default function ReaderPageClient() {
     playlistState.isPlaylistMode,
     playlistState.totalCount,
     playlistState.playlistId,
+    playlistState.repeatMode,
+    playlistState.shuffle,
     currentPlaylistIndex,
     onArticleEnd,
   ]);
@@ -975,6 +988,22 @@ export default function ReaderPageClient() {
                   <div className="flex items-center gap-3 sm:gap-4">
                     {playlistState.isPlaylistMode && (
                       <button
+                        onClick={toggleShuffle}
+                        className={`p-2 rounded-full transition-colors ${
+                          playlistState.shuffle
+                            ? "text-green-500 hover:bg-green-500/10"
+                            : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                        }`}
+                        data-testid="desktop-shuffle-button"
+                        title={playlistState.shuffle ? "シャッフル: オン" : "シャッフル: オフ"}
+                        aria-label={playlistState.shuffle ? "シャッフル: オン" : "シャッフル: オフ"}
+                      >
+                        <Shuffle className="size-5" />
+                      </button>
+                    )}
+
+                    {playlistState.isPlaylistMode && (
+                      <button
                         onClick={() => {
                           if (isPlaylistContextReady && canMovePrevious) {
                             navigateToPlaylistItem(
@@ -1034,6 +1063,38 @@ export default function ReaderPageClient() {
                         aria-label="次の記事"
                       >
                         <SkipForward className="size-5" />
+                      </button>
+                    )}
+
+                    {playlistState.isPlaylistMode && (
+                      <button
+                        onClick={toggleRepeatMode}
+                        className={`p-2 rounded-full transition-colors ${
+                          playlistState.repeatMode !== "off"
+                            ? "text-green-500 hover:bg-green-500/10"
+                            : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                        }`}
+                        data-testid="desktop-repeat-button"
+                        title={
+                          playlistState.repeatMode === "off"
+                            ? "リピート: オフ"
+                            : playlistState.repeatMode === "one"
+                              ? "リピート: 1曲"
+                              : "リピート: 全曲"
+                        }
+                        aria-label={
+                          playlistState.repeatMode === "off"
+                            ? "リピート: オフ"
+                            : playlistState.repeatMode === "one"
+                              ? "リピート: 1曲"
+                              : "リピート: 全曲"
+                        }
+                      >
+                        {playlistState.repeatMode === "one" ? (
+                          <Repeat1 className="size-5" />
+                        ) : (
+                          <Repeat className="size-5" />
+                        )}
                       </button>
                     )}
                   </div>
@@ -1149,6 +1210,22 @@ export default function ReaderPageClient() {
               {/* Prev - Play - Next (center aligned) */}
               {playlistState.isPlaylistMode && (
                 <button
+                  onClick={toggleShuffle}
+                  className={`p-2 rounded-full transition-colors ${
+                    playlistState.shuffle
+                      ? "text-green-500 hover:bg-green-500/10"
+                      : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  }`}
+                  data-testid="mobile-shuffle-button"
+                  title={playlistState.shuffle ? "シャッフル: オン" : "シャッフル: オフ"}
+                  aria-label={playlistState.shuffle ? "シャッフル: オン" : "シャッフル: オフ"}
+                >
+                  <Shuffle className="size-4" />
+                </button>
+              )}
+
+              {playlistState.isPlaylistMode && (
+                <button
                   onClick={() => {
                     if (isPlaylistContextReady && canMovePrevious) {
                       navigateToPlaylistItem(
@@ -1206,6 +1283,38 @@ export default function ReaderPageClient() {
                   aria-label="次の記事"
                 >
                   <SkipForward className="size-5" />
+                </button>
+              )}
+
+              {playlistState.isPlaylistMode && (
+                <button
+                  onClick={toggleRepeatMode}
+                  className={`p-2 rounded-full transition-colors ${
+                    playlistState.repeatMode !== "off"
+                      ? "text-green-500 hover:bg-green-500/10"
+                      : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  }`}
+                  data-testid="mobile-repeat-button"
+                  title={
+                    playlistState.repeatMode === "off"
+                      ? "リピート: オフ"
+                      : playlistState.repeatMode === "one"
+                        ? "リピート: 1曲"
+                        : "リピート: 全曲"
+                  }
+                  aria-label={
+                    playlistState.repeatMode === "off"
+                      ? "リピート: オフ"
+                      : playlistState.repeatMode === "one"
+                        ? "リピート: 1曲"
+                        : "リピート: 全曲"
+                  }
+                >
+                  {playlistState.repeatMode === "one" ? (
+                    <Repeat1 className="size-4" />
+                  ) : (
+                    <Repeat className="size-4" />
+                  )}
                 </button>
               )}
             </div>

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -13,6 +13,14 @@ import { STORAGE_KEYS } from "@/lib/constants";
 import { logger } from "@/lib/logger";
 import type { PlaylistItemWithArticle } from "@/types/playlist";
 
+/**
+ * リピートモード:
+ * - "off"  : リピートなし（プレイリスト末尾で停止）
+ * - "one"  : 1記事リピート（同じ記事を繰り返し再生）
+ * - "all"  : プレイリストリピート（末尾到達後、先頭に戻る）
+ */
+export type RepeatMode = "off" | "one" | "all";
+
 // デバッグログ用の定数
 const DEBUG_QUEUE_PREVIEW_COUNT = 5; // キュー順序ログに出力するアイテム数
 const DEBUG_TITLE_MAX_LENGTH = 30; // タイトルの最大文字数
@@ -46,6 +54,9 @@ export interface PlaylistPlaybackState {
   sortField: string | null;
   sortOrder: "asc" | "desc" | null;
   sortKey: string | null; // "position", "title", "title-desc", "added_at", "added_at-desc" など
+  repeatMode: RepeatMode;
+  shuffle: boolean;
+  shuffledIndices: number[]; // シャッフル時のインデックス順序
 }
 
 export interface PlaylistPlaybackContextType {
@@ -68,6 +79,8 @@ export interface PlaylistPlaybackContextType {
   ) => Promise<void>;
   canMovePrevious: boolean;
   canMoveNext: boolean;
+  toggleRepeatMode: () => void;
+  toggleShuffle: () => void;
 }
 
 const PlaylistPlaybackContext = createContext<
@@ -99,6 +112,26 @@ function parseSortOption(sortOption: string | null): {
   return { field: "position", order: "asc" };
 }
 
+/**
+ * Fisher-Yates シャッフルアルゴリズムでインデックス配列を生成
+ */
+export function generateShuffledIndices(length: number, currentIndex?: number): number[] {
+  const indices = Array.from({ length }, (_, i) => i);
+  // Fisher-Yates shuffle
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [indices[i], indices[j]] = [indices[j], indices[i]];
+  }
+  // 現在再生中のインデックスを先頭に持ってくる
+  if (currentIndex !== undefined && currentIndex >= 0 && currentIndex < length) {
+    const pos = indices.indexOf(currentIndex);
+    if (pos > 0) {
+      [indices[0], indices[pos]] = [indices[pos], indices[0]];
+    }
+  }
+  return indices;
+}
+
 function savePlaybackState(state: PlaylistPlaybackState): void {
   if (typeof window !== "undefined") {
     try {
@@ -113,7 +146,10 @@ function savePlaybackState(state: PlaylistPlaybackState): void {
           isPlaylistMode: state.isPlaylistMode,
           sortField: state.sortField,
           sortOrder: state.sortOrder,
-          sortKey: state.sortKey, // 追加: sortKeyも保存
+          sortKey: state.sortKey,
+          repeatMode: state.repeatMode,
+          shuffle: state.shuffle,
+          shuffledIndices: state.shuffledIndices,
         })
       );
     } catch (error) {
@@ -155,7 +191,10 @@ export function PlaylistPlaybackProvider({
       isPlaylistMode: saved?.isPlaylistMode || false,
       sortField: saved?.sortField || null,
       sortOrder: saved?.sortOrder || null,
-      sortKey: saved?.sortKey || null, // 追加: sortKeyを読み込み
+      sortKey: saved?.sortKey || null,
+      repeatMode: (saved as PlaylistPlaybackState | null)?.repeatMode || "off",
+      shuffle: (saved as PlaylistPlaybackState | null)?.shuffle || false,
+      shuffledIndices: (saved as PlaylistPlaybackState | null)?.shuffledIndices || [],
     };
   });
 
@@ -191,16 +230,25 @@ export function PlaylistPlaybackProvider({
       // sortKeyからsortFieldとsortOrderをパース
       const { field: sortField, order: sortOrder } = parseSortOption(sortKey || null);
 
-      setState({
-        playlistId,
-        playlistName,
-        currentIndex: startIndex,
-        items,
-        totalCount: items.length,
-        isPlaylistMode: true,
-        sortField,
-        sortOrder,
-        sortKey: sortKey || "position",
+      setState((prev) => {
+        const shuffle = prev.shuffle;
+        const shuffledIndices = shuffle
+          ? generateShuffledIndices(items.length, startIndex)
+          : [];
+        return {
+          playlistId,
+          playlistName,
+          currentIndex: startIndex,
+          items,
+          totalCount: items.length,
+          isPlaylistMode: true,
+          sortField,
+          sortOrder,
+          sortKey: sortKey || "position",
+          repeatMode: prev.repeatMode,
+          shuffle,
+          shuffledIndices,
+        };
       });
 
       // 最初の記事に遷移（自動再生フラグ付き）
@@ -220,6 +268,46 @@ export function PlaylistPlaybackProvider({
     [router]
   );
 
+  /**
+   * シャッフルモードで次のインデックスを取得するヘルパー
+   */
+  const getNextShuffleIndex = useCallback((prevState: PlaylistPlaybackState): number | null => {
+    const { shuffledIndices, currentIndex, items } = prevState;
+    if (shuffledIndices.length === 0) return null;
+    const currentShufflePos = shuffledIndices.indexOf(currentIndex);
+    if (currentShufflePos === -1) {
+      // currentIndexがシャッフル配列にない場合は先頭から
+      return shuffledIndices[0];
+    }
+    const nextShufflePos = currentShufflePos + 1;
+    if (nextShufflePos >= shuffledIndices.length) {
+      // シャッフルリストの終端
+      if (prevState.repeatMode === "all") {
+        // リピートall: 新しいシャッフル順を生成して先頭から
+        return null; // 呼び出し側で再シャッフル
+      }
+      return null; // 終端
+    }
+    return shuffledIndices[nextShufflePos];
+  }, []);
+
+  /**
+   * シャッフルモードで前のインデックスを取得するヘルパー
+   */
+  const getPrevShuffleIndex = useCallback((prevState: PlaylistPlaybackState): number | null => {
+    const { shuffledIndices, currentIndex } = prevState;
+    if (shuffledIndices.length === 0) return null;
+    const currentShufflePos = shuffledIndices.indexOf(currentIndex);
+    if (currentShufflePos <= 0) {
+      // 先頭 → リピートallなら末尾、そうでなければnull
+      if (prevState.repeatMode === "all") {
+        return shuffledIndices[shuffledIndices.length - 1];
+      }
+      return null;
+    }
+    return shuffledIndices[currentShufflePos - 1];
+  }, []);
+
   const playNext = useCallback(() => {
     setState((prevState) => {
       // デバッグ: 次曲決定ロジックの入力値を出力
@@ -229,6 +317,8 @@ export function PlaylistPlaybackProvider({
         itemsLength: prevState.items.length,
         isPlaylistMode: prevState.isPlaylistMode,
         sortKey: prevState.sortKey,
+        repeatMode: prevState.repeatMode,
+        shuffle: prevState.shuffle,
         currentArticleId: prevState.items[prevState.currentIndex]?.article_id,
         currentArticleTitle: truncateTitle(prevState.items[prevState.currentIndex]?.article?.title),
       });
@@ -244,8 +334,39 @@ export function PlaylistPlaybackProvider({
         );
         return prevState;
       }
-      // wrap-around to support circular navigation
-      const nextIndex = (prevState.currentIndex + 1) % prevState.items.length;
+
+      let nextIndex: number;
+
+      if (prevState.shuffle) {
+        // シャッフルモード
+        const next = getNextShuffleIndex(prevState);
+        if (next === null) {
+          if (prevState.repeatMode === "all") {
+            // 再シャッフルして先頭から
+            const newShuffled = generateShuffledIndices(prevState.items.length);
+            nextIndex = newShuffled[0];
+            const nextItem = prevState.items[nextIndex];
+            if (nextItem?.article?.url && prevState.playlistId) {
+              router.push(createReaderUrl({
+                articleUrl: nextItem.article.url,
+                playlistId: prevState.playlistId,
+                playlistIndex: nextIndex,
+                autoplay: true,
+              }));
+              return { ...prevState, currentIndex: nextIndex, shuffledIndices: newShuffled };
+            }
+            return prevState;
+          }
+          // シャッフルリスト終端 & repeatモードがoffの場合: wrap-aroundで循環
+          nextIndex = prevState.shuffledIndices[0] ?? ((prevState.currentIndex + 1) % prevState.items.length);
+        } else {
+          nextIndex = next;
+        }
+      } else {
+        // 通常モード: wrap-around
+        nextIndex = (prevState.currentIndex + 1) % prevState.items.length;
+      }
+
       const nextItem = prevState.items[nextIndex];
 
       logger.info("次の記事へ移動", {
@@ -281,7 +402,7 @@ export function PlaylistPlaybackProvider({
 
       return prevState;
     });
-  }, [router]);
+  }, [router, getNextShuffleIndex]);
 
   const playPrevious = useCallback(() => {
     setState((prevState) => {
@@ -292,6 +413,8 @@ export function PlaylistPlaybackProvider({
         itemsLength: prevState.items.length,
         isPlaylistMode: prevState.isPlaylistMode,
         sortKey: prevState.sortKey,
+        repeatMode: prevState.repeatMode,
+        shuffle: prevState.shuffle,
         currentArticleId: prevState.items[prevState.currentIndex]?.article_id,
         currentArticleTitle: truncateTitle(prevState.items[prevState.currentIndex]?.article?.title),
       });
@@ -306,10 +429,25 @@ export function PlaylistPlaybackProvider({
         );
         return prevState;
       }
-      // wrap-around to support circular navigation
-      const prevIndex =
-        (prevState.currentIndex - 1 + prevState.items.length) %
-        prevState.items.length;
+
+      let prevIndex: number;
+
+      if (prevState.shuffle) {
+        // シャッフルモード
+        const prev = getPrevShuffleIndex(prevState);
+        if (prev === null) {
+          // 先頭: wrap-around
+          prevIndex = (prevState.currentIndex - 1 + prevState.items.length) % prevState.items.length;
+        } else {
+          prevIndex = prev;
+        }
+      } else {
+        // 通常モード: wrap-around
+        prevIndex =
+          (prevState.currentIndex - 1 + prevState.items.length) %
+          prevState.items.length;
+      }
+
       const prevItem = prevState.items[prevIndex];
 
       logger.info("前の記事へ移動", {
@@ -345,7 +483,7 @@ export function PlaylistPlaybackProvider({
 
       return prevState;
     });
-  }, [router]);
+  }, [router, getPrevShuffleIndex]);
 
   const stopPlaylistPlayback = useCallback(() => {
     setState({
@@ -358,6 +496,9 @@ export function PlaylistPlaybackProvider({
       sortField: null,
       sortOrder: null,
       sortKey: null,
+      repeatMode: "off",
+      shuffle: false,
+      shuffledIndices: [],
     });
   }, []);
 
@@ -370,12 +511,31 @@ export function PlaylistPlaybackProvider({
         itemsLength: prevState.items.length,
         isPlaylistMode: prevState.isPlaylistMode,
         sortKey: prevState.sortKey,
+        repeatMode: prevState.repeatMode,
+        shuffle: prevState.shuffle,
         currentArticleId: prevState.items[prevState.currentIndex]?.article_id,
         currentArticleTitle: truncateTitle(prevState.items[prevState.currentIndex]?.article?.title),
       });
 
       if (!prevState.isPlaylistMode) {
         logger.info("onArticleEnd: プレイリストモードではない");
+        return prevState;
+      }
+
+      // リピート1: 同じ記事を再生
+      if (prevState.repeatMode === "one") {
+        logger.info("onArticleEnd: リピート1モード - 同じ記事を再生", {
+          currentIndex: prevState.currentIndex,
+        });
+        const currentItem = prevState.items[prevState.currentIndex];
+        if (currentItem?.article?.url && prevState.playlistId) {
+          router.push(createReaderUrl({
+            articleUrl: currentItem.article.url,
+            playlistId: prevState.playlistId,
+            playlistIndex: prevState.currentIndex,
+            autoplay: true,
+          }));
+        }
         return prevState;
       }
 
@@ -386,8 +546,37 @@ export function PlaylistPlaybackProvider({
       });
 
       if (prevState.items.length > 0) {
-        // Circular next on end
-        const nextIndex = (prevState.currentIndex + 1) % prevState.items.length;
+        let nextIndex: number;
+        let newShuffledIndices = prevState.shuffledIndices;
+
+        if (prevState.shuffle) {
+          // シャッフルモード
+          const next = getNextShuffleIndex(prevState);
+          if (next === null) {
+            if (prevState.repeatMode === "all") {
+              // リピートall + シャッフル: 新シャッフル順で先頭から
+              newShuffledIndices = generateShuffledIndices(prevState.items.length);
+              nextIndex = newShuffledIndices[0];
+            } else {
+              // リピートoff + シャッフル: プレイリスト終了
+              logger.info("onArticleEnd: シャッフルリスト終了（リピートoff）");
+              return prevState;
+            }
+          } else {
+            nextIndex = next;
+          }
+        } else {
+          // 通常モード
+          const isLastItem = prevState.currentIndex >= prevState.items.length - 1;
+          if (isLastItem && prevState.repeatMode === "off") {
+            // リピートoff: プレイリスト終了
+            logger.info("onArticleEnd: プレイリスト最後（リピートoff）");
+            return prevState;
+          }
+          // リピートall or 途中: 循環
+          nextIndex = (prevState.currentIndex + 1) % prevState.items.length;
+        }
+
         const nextItem = prevState.items[nextIndex];
 
         logger.info("自動的に次の記事へ遷移", {
@@ -415,7 +604,7 @@ export function PlaylistPlaybackProvider({
           });
         }
 
-        return { ...prevState, currentIndex: nextIndex };
+        return { ...prevState, currentIndex: nextIndex, shuffledIndices: newShuffledIndices };
       }
 
       // プレイリストの最後に到達
@@ -424,7 +613,7 @@ export function PlaylistPlaybackProvider({
       });
       return prevState;
     });
-  }, [router]);
+  }, [router, getNextShuffleIndex]);
 
   /**
    * 記事URLからプレイリストを自動検出して初期化
@@ -505,7 +694,7 @@ export function PlaylistPlaybackProvider({
       });
 
       // プレイリストコンテキストを初期化（ページ遷移なし）
-      setState({
+      setState((prev) => ({
         playlistId: targetPlaylist.id,
         playlistName: targetPlaylist.name,
         currentIndex,
@@ -514,8 +703,13 @@ export function PlaylistPlaybackProvider({
         isPlaylistMode: true,
         sortField,
         sortOrder,
-        sortKey: savedSortOption || "position", // 追加: sortKeyを保存
-      });
+        sortKey: savedSortOption || "position",
+        repeatMode: prev.repeatMode,
+        shuffle: prev.shuffle,
+        shuffledIndices: prev.shuffle
+          ? generateShuffledIndices(items.length, currentIndex)
+          : [],
+      }));
     } catch (error) {
       logger.error("プレイリスト初期化エラー", error);
     }
@@ -580,7 +774,7 @@ export function PlaylistPlaybackProvider({
           queueOrder: createQueueOrderLog(items),
         });
 
-        setState({
+        setState((prev) => ({
           playlistId: playlistData.id,
           playlistName: playlistData.name,
           currentIndex: index,
@@ -589,8 +783,13 @@ export function PlaylistPlaybackProvider({
           isPlaylistMode: true,
           sortField,
           sortOrder,
-          sortKey: savedSortOption || "position", // 追加: sortKeyを保存
-        });
+          sortKey: savedSortOption || "position",
+          repeatMode: prev.repeatMode,
+          shuffle: prev.shuffle,
+          shuffledIndices: prev.shuffle
+            ? generateShuffledIndices(items.length, index)
+            : [],
+        }));
       } catch (error) {
         logger.error("initializeFromPlaylist error", error);
       }
@@ -601,6 +800,40 @@ export function PlaylistPlaybackProvider({
   // With circular navigation enabled, Prev/Next are available as long as items exist
   const canMovePrevious = state.items.length > 0;
   const canMoveNext = state.items.length > 0;
+
+  /**
+   * リピートモードをトグル: off → all → one → off
+   */
+  const toggleRepeatMode = useCallback(() => {
+    setState((prev) => {
+      const nextMode: RepeatMode =
+        prev.repeatMode === "off" ? "all" : prev.repeatMode === "all" ? "one" : "off";
+      logger.info("リピートモード変更", {
+        from: prev.repeatMode,
+        to: nextMode,
+      });
+      return { ...prev, repeatMode: nextMode };
+    });
+  }, []);
+
+  /**
+   * シャッフルモードをトグル
+   */
+  const toggleShuffle = useCallback(() => {
+    setState((prev) => {
+      const newShuffle = !prev.shuffle;
+      logger.info("シャッフルモード変更", {
+        shuffle: newShuffle,
+      });
+      return {
+        ...prev,
+        shuffle: newShuffle,
+        shuffledIndices: newShuffle
+          ? generateShuffledIndices(prev.items.length, prev.currentIndex)
+          : [],
+      };
+    });
+  }, []);
 
   const value: PlaylistPlaybackContextType = {
     state,
@@ -613,6 +846,8 @@ export function PlaylistPlaybackProvider({
     initializeFromPlaylist,
     canMovePrevious,
     canMoveNext,
+    toggleRepeatMode,
+    toggleShuffle,
   };
 
   return (

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -182,6 +182,19 @@ export function PlaylistPlaybackProvider({
   const router = useRouter();
   const [state, setState] = useState<PlaylistPlaybackState>(() => {
     const saved = loadPlaybackState();
+    // バリデーション付きでrepeatMode/shuffle/shuffledIndicesを復元
+    const validRepeatModes: RepeatMode[] = ["off", "one", "all"];
+    const rawRepeatMode = (saved as PlaylistPlaybackState | null)?.repeatMode;
+    const repeatMode: RepeatMode = rawRepeatMode && validRepeatModes.includes(rawRepeatMode)
+      ? rawRepeatMode
+      : "off";
+    const rawShuffle = (saved as PlaylistPlaybackState | null)?.shuffle;
+    const shuffle = typeof rawShuffle === "boolean" ? rawShuffle : false;
+    const rawShuffledIndices = (saved as PlaylistPlaybackState | null)?.shuffledIndices;
+    const shuffledIndices = Array.isArray(rawShuffledIndices)
+      ? rawShuffledIndices.filter((v): v is number => typeof v === "number")
+      : [];
+
     return {
       playlistId: saved?.playlistId || null,
       playlistName: saved?.playlistName || null,
@@ -192,9 +205,9 @@ export function PlaylistPlaybackProvider({
       sortField: saved?.sortField || null,
       sortOrder: saved?.sortOrder || null,
       sortKey: saved?.sortKey || null,
-      repeatMode: (saved as PlaylistPlaybackState | null)?.repeatMode || "off",
-      shuffle: (saved as PlaylistPlaybackState | null)?.shuffle || false,
-      shuffledIndices: (saved as PlaylistPlaybackState | null)?.shuffledIndices || [],
+      repeatMode,
+      shuffle,
+      shuffledIndices,
     };
   });
 
@@ -272,7 +285,7 @@ export function PlaylistPlaybackProvider({
    * シャッフルモードで次のインデックスを取得するヘルパー
    */
   const getNextShuffleIndex = useCallback((prevState: PlaylistPlaybackState): number | null => {
-    const { shuffledIndices, currentIndex, items } = prevState;
+    const { shuffledIndices, currentIndex } = prevState;
     if (shuffledIndices.length === 0) return null;
     const currentShufflePos = shuffledIndices.indexOf(currentIndex);
     if (currentShufflePos === -1) {
@@ -436,8 +449,12 @@ export function PlaylistPlaybackProvider({
         // シャッフルモード
         const prev = getPrevShuffleIndex(prevState);
         if (prev === null) {
-          // 先頭: wrap-around
-          prevIndex = (prevState.currentIndex - 1 + prevState.items.length) % prevState.items.length;
+          // 先頭: シャッフルキューの最後へ wrap-around
+          if (prevState.shuffledIndices.length > 0) {
+            prevIndex = prevState.shuffledIndices[prevState.shuffledIndices.length - 1];
+          } else {
+            prevIndex = (prevState.currentIndex - 1 + prevState.items.length) % prevState.items.length;
+          }
         } else {
           prevIndex = prev;
         }

--- a/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
+++ b/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
@@ -3,6 +3,9 @@ import { render, act } from "@testing-library/react";
 import {
   PlaylistPlaybackProvider,
   usePlaylistPlayback,
+  generateShuffledIndices,
+  type RepeatMode,
+  type PlaylistPlaybackContextType,
 } from "@/contexts/PlaylistPlaybackContext";
 
 // Mock next/navigation useRouter
@@ -21,16 +24,28 @@ const sampleItems = Array.from({ length: 3 }).map((_, i) => ({
   id: `item-${i}`,
   article_id: `article-${i}`,
   position: i,
+  playlist_id: "pl-1",
+  added_at: new Date().toISOString(),
   article: {
     id: `article-${i}`,
+    owner_email: "test@example.com",
     url: `https://example.com/article-${i}`,
     title: `Article ${i}`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
   },
 }));
+
+// Helper to get the test context
+function getCtx(): PlaylistPlaybackContextType {
+  // @ts-expect-error test harness: accessing internal
+  return window.__test__;
+}
 
 describe("PlaylistPlaybackContext circular behavior", () => {
   beforeEach(() => {
     pushMock.mockClear();
+    localStorage.clear();
   });
 
   test("canMovePrevious and canMoveNext are true when items exist", async () => {
@@ -42,8 +57,7 @@ describe("PlaylistPlaybackContext circular behavior", () => {
 
     // initialize
     await act(async () => {
-      // @ts-expect-error test harness: calling internal helper
-      await window.__test__.startPlaylistPlayback(
+      getCtx().startPlaylistPlayback(
         "pl-1",
         "My Playlist",
         sampleItems,
@@ -51,8 +65,7 @@ describe("PlaylistPlaybackContext circular behavior", () => {
       );
     });
 
-    // @ts-expect-error test harness: reading internal flags
-    const { canMovePrevious, canMoveNext, state } = window.__test__;
+    const { canMovePrevious, canMoveNext, state } = getCtx();
 
     expect(state.items.length).toBe(3);
     expect(canMovePrevious).toBe(true);
@@ -68,15 +81,13 @@ describe("PlaylistPlaybackContext circular behavior", () => {
 
     await act(async () => {
       // start at last index
-      // @ts-expect-error test harness: calling internal helper
-      await window.__test__.startPlaylistPlayback(
+      getCtx().startPlaylistPlayback(
         "pl-1",
         "My Playlist",
         sampleItems,
         2
       );
-      // @ts-expect-error test harness: calling internal helper
-      await window.__test__.playNext();
+      getCtx().playNext();
     });
 
     // Expect push to be called with index=0
@@ -94,20 +105,349 @@ describe("PlaylistPlaybackContext circular behavior", () => {
 
     await act(async () => {
       // start at first index
-      // @ts-expect-error test harness: calling internal helper
-      await window.__test__.startPlaylistPlayback(
+      getCtx().startPlaylistPlayback(
         "pl-1",
         "My Playlist",
         sampleItems,
         0
       );
-      // @ts-expect-error test harness: calling internal helper
-      await window.__test__.playPrevious();
+      getCtx().playPrevious();
     });
 
     // Expect push to be called with index=2
     expect(pushMock).toHaveBeenCalled();
     const lastCall = pushMock.mock.calls[pushMock.mock.calls.length - 1][0];
     expect(lastCall).toContain("index=2");
+  });
+});
+
+describe("PlaylistPlaybackContext repeat modes", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+  });
+
+  test("default repeatMode is 'off' and shuffle is false", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+    });
+
+    expect(getCtx().state.repeatMode).toBe("off");
+    expect(getCtx().state.shuffle).toBe(false);
+    expect(getCtx().state.shuffledIndices).toEqual([]);
+  });
+
+  test("toggleRepeatMode cycles off → all → one → off", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+    });
+
+    expect(getCtx().state.repeatMode).toBe("off");
+
+    await act(async () => {
+      getCtx().toggleRepeatMode();
+    });
+    expect(getCtx().state.repeatMode).toBe("all");
+
+    await act(async () => {
+      getCtx().toggleRepeatMode();
+    });
+    expect(getCtx().state.repeatMode).toBe("one");
+
+    await act(async () => {
+      getCtx().toggleRepeatMode();
+    });
+    expect(getCtx().state.repeatMode).toBe("off");
+  });
+
+  test("toggleShuffle enables shuffle and generates shuffledIndices", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+    });
+
+    expect(getCtx().state.shuffle).toBe(false);
+
+    await act(async () => {
+      getCtx().toggleShuffle();
+    });
+
+    expect(getCtx().state.shuffle).toBe(true);
+    expect(getCtx().state.shuffledIndices).toHaveLength(3);
+    // Current index (0) should be at position 0
+    expect(getCtx().state.shuffledIndices[0]).toBe(0);
+    // All indices should be present
+    expect(getCtx().state.shuffledIndices.sort()).toEqual([0, 1, 2]);
+  });
+
+  test("toggleShuffle off clears shuffledIndices", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+      getCtx().toggleShuffle();
+    });
+
+    expect(getCtx().state.shuffle).toBe(true);
+
+    await act(async () => {
+      getCtx().toggleShuffle();
+    });
+
+    expect(getCtx().state.shuffle).toBe(false);
+    expect(getCtx().state.shuffledIndices).toEqual([]);
+  });
+
+  test("onArticleEnd with repeatMode='one' replays the same article", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 1);
+    });
+
+    // Set repeat mode to "one"
+    await act(async () => {
+      getCtx().toggleRepeatMode(); // off → all
+    });
+    await act(async () => {
+      getCtx().toggleRepeatMode(); // all → one
+    });
+    expect(getCtx().state.repeatMode).toBe("one");
+
+    pushMock.mockClear();
+
+    await act(async () => {
+      getCtx().onArticleEnd();
+    });
+
+    // Should push with the same index (1)
+    expect(pushMock).toHaveBeenCalled();
+    const lastCall = pushMock.mock.calls[pushMock.mock.calls.length - 1][0];
+    expect(lastCall).toContain("index=1");
+    expect(lastCall).toContain("article-1");
+  });
+
+  test("onArticleEnd with repeatMode='off' stops at end of playlist", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    // Start at last index with repeatMode off
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 2);
+    });
+
+    expect(getCtx().state.repeatMode).toBe("off");
+
+    pushMock.mockClear();
+
+    await act(async () => {
+      getCtx().onArticleEnd();
+    });
+
+    // Should NOT push (playlist ended)
+    expect(pushMock).not.toHaveBeenCalled();
+    // Index should remain at 2
+    expect(getCtx().state.currentIndex).toBe(2);
+  });
+
+  test("onArticleEnd with repeatMode='all' wraps around at end of playlist", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    // Start at last index
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 2);
+    });
+
+    // Set repeat mode to "all"
+    await act(async () => {
+      getCtx().toggleRepeatMode(); // off → all
+    });
+    expect(getCtx().state.repeatMode).toBe("all");
+
+    pushMock.mockClear();
+
+    await act(async () => {
+      getCtx().onArticleEnd();
+    });
+
+    // Should wrap around to index 0
+    expect(pushMock).toHaveBeenCalled();
+    const lastCall = pushMock.mock.calls[pushMock.mock.calls.length - 1][0];
+    expect(lastCall).toContain("index=0");
+  });
+
+  test("onArticleEnd mid-playlist with repeatMode='off' continues to next", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    // Start at middle index (not last)
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+    });
+
+    expect(getCtx().state.repeatMode).toBe("off");
+
+    pushMock.mockClear();
+
+    await act(async () => {
+      getCtx().onArticleEnd();
+    });
+
+    // Should continue to next article
+    expect(pushMock).toHaveBeenCalled();
+    const lastCall = pushMock.mock.calls[pushMock.mock.calls.length - 1][0];
+    expect(lastCall).toContain("index=1");
+  });
+
+  test("state is persisted to and loaded from localStorage", async () => {
+    const { unmount } = render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+      getCtx().toggleRepeatMode(); // off → all
+      getCtx().toggleShuffle(); // false → true
+    });
+
+    unmount();
+
+    // Re-render and check that state is restored
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    expect(getCtx().state.repeatMode).toBe("all");
+    expect(getCtx().state.shuffle).toBe(true);
+    expect(getCtx().state.shuffledIndices.length).toBeGreaterThan(0);
+  });
+});
+
+describe("generateShuffledIndices", () => {
+  test("generates array with all indices", () => {
+    const result = generateShuffledIndices(5);
+    expect(result).toHaveLength(5);
+    expect(result.sort()).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("places currentIndex at position 0", () => {
+    const result = generateShuffledIndices(5, 3);
+    expect(result[0]).toBe(3);
+    expect(result).toHaveLength(5);
+    expect(result.sort()).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("handles empty array", () => {
+    const result = generateShuffledIndices(0);
+    expect(result).toEqual([]);
+  });
+
+  test("handles single element", () => {
+    const result = generateShuffledIndices(1, 0);
+    expect(result).toEqual([0]);
+  });
+
+  test("currentIndex out of range is ignored", () => {
+    const result = generateShuffledIndices(3, 10);
+    expect(result).toHaveLength(3);
+    expect(result.sort()).toEqual([0, 1, 2]);
+  });
+});
+
+describe("PlaylistPlaybackContext shuffle playback", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+  });
+
+  test("playNext in shuffle mode follows shuffled order", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+      getCtx().toggleShuffle();
+    });
+
+    const shuffledIndices = [...getCtx().state.shuffledIndices];
+    expect(shuffledIndices[0]).toBe(0); // Current index is first in shuffle order
+
+    pushMock.mockClear();
+
+    await act(async () => {
+      getCtx().playNext();
+    });
+
+    // Should navigate to the second item in the shuffled order
+    expect(pushMock).toHaveBeenCalled();
+    const lastCall = pushMock.mock.calls[pushMock.mock.calls.length - 1][0];
+    expect(lastCall).toContain(`index=${shuffledIndices[1]}`);
+  });
+
+  test("stopPlaylistPlayback resets repeat and shuffle", async () => {
+    render(
+      <PlaylistPlaybackProvider>
+        <TestComponent />
+      </PlaylistPlaybackProvider>
+    );
+
+    await act(async () => {
+      getCtx().startPlaylistPlayback("pl-1", "My Playlist", sampleItems, 0);
+      getCtx().toggleRepeatMode(); // off → all
+      getCtx().toggleShuffle();
+    });
+
+    expect(getCtx().state.repeatMode).toBe("all");
+    expect(getCtx().state.shuffle).toBe(true);
+
+    await act(async () => {
+      getCtx().stopPlaylistPlayback();
+    });
+
+    expect(getCtx().state.repeatMode).toBe("off");
+    expect(getCtx().state.shuffle).toBe(false);
+    expect(getCtx().state.shuffledIndices).toEqual([]);
   });
 });

--- a/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
+++ b/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
@@ -4,7 +4,6 @@ import {
   PlaylistPlaybackProvider,
   usePlaylistPlayback,
   generateShuffledIndices,
-  type RepeatMode,
   type PlaylistPlaybackContextType,
 } from "@/contexts/PlaylistPlaybackContext";
 


### PR DESCRIPTION
## 概要

Spotify風の連続再生コントロールを実装しました。

## 機能

### リピートモード（3段切り替え）
- **オフ**: プレイリスト末尾で停止
- **全曲リピート**: プレイリスト末尾到達後、先頭に戻って再生
- **1曲リピート**: 同じ記事を繰り返し再生

### シャッフルモード
- Fisher-Yatesアルゴリズムによるランダム順再生
- 現在の記事をシャッフルキューの先頭に配置
- リピートall + シャッフル時は新しいシャッフル順を生成

### UI
- デスクトップ・モバイル両方でシャッフル/リピートボタンを表示
- アクティブ状態は緑色ハイライト（Spotify UXと一致）
- リピートモードに応じたアイコン切り替え（Repeat / Repeat1）

### 永続化
- repeatMode, shuffle, shuffledIndicesをlocalStorageに保存

## テスト

19テスト追加:
- リピートモードの切り替え（off→all→one→off）
- シャッフルモードのオン/オフ
- onArticleEndの各モード別動作
- localStorage永続化
- generateShuffledIndicesユニットテスト

## 変更ファイル
- `contexts/PlaylistPlaybackContext.tsx` - リピート・シャッフルロジック追加
- `app/reader/ReaderClient.tsx` - UI コントロール追加
- `contexts/__tests__/PlaylistPlaybackContext.test.tsx` - テスト追加
