### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/packages/api-server/main.py
+++ b/packages/api-server/main.py
@@ -21,15 +21,14 @@ app = FastAPI(title="Audicle API Server", version="1.0.0")
 
 # CORS設定
 cors_origins_env = os.getenv("CORS_ALLOWED_ORIGINS")
+allow_origins = []
 if cors_origins_env:
     allow_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
     if "*" in allow_origins:
         raise ValueError("CORS_ALLOWED_ORIGINS に '*' は使用できません。allow_credentials=True と組み合わせると起動に失敗します。")
-    if not allow_origins:
-        logger.warning("CORS_ALLOWED_ORIGINS が設定されましたが有効なオリジンがありません。デフォルト値を使用します。")
-        allow_origins = ["http://localhost:3000", "http://localhost:3001"]
-else:
-    allow_origins = ["http://localhost:3000", "http://localhost:3001"]
+
+if not allow_origins:
+    logger.warning("CORS_ALLOWED_ORIGINS が設定されていないか、有効なオリジンがありません。CORSは許可されません。")
 
 logger.info("CORS許可オリジン: %s", allow_origins)
 

--- a/packages/api-server/main.py
+++ b/packages/api-server/main.py
@@ -28,7 +28,7 @@ if cors_origins_env:
         raise ValueError("CORS_ALLOWED_ORIGINS に '*' は使用できません。allow_credentials=True と組み合わせると起動に失敗します。")
 
 if not allow_origins:
-    logger.warning("CORS_ALLOWED_ORIGINS が設定されていないか、有効なオリジンがありません。CORSは許可されません。")
+    raise ValueError("CORS_ALLOWED_ORIGINS 環境変数が設定されていないか、有効なオリジンがありません。フロントエンドからのアクセスを許可するために、有効なオリジンを指定してください。")
 
 logger.info("CORS許可オリジン: %s", allow_origins)
 

--- a/packages/api-server/tests/test_chunk_text_logic.py
+++ b/packages/api-server/tests/test_chunk_text_logic.py
@@ -15,6 +15,7 @@ sys.modules["google.cloud"] = MagicMock()
 sys.modules["google.cloud.texttospeech"] = MagicMock()
 sys.modules["uvicorn"] = MagicMock()
 
+os.environ["CORS_ALLOWED_ORIGINS"] = "http://localhost"
 # Add parent directory to path to import main
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/packages/api-server/tests/test_text_splitting.py
+++ b/packages/api-server/tests/test_text_splitting.py
@@ -14,6 +14,7 @@ sys.modules["google.cloud"] = MagicMock()
 sys.modules["google.cloud.texttospeech"] = MagicMock()
 sys.modules["uvicorn"] = MagicMock()
 
+os.environ["CORS_ALLOWED_ORIGINS"] = "http://localhost"
 # Add parent directory to path to import main
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
🎯 **What:** The API server had a hardcoded default CORS configuration allowing `http://localhost:3000` and `http://localhost:3001` when the `CORS_ALLOWED_ORIGINS` environment variable was not set or empty.

⚠️ **Risk:** Allowing hardcoded localhost origins by default could lead to cross-site scripting (XSS) or other vulnerabilities if the application is deployed in a production environment where this configuration is inadvertently left unset.

🛡️ **Solution:** The fallback hardcoded localhost arrays were removed. Now, if the `CORS_ALLOWED_ORIGINS` environment variable is absent or empty, the `allow_origins` array securely defaults to an empty list `[]`.

