### PR TITLE
🧪 Add test for synthesize_speech endpoint in main.py

### DIFF
--- a/packages/api-server/tests/test_chunk_text_logic.py
+++ b/packages/api-server/tests/test_chunk_text_logic.py
@@ -2,13 +2,9 @@ import sys
 import unittest
 from unittest.mock import MagicMock
 import os
+import re
 
 # Mock external dependencies
-sys.modules["aiofiles"] = MagicMock()
-sys.modules["fastapi"] = MagicMock()
-sys.modules["fastapi.responses"] = MagicMock()
-sys.modules["fastapi.middleware.cors"] = MagicMock()
-sys.modules["pydantic"] = MagicMock()
 sys.modules["google.api_core.exceptions"] = MagicMock()
 sys.modules["google.cloud"] = MagicMock()
 sys.modules["google.cloud.texttospeech"] = MagicMock()
@@ -25,7 +21,7 @@ class TestChunkTextLogic(unittest.TestCase):
         """Test that text smaller than limit returns as is."""
         text = "Hello world"
         limit = 50
-        chunks = _chunk_text(text, limit, [r'(\s)'])
+        chunks = _chunk_text(text, limit, [re.compile(r'(\s)')])
         self.assertEqual(chunks, ["Hello world"])
 
     def test_delimiter_merging(self):
@@ -33,7 +29,7 @@ class TestChunkTextLogic(unittest.TestCase):
         text = "Hello. World."
         limit = 7 # Force split. "Hello." is 6 bytes. " World." is 7 bytes.
         # Split by period
-        chunks = _chunk_text(text, limit, [r'([.])'])
+        chunks = _chunk_text(text, limit, [re.compile(r'([.])')])
         # Expect ["Hello.", " World."]
         self.assertEqual(chunks, ["Hello.", " World."])
 
@@ -46,7 +42,7 @@ class TestChunkTextLogic(unittest.TestCase):
 
         text = "Part1,Part2. Part3,Part4."
         limit = 12
-        separators = [r'([.])', r'([,])']
+        separators = [re.compile(r'([.])'), re.compile(r'([,])')]
 
         chunks = _chunk_text(text, limit, separators)
 
@@ -85,7 +81,7 @@ class TestChunkTextLogic(unittest.TestCase):
 
         text = "a.b.c.d."
         limit = 4
-        chunks = _chunk_text(text, limit, [r'([.])'])
+        chunks = _chunk_text(text, limit, [re.compile(r'([.])')])
         self.assertEqual(chunks, ["a.b.", "c.d."])
 
 if __name__ == '__main__':

