### PR TITLE
fix: プレイリストAPI 404時のフォールバックとデバッグログ改善

### DIFF
--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -171,6 +171,16 @@ export default function ReaderPageClient() {
   } = useAudioPlayback();
 
   const handleArticleEnd = useCallback(() => {
+    logger.info("handleArticleEnd 呼び出し", {
+      isPlaylistMode: playlistState.isPlaylistMode,
+      repeatMode: playlistState.repeatMode,
+      shuffle: playlistState.shuffle,
+      currentIndex: currentPlaylistIndex,
+      totalCount: playlistState.totalCount,
+      shuffledIndicesLength: playlistState.shuffledIndices.length,
+      playlistId: playlistState.playlistId,
+    });
+
     // プレイリストモード時の処理
     if (playlistState.isPlaylistMode) {
       // リピートoff時の完了判定

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -766,6 +766,37 @@ export function PlaylistPlaybackProvider({
             playlistId,
             status: res.status,
           });
+
+          // API失敗時: localStorageの状態がこのプレイリストの有効なデータを持っているか確認
+          // 持っていれば、プレイリストモードを維持（古いアイテムでフォールバック）
+          setState((prev) => {
+            if (
+              prev.isPlaylistMode &&
+              prev.playlistId === playlistId &&
+              prev.items.length > 0
+            ) {
+              logger.info(
+                "API失敗: localStorageのキャッシュデータでプレイリストモードを維持",
+                {
+                  playlistId,
+                  cachedItemsCount: prev.items.length,
+                  currentIndex: startIndex,
+                }
+              );
+              const index = Math.max(
+                0,
+                Math.min(startIndex, prev.items.length - 1)
+              );
+              return {
+                ...prev,
+                currentIndex: index,
+                shuffledIndices: prev.shuffle
+                  ? generateShuffledIndices(prev.items.length, index)
+                  : prev.shuffledIndices,
+              };
+            }
+            return prev;
+          });
           return;
         }
 

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -790,6 +790,9 @@ export function PlaylistPlaybackProvider({
               return {
                 ...prev,
                 currentIndex: index,
+                sortField,
+                sortOrder,
+                sortKey: savedSortOption || "position",
                 shuffledIndices: prev.shuffle
                   ? generateShuffledIndices(prev.items.length, index)
                   : prev.shuffledIndices,


### PR DESCRIPTION
## 問題

1. プレイリストAPI (`/api/playlists/[id]`) が 404 を返すと、`initializeFromPlaylist` が `return` して **プレイリストコンテキストが初期化されない** 
2. localStorageには前回の有効なプレイリスト状態が残っているが、APIが失敗したことでインデックスの不整合が発生
3. シャッフルモードなのに同じ記事がリピートされる問題（`repeatMode` が `one` になっている可能性）の診断が困難

## 原因分析

ログから:
```
GET .../api/playlists/f33262e0-...?sortField=title&sortOrder=asc 404 (Not Found)
[WARN] プレイリスト取得失敗 {playlistId: ..., status: 404}
```

API 404 でプレイリスト初期化が失敗 → localStorageの古い状態（`repeatMode: 'one'`の可能性）で動作 → 同じ記事がリピートされる

## 修正

### 1. API失敗時のlocalStorageフォールバック
`initializeFromPlaylist` がAPI 404を受けた場合、localStorageに同じプレイリストIDの有効なアイテムデータが残っていれば、それをフォールバックとして使用。プレイリストモードを維持して連続再生を継続。

### 2. デバッグログの改善
`handleArticleEnd` の先頭に、repeatMode、shuffle、currentIndex、totalCount、shuffledIndicesLength を含む包括的なログを追加。実際の再生状態をコンソールで即座に確認可能に。

## 変更ファイル
- `contexts/PlaylistPlaybackContext.tsx` — API 404 フォールバックロジック追加
- `app/reader/ReaderClient.tsx` — handleArticleEnd デバッグログ改善
