### PR TITLE
🧹 [code health improvement] Remove console.log from synthesize route

### DIFF
--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -115,7 +115,6 @@ function getTTSClient(): TextToSpeechClient | null {
     const googleKeyFileEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS;
     if (googleKeyFileEnv && fs.existsSync(googleKeyFileEnv)) {
         ttsCLient = new TextToSpeechClient({ keyFilename: googleKeyFileEnv });
-        console.log('[INFO] GOOGLE_APPLICATION_CREDENTIALS used as keyFilename');
         return ttsCLient;
     }
 
@@ -124,7 +123,6 @@ function getTTSClient(): TextToSpeechClient | null {
         // In test environments or CI, return null to allow fallback behavior
         // (the caller will synthesize a dummy buffer).
         if (process.env.NODE_ENV !== 'production' || process.env.CI === 'true' || process.env.TEST_SESSION_TOKEN) {
-            console.log('[INFO] GOOGLE_APPLICATION_CREDENTIALS_JSON not set, using fallback for test environment');
             return null;
         }
         throw new Error('GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable is not set');
@@ -152,9 +150,6 @@ function getTTSClient(): TextToSpeechClient | null {
         try {
             const unescaped = credentialsJson.replace(/\\n/g, '\n').replace(/^"|"$/g, '');
             credentials = tryParseJson(unescaped);
-            if (credentials) {
-                console.log('[INFO] GOOGLE_APPLICATION_CREDENTIALS_JSON was loaded from an escaped JSON string');
-            }
         } catch (_) { void _; }
     }
 
@@ -163,9 +158,6 @@ function getTTSClient(): TextToSpeechClient | null {
         try {
             const decoded = Buffer.from(credentialsJson, 'base64').toString('utf8');
             credentials = tryParseJson(decoded);
-            if (credentials) {
-                console.log('[INFO] GOOGLE_APPLICATION_CREDENTIALS_JSON was loaded from base64');
-            }
         } catch {
             // ignore decode errors
         }
@@ -177,7 +169,6 @@ function getTTSClient(): TextToSpeechClient | null {
             const trimmed = credentialsJson.trim();
             if ((trimmed.startsWith('/') || trimmed.endsWith('.json') || trimmed.includes('.json')) && fs.existsSync(trimmed)) {
                 ttsCLient = new TextToSpeechClient({ keyFilename: trimmed });
-                console.log('[INFO] GOOGLE_APPLICATION_CREDENTIALS_JSON used as keyFilename');
                 return ttsCLient;
             }
         } catch (_e) {
@@ -206,7 +197,6 @@ async function synthesizeToBuffer(text: string, voice: string, speakingRate: num
 
     // Fallback for test environments without credentials
     if (!client) {
-        console.log('[INFO] Using fallback dummy audio buffer for test environment');
         // Return a minimal MP3 buffer (silence) for testing
         // This is a very small MP3 frame that represents silence
         const dummyMp3Buffer = Buffer.from([


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed multiple unstructured `console.log` debugging statements from `packages/web-app-vercel/app/api/synthesize/route.ts` along with the unused empty `if (credentials)` blocks wrapping them.

💡 **Why:** How this improves maintainability
These statements were strictly for debugging and do not use the application's structured `log` utility function. In production code, debug statements should be removed or routed through proper logging frameworks. This improves code readability and eliminates dead code (empty conditional blocks).

✅ **Verification:** How you confirmed the change is safe
Ran `npm run test` and `npm run lint` within the `web-app-vercel` directory. Confirmed no regressions in the target logic. Ensured the diff is precise and minimal, without altering the rest of the file's layout or triggering massive format changes.

✨ **Result:** The improvement achieved
Cleaned up code without any change to functionality.

---
*PR created automatically by Jules for task [10900908371898131232](https://jules.google.com/task/10900908371898131232) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/web-app-vercel/app/api/synthesize/route.ts` 内の `getTTSClient()` および `synthesizeToBuffer()` 関数から、非構造化デバッグ用 `console.log` 文を6件、およびそれを包むだけだった空の `if (credentials)` ブロックを2件削除するコード健全性の改善です。機能的な変更は一切なく、アプリケーションの構造化ロギングユーティリティ `log` を使っていないデバッグ文を取り除くことで可読性を向上させています。

**主な変更点:**
- `GOOGLE_APPLICATION_CREDENTIALS` を keyFilename として使用した際の `console.log` を削除
- テスト環境フォールバック時の `console.log` を削除
- エスケープ済みJSON・Base64 でのクレデンシャルロード成功時の `if (credentials) { console.log(...) }` ブロックを削除（これらは `console.log` しか含まない空のブロックだった）
- `keyFilename` としてファイルパスを使用した際の `console.log` を削除
- テスト環境向けダミー音声バッファ使用時の `console.log` を削除

**備考:**
- `synthesizeToBuffer()` 内に残る `console.error` 呼び出し（行226・281）はリクエストスコープの `log` 関数にアクセスできないモジュールレベル関数でのログ出力という同じパターンに該当しますが、これらは本PRの対象外の既存コードです。必要であれば別途対処することを検討してください。
</details>

<h3>Confidence Score: 5/5</h3>

- 機能的変更を含まないクリーンなコード健全性改善であり、安全にマージできます。
- 削除されたのはデバッグ用 console.log 文と、それしか含まない空の if ブロックのみです。ロジック、認証、キャッシュ、TTSクライアント初期化のいずれにも変更はありません。テスト・Lint の確認済みとのことで、リグレッションリスクはほぼゼロです。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/synthesize/route.ts | 6件の非構造化 console.log デバッグ文と、それを包んでいた空の if(credentials) ブロック2件を削除。機能的な変更はなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTTSClient 呼び出し] --> B{既存クライアントあり?}
    B -- Yes --> C[既存クライアントを返す]
    B -- No --> D{GOOGLE_APPLICATION_CREDENTIALS\nファイルが存在する?}
    D -- Yes --> E[keyFilename でクライアント生成\n~~console.log 削除済み~~]
    D -- No --> F{GOOGLE_APPLICATION_CREDENTIALS_JSON\n設定済み?}
    F -- No --> G{テスト/CI環境?}
    G -- Yes --> H[null を返す\n~~console.log 削除済み~~]
    G -- No --> I[エラーをスロー]
    F -- Yes --> J[プレーン JSON としてパース試行]
    J -- 成功 --> N
    J -- 失敗 --> K[エスケープ JSON としてパース試行\n~~if credentials: console.log 削除済み~~]
    K -- 成功 --> N
    K -- 失敗 --> L[Base64 デコードしてパース試行\n~~if credentials: console.log 削除済み~~]
    L -- 成功 --> N
    L -- 失敗 --> M[ファイルパスとして試行\n~~console.log 削除済み~~]
    M -- 成功 --> E
    M -- 失敗 --> O[エラーをスロー]
    N[credentials オブジェクトでクライアント生成] --> C2[クライアントを返す]

    style E fill:#f9f,stroke:#ccc,stroke-dasharray: 5 5
    style H fill:#f9f,stroke:#ccc,stroke-dasharray: 5 5
    style K fill:#f9f,stroke:#ccc,stroke-dasharray: 5 5
    style L fill:#f9f,stroke:#ccc,stroke-dasharray: 5 5
    style M fill:#f9f,stroke:#ccc,stroke-dasharray: 5 5
```

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove unstructured console.log from ..."](https://github.com/hiroki-org/audicle/commit/d748d97682941d8c152aadea7006af123c8a68b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26135805)</sub>

<!-- /greptile_comment -->