--- a/packages/api-server/tests/test_synthesize.py
+++ b/packages/api-server/tests/test_synthesize.py
@@ -1,0 +1,111 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+import os
+import io
+
+# ONLY mock external missing dependencies, DO NOT mock fastapi, pydantic
+sys.modules["google.api_core.exceptions"] = MagicMock()
+sys.modules["google.cloud"] = MagicMock()
+sys.modules["google.cloud.texttospeech"] = MagicMock()
+
+# Add parent directory to path to import main
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+import main
+
+class TestSynthesizeSpeech(unittest.TestCase):
+    def setUp(self):
+        # Reset the semaphore before each test to ensure clean state
+        main._tts_semaphore = None
+        self.client = TestClient(main.app)
+
+    @patch('main._split_text')
+    @patch('main._synthesize_to_bytes', new_callable=AsyncMock)
+    def test_single_chunk_success(self, mock_synthesize, mock_split):
+        mock_split.return_value = ["Hello world"]
+        mock_synthesize.return_value = b"mocked_audio"
+
+        response = self.client.post("/synthesize", json={"text": "Hello world", "voice": "test-voice"})
+
+        mock_split.assert_called_once_with("Hello world")
+        mock_synthesize.assert_called_once_with("Hello world", "test-voice")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"mocked_audio")
+        self.assertEqual(response.headers["content-type"], "audio/mpeg")
+        self.assertEqual(response.headers["content-disposition"], "attachment; filename=speech.mp3")
+
+    @patch('main._split_text')
+    @patch('main._synthesize_to_bytes', new_callable=AsyncMock)
+    def test_multiple_chunks_success(self, mock_synthesize, mock_split):
+        mock_split.return_value = ["Hello ", "world"]
+        mock_synthesize.side_effect = [b"mocked_", b"audio"]
+
+        response = self.client.post("/synthesize", json={"text": "Hello world", "voice": "test-voice"})
+
+        mock_split.assert_called_once_with("Hello world")
+        self.assertEqual(mock_synthesize.call_count, 2)
+        mock_synthesize.assert_any_call("Hello ", "test-voice")
+        mock_synthesize.assert_any_call("world", "test-voice")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"mocked_audio")
+        self.assertEqual(response.headers["content-type"], "audio/mpeg")
+
+    @patch('main._split_text')
+    @patch('main._synthesize_to_bytes', new_callable=AsyncMock)
+    @patch('os.path.exists')
+    @patch('aiofiles.open')
+    def test_partial_chunk_failure_fallback_file(self, mock_aiofiles_open, mock_exists, mock_synthesize, mock_split):
+        mock_split.return_value = ["Hello ", "world"]
+        mock_synthesize.side_effect = [b"mocked_", Exception("Test error")]
+        mock_exists.return_value = True
+
+        mock_file_context = MagicMock()
+        mock_file_context.read = AsyncMock(return_value=b"fallback_audio")
+        mock_aiofiles_open.return_value.__aenter__ = AsyncMock(return_value=mock_file_context)
+        mock_aiofiles_open.return_value.__aexit__ = AsyncMock()
+
+        response = self.client.post("/synthesize", json={"text": "Hello world", "voice": "test-voice"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"fallback_audio")
+        self.assertEqual(response.headers["content-type"], "audio/mpeg")
+        self.assertEqual(response.headers["content-disposition"], "attachment; filename=fallback.mp3")
+        self.assertEqual(response.headers["x-fallback"], "true")
+        self.assertIn("Test error", response.headers["x-error"])
+
+    @patch('main._split_text')
+    @patch('main._synthesize_to_bytes', new_callable=AsyncMock)
+    @patch('os.path.exists')
+    def test_partial_chunk_failure_no_fallback_file(self, mock_exists, mock_synthesize, mock_split):
+        mock_split.return_value = ["Hello ", "world"]
+        mock_synthesize.side_effect = [b"mocked_", Exception("Test error")]
+        mock_exists.return_value = False
+
+        response = self.client.post("/synthesize", json={"text": "Hello world", "voice": "test-voice"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+        self.assertEqual(response.headers["content-type"], "audio/mpeg")
+        self.assertEqual(response.headers["content-disposition"], "attachment; filename=empty.mp3")
+        self.assertEqual(response.headers["x-fallback"], "true")
+        self.assertIn("Test error", response.headers["x-error"])
+
+    @patch('main._split_text')
+    @patch('os.path.exists')
+    def test_fallback_failure(self, mock_exists, mock_split):
+        mock_split.side_effect = Exception("Split failed")
+        mock_exists.side_effect = Exception("Fallback disk read failed")
+
+        response = self.client.post("/synthesize", json={"text": "Hello world", "voice": "test-voice"})
+
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        self.assertIn("Split failed", data["detail"])
+        self.assertIn("Fallback disk read failed", data["detail"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/api-server/tests/test_text_splitting.py
+++ b/packages/api-server/tests/test_text_splitting.py
@@ -1,14 +1,9 @@
 import sys
 import unittest
 from unittest.mock import MagicMock
-sys.modules["aiofiles"] = MagicMock()
 import os
 
 # Mock external dependencies
-sys.modules["fastapi"] = MagicMock()
-sys.modules["fastapi.responses"] = MagicMock()
-sys.modules["fastapi.middleware.cors"] = MagicMock()
-sys.modules["pydantic"] = MagicMock()
 sys.modules["google.api_core.exceptions"] = MagicMock()
 sys.modules["google.cloud"] = MagicMock()
 sys.modules["google.cloud.texttospeech"] = MagicMock()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added comprehensive unit tests for the `/synthesize` endpoint using `TestClient` to verify happy paths (single/multiple chunks), partial chunk failures, and fallback audio generation. Cleaned up global `sys.modules` patching in related test files to prevent test isolation leaks.

📊 **Coverage:** What scenarios are now tested
- Single chunk successful synthesis.
- Multiple chunks successfully split and synthesized.
- Partial chunk failure triggering the `fallback.mp3` fallback.
- Partial chunk failure returning an empty response when the fallback file is missing.
- Complete fallback process failure triggering an HTTP 500 error.

✨ **Result:** The improvement in test coverage
The critical `synthesize_speech` functionality and its fallback mechanism are now fully covered and verified, ensuring reliable audio generation and better resilience against GCP TTS failures.

---
*PR created automatically by Jules for task [12974909745901719567](https://jules.google.com/task/12974909745901719567) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `/synthesize` エンドポイントに対する包括的なユニットテスト (`test_synthesize.py`) を新規追加し、既存の `test_chunk_text_logic.py` と `test_text_splitting.py` から不要なグローバル `sys.modules` モックを削除するクリーンアップを行っています。テスト新規追加により、シングル/マルチチャンク成功・フォールバックファイルあり/なし・フォールバック自体の失敗という5つのシナリオがカバーされました。

- `test_synthesize.py` に `import io` が追加されていますが、ファイル内でどこでも使用されていません。
- `@patch('os.path.exists')` がグローバルスコープで使用されており、テスト実行中に `os.path.exists` を呼ぶすべてのコードに影響します。`@patch('main.os.path.exists')` に変更することで、モックのスコープを `main` モジュール内のみに絞れます（`test_partial_chunk_failure_fallback_file`, `test_partial_chunk_failure_no_fallback_file`, `test_fallback_failure` の3箇所）。
- `test_fallback_failure` は `_split_text` の失敗をトリガーにしていますが、「合成チャンク失敗後にフォールバックも失敗する」という本来のシナリオとは若干異なります（テストとしては通過しますが、意図との乖離があります）。
- 既存テストファイルから `fastapi`・`pydantic`・`aiofiles` のモックを削除したクリーンアップは、`TestClient` が実際の FastAPI を必要とするため適切な修正です。
</details>

<h3>Confidence Score: 4/5</h3>

- テストのみの変更であり、本番コードへの影響はありません。マージ自体は安全です。
- テストコードのみの変更で本番コードへのリスクはありません。未使用インポートや `os.path.exists` のパッチスコープに関する改善点はありますが、テストロジック自体は正しく動作します。
- packages/api-server/tests/test_synthesize.py — `import io` の削除と `@patch('os.path.exists')` のスコープ修正を検討してください。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api-server/tests/test_synthesize.py | 新規追加されたテストファイル。`/synthesize` エンドポイントのハッピーパス・フォールバックをカバーするが、`import io` の未使用インポートや `@patch('os.path.exists')` のスコープが広すぎる問題がある。 |
| packages/api-server/tests/test_chunk_text_logic.py | `sys.modules` の不要なモックを削除し、`_chunk_text` に渡すセパレータを文字列から `re.compile()` 済みのパターンオブジェクトに変更。変更は適切で問題なし。 |
| packages/api-server/tests/test_text_splitting.py | `sys.modules` の不要な `fastapi`・`aiofiles`・`pydantic` モックを削除。`test_synthesize.py` が実際の FastAPI を必要とするためモック汚染を防ぐクリーンアップ。問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TC as TestClient
    participant EP as synthesize_speech endpoint
    participant ST as _split_text (mocked)
    participant SB as _synthesize_to_bytes (mocked)
    participant FS as os.path.exists (mocked)
    participant AF as aiofiles.open (mocked)

    Note over TC,AF: ✅ test_single_chunk_success
    TC->>EP: POST /synthesize
    EP->>ST: _split_text(text)
    ST-->>EP: ["Hello world"]
    EP->>SB: _synthesize_to_bytes("Hello world", voice)
    SB-->>EP: b"mocked_audio"
    EP-->>TC: 200 audio/mpeg

    Note over TC,AF: ✅ test_multiple_chunks_success
    TC->>EP: POST /synthesize
    EP->>ST: _split_text(text)
    ST-->>EP: ["Hello ", "world"]
    EP->>SB: asyncio.gather(chunk1, chunk2)
    SB-->>EP: [b"mocked_", b"audio"]
    EP-->>TC: 200 b"mocked_audio"

    Note over TC,AF: ✅ test_partial_chunk_failure_fallback_file
    TC->>EP: POST /synthesize
    EP->>ST: _split_text(text)
    ST-->>EP: ["Hello ", "world"]
    EP->>SB: asyncio.gather (return_exceptions=True)
    SB-->>EP: [b"mocked_", Exception("Test error")]
    EP->>EP: raise RuntimeError(summary)
    EP->>FS: os.path.exists("fallback.mp3")
    FS-->>EP: True
    EP->>AF: aiofiles.open("fallback.mp3")
    AF-->>EP: b"fallback_audio"
    EP-->>TC: 200 X-Fallback: true

    Note over TC,AF: ✅ test_partial_chunk_failure_no_fallback_file
    TC->>EP: POST /synthesize
    EP->>FS: os.path.exists("fallback.mp3")
    FS-->>EP: False
    EP-->>TC: 200 b"" filename=empty.mp3

    Note over TC,AF: ✅ test_fallback_failure
    TC->>EP: POST /synthesize
    EP->>ST: _split_text(text)
    ST-->>EP: raise Exception("Split failed")
    EP->>FS: os.path.exists (fallback path)
    FS-->>EP: raise Exception("Fallback disk read failed")
    EP-->>TC: 500 HTTPException
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/api-server/tests/test_synthesize.py
Line: 5

Comment:
**未使用の `import io`**

`import io` がインポートされていますが、ファイル内でどこでも使用されていません。

```suggestion
```

削除することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/api-server/tests/test_synthesize.py
Line: 59-60

Comment:
**`os.path.exists` のパッチスコープが広すぎる**

`@patch('os.path.exists')` はグローバルの `os.path.exists` をモックします。これはテスト実行中に `os.path.exists` を呼ぶすべてのコード（テストフレームワーク内部含む）に影響します。`main.py` 内での使用箇所だけをモックするために `@patch('main.os.path.exists')` を使うべきです。

同じ問題が以下の箇所にも存在します：
- `test_partial_chunk_failure_no_fallback_file` (82行目)
- `test_fallback_failure` (98行目)

```suggestion
    @patch('main.os.path.exists')
    @patch('main.aiofiles.open')
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/api-server/tests/test_synthesize.py
Line: 97-101

Comment:
**`_synthesize_to_bytes` のモックが欠落している可能性**

`test_fallback_failure` では `_split_text` が例外を投げるためチャンクの合成は実行されませんが、`_synthesize_to_bytes` のモックが存在しません。現状では `_split_text` が例外を投げるためテストは通りますが、テストの意図（「フォールバック自体も失敗する」シナリオ）として、 `_split_text` が成功して `_synthesize_to_bytes` が失敗した後にフォールバックも失敗するケースも検証すると、より実用的なカバレッジになります。

現在の実装では `mock_exists.side_effect` はフォールバックパスの `os.path.exists` コールにしか到達しないため、合成チャンクに失敗してフォールバックディスク読み取りも失敗するという本来のシナリオとはやや乖離しています。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for synthesize\_speech endpoi..."](https://github.com/hiroki-org/audicle/commit/d2bdba670c1d6efa2d42c3819955bf6fc1dd9985) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26155884)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->