### PR TITLE
fix: 連続再生が次の記事に進まない問題を修正

### DIFF
--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -171,7 +171,8 @@ export default function ReaderPageClient() {
   } = useAudioPlayback();
 
   const handleArticleEnd = useCallback(() => {
-    if (isPlaylistMode && playlistState.isPlaylistMode) {
+    // プレイリストモード時の処理
+    if (playlistState.isPlaylistMode) {
       // リピートoff時の完了判定
       if (playlistState.repeatMode === "off") {
         let isAtEnd = false;
@@ -203,9 +204,12 @@ export default function ReaderPageClient() {
         shuffle: playlistState.shuffle,
       });
       onArticleEnd();
+      return;
     }
+
+    // プレイリストモードでない未分類再生時は何もしない
+    logger.info("handleArticleEnd: プレイリストモードではないためスキップ");
   }, [
-    isPlaylistMode,
     playlistState.isPlaylistMode,
     playlistState.totalCount,
     playlistState.playlistId,

--- a/packages/web-app-vercel/hooks/useMediaSession.ts
+++ b/packages/web-app-vercel/hooks/useMediaSession.ts
@@ -138,7 +138,7 @@ export function useMediaSession({
         : undefined;
 
     try {
-      setPositionState({ duration, position, playbackRate });
+      setPositionState.call(mediaSession, { duration, position, playbackRate });
     } catch (error) {
       logger.warn("Failed to set Media Session position state", error);
     }

--- a/packages/web-app-vercel/hooks/useMediaSession.ts
+++ b/packages/web-app-vercel/hooks/useMediaSession.ts
@@ -76,7 +76,7 @@ export function useMediaSession({
   const hasSetPositionState = (
     session: MediaSession
   ): session is MediaSession & { setPositionState: (state: PositionState) => void } =>
-    "setPositionState" in session;
+    typeof (session as unknown as Record<string, unknown>).setPositionState === "function";
 
   // コールバック関数の参照を保持（再レンダリングによる再登録を防ぐ）
   const onPlayRef = useRef(onPlay);

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -200,7 +200,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
         : undefined;
 
     try {
-      setPositionState({ duration, position, playbackRate });
+      setPositionState.call(mediaSession, { duration, position, playbackRate });
     } catch (error) {
       // Safari/PWA など実装差分があり得るため、握りつぶさずログだけ残す
       logger.warn('Failed to set Media Session position state', error);

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -181,7 +181,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       }) => void;
     }).setPositionState;
 
-    if (!setPositionState) return;
+    if (!setPositionState || typeof setPositionState !== "function") return;
     const audio = audioRef.current;
     if (!audio) return;
 


### PR DESCRIPTION
## 問題

連続再生（リピート・シャッフル）機能を追加したが、記事再生終了後に次の記事に進まなくなっていた。

また、Media Session API で `Illegal invocation` エラーが大量に発生していた。

## 根本原因

### 1. 連続再生が動作しない

`handleArticleEnd` が **2つの条件** `isPlaylistMode && playlistState.isPlaylistMode` の両方が `true` でないと動作しない設計だった:

- `isPlaylistMode`: ローカルstate、**URL の `playlist` クエリパラメータの有無で初回レンダリング時にのみ設定**
- `playlistState.isPlaylistMode`: コンテキスト、**プレイリスト初期化後に動的に更新**

`initializeFromArticle` でプレイリストが後から自動検出された場合、`isPlaylistMode` が `false` のまま → handleArticleEnd が何もしない。

### 2. Media Session API `Illegal invocation`

`setPositionState` を `mediaSession` オブジェクトからデタッチして呼んでいたため、`this` コンテキストが失われていた。

## 修正

1. **`handleArticleEnd` を `playlistState.isPlaylistMode` のみで判断するように変更** — ローカルの `isPlaylistMode` state に依存しない
2. **`setPositionState.call(mediaSession, ...)`** で `this` コンテキストを保持（`useMediaSession.ts` と `usePlayback.ts` の2箇所）

## 変更ファイル

- `app/reader/ReaderClient.tsx` — handleArticleEnd 条件修正
- `hooks/useMediaSession.ts` — setPositionState Illegal invocation 修正
- `hooks/usePlayback.ts` — setPositionState Illegal invocation 修正