---
*PR created automatically by Jules for task [8943046080930150251](https://jules.google.com/task/8943046080930150251) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`CORS_ALLOWED_ORIGINS` 環境変数が未設定または空の場合にハードコードされた `http://localhost:3000` および `http://localhost:3001` へのフォールバックを削除し、代わりに空リスト `[]` をデフォルトとする変更を加えています。本番環境で誤って環境変数を未設定のままデプロイしてしまった際の意図しないオリジン許可を防ぐセキュリティ改善です。

- **変更内容**: `allow_origins` のデフォルトを `["http://localhost:3000", "http://localhost:3001"]` から `[]` に変更。環境変数が未設定または有効なオリジンがない場合は警告ログを出力して起動を続行。
- **ロジックの正確性**: `cors_origins_env` が truthy だが strip 後に空になるケース（例: `CORS_ALLOWED_ORIGINS="  , "`）も正しく空リストに帰結し、警告ログが出力される。
- **ローカル開発への影響**: 今後ローカル開発者は `CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001` を明示的に設定する必要があるため、`.env.example` や `docker-compose.yml`、README などでの周知が望ましい。
- **本番環境の無効設定検出**: `allow_origins=[]` のまま起動が続行されると、フロントエンドからのリクエストがブラウザレベルでブロックされるが、その原因発見が遅れる可能性がある。本番環境では起動時に例外を raise する等の追加対策を検討する価値がある。
- **既存の設定**: `allow_credentials=True` と `allow_methods=["*"]` の組み合わせは CORS 仕様上 Starlette が内部処理するが、明示的なメソッドリストへの変更を検討する価値がある（今回の変更では未対応）。
</details>


<h3>Confidence Score: 4/5</h3>

- セキュリティ修正として正しく機能しており、マージしても安全。ただしローカル開発環境への影響と本番環境での無効設定検出の仕組みを補強することが望ましい。
- 変更のロジックは正確で、目的通りのセキュリティ改善が達成されている。空リストのフォールバックは CORSMiddleware で正しく機能する。ただし、環境変数未設定時に警告のみで起動続行する点や、ローカル開発者向けドキュメント不足がわずかな懸念事項として残る。
- packages/api-server/main.py の CORS 設定箇所（30-41行目）を重点的に確認してください。また、.env.example や docker-compose.yml など環境変数を定義しているファイルにも CORS_ALLOWED_ORIGINS の記載を追加することを推奨します。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api-server/main.py | CORS設定のフォールバックをlocalhostからから空リスト[]に変更。ロジックは概ね正しいが、ローカル開発環境への影響と、CORSが無効な場合の警告のみで起動を続ける点が注意必要。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[サーバー起動] --> B{CORS_ALLOWED_ORIGINS\n環境変数が設定されているか？}
    B -- "はい（非空文字列）" --> C["カンマ区切りでパース\n+ strip() して空文字を除外"]
    B -- "いいえ / 空" --> D["allow_origins = []（初期値）"]
    C --> E{"'*' が含まれるか？"}
    E -- "はい" --> F["ValueError を raise\nサーバー起動失敗"]
    E -- "いいえ" --> G["allow_origins = 有効なオリジンリスト"]
    G --> H{"allow_origins が空か？"}
    D --> H
    H -- "はい" --> I["WARNING ログ出力\n（旧: localhost にフォールバック）"]
    H -- "いいえ" --> J["INFO ログ: 許可オリジン一覧"]
    I --> J
    J --> K["CORSMiddleware に\nallow_origins を渡す"]
    K --> L{"リクエスト受信\nOrigin ヘッダーあり？"}
    L -- "マッチするオリジン有り" --> M["CORS ヘッダーを付与して応答"]
    L -- "マッチなし / 空リスト" --> N["CORS ヘッダーなし\nブラウザがブロック"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/api-server/main.py`, line 35-41 ([link](https://github.com/hiroki-org/audicle/blob/2c353b294002c478e1cbe7b03acb62fa6f2c64b5/packages/api-server/main.py#L35-L41)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`allow_methods=["*"]` と `allow_credentials=True` の組み合わせ**

   これは今回の変更で導入されたものではありませんが、この PR を機に確認しておく価値があります。

   `allow_origins=[]`（空リスト）の場合、CORS ヘッダーはどのオリジンにも付与されないため実害はありませんが、`allow_origins` に実際のオリジンが設定された際に `allow_methods=["*"]` と `allow_credentials=True` を組み合わせると、[CORS 仕様](https://fetch.spec.whatwg.org/#cors-preflight-fetch)上 `Access-Control-Allow-Methods: *` はクレデンシャル付きリクエストでは無視されます。Starlette (0.20.0 以降) はこれを内部的に展開して処理するため実際の問題は起きにくいですが、明示的なメソッドリスト（例: `["GET", "POST", "OPTIONS"]`）を指定する方がより安全で意図が明確です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/api-server/main.py
   Line: 35-41

   Comment:
   **`allow_methods=["*"]` と `allow_credentials=True` の組み合わせ**

   これは今回の変更で導入されたものではありませんが、この PR を機に確認しておく価値があります。

   `allow_origins=[]`（空リスト）の場合、CORS ヘッダーはどのオリジンにも付与されないため実害はありませんが、`allow_origins` に実際のオリジンが設定された際に `allow_methods=["*"]` と `allow_credentials=True` を組み合わせると、[CORS 仕様](https://fetch.spec.whatwg.org/#cors-preflight-fetch)上 `Access-Control-Allow-Methods: *` はクレデンシャル付きリクエストでは無視されます。Starlette (0.20.0 以降) はこれを内部的に展開して処理するため実際の問題は起きにくいですが、明示的なメソッドリスト（例: `["GET", "POST", "OPTIONS"]`）を指定する方がより安全で意図が明確です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/api-server/main.py
Line: 30-31

Comment:
**本番環境での無効CORS設定の検出について**

`allow_origins` が空のまま起動が続行されると、フロントエンドからのすべてのブラウザリクエストが静かにブロックされます。ログに警告は出ますが、本番環境でうっかり `CORS_ALLOWED_ORIGINS` を未設定のまま動かしてしまった場合、問題の発見が遅れる可能性があります。

環境変数 `APP_ENV` や `ENVIRONMENT` などで本番環境を識別できる場合は、本番環境かつ `allow_origins` が空のときに起動を失敗させる（例外を raise する）ことを検討してください。

```python
if not allow_origins:
    logger.warning("CORS_ALLOWED_ORIGINS が設定されていないか、有効なオリジンがありません。CORSは許可されません。")
    if os.getenv("APP_ENV", "development") == "production":
        raise ValueError("本番環境では CORS_ALLOWED_ORIGINS を必ず設定してください。")
```

ローカル開発環境では `.env` ファイルや `docker-compose.yml` などに `CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001` を追記する対応も合わせて行うと、開発者が困惑するケースを防げます。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/api-server/main.py
Line: 35-41

Comment:
**`allow_methods=["*"]` と `allow_credentials=True` の組み合わせ**

これは今回の変更で導入されたものではありませんが、この PR を機に確認しておく価値があります。

`allow_origins=[]`（空リスト）の場合、CORS ヘッダーはどのオリジンにも付与されないため実害はありませんが、`allow_origins` に実際のオリジンが設定された際に `allow_methods=["*"]` と `allow_credentials=True` を組み合わせると、[CORS 仕様](https://fetch.spec.whatwg.org/#cors-preflight-fetch)上 `Access-Control-Allow-Methods: *` はクレデンシャル付きリクエストでは無視されます。Starlette (0.20.0 以降) はこれを内部的に展開して処理するため実際の問題は起きにくいですが、明示的なメソッドリスト（例: `["GET", "POST", "OPTIONS"]`）を指定する方がより安全で意図が明確です。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix overly permissive CORS policy"](https://github.com/hiroki-org/audicle/commit/2c353b294002c478e1cbe7b03acb62fa6f2c64b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26134024)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->