### PR TITLE
🧪 Add tests for ArticleListSkeleton

### DIFF
--- a/packages/web-app-vercel/components/ArticleListSkeleton.tsx
+++ b/packages/web-app-vercel/components/ArticleListSkeleton.tsx
@@ -3,19 +3,19 @@ import { Card, CardContent } from "@/components/ui/card";
 
 export function ArticleListSkeleton() {
     return (
-        <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:gap-8">
+        <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:gap-8" aria-hidden="true">
             {[...Array(5)].map((_, i) => (
                 <Card key={i} data-testid="skeleton-card" className="relative group bg-zinc-900/50 border-zinc-800">
                     <CardContent className="p-4 sm:p-6">
                         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
                             <div className="flex-1 min-w-0">
-                                <div className="h-6 w-3/4 bg-zinc-800 rounded animate-pulse mb-2" />
-                                <div className="h-4 w-1/3 bg-zinc-800 rounded animate-pulse mb-3" />
-                                <div className="h-3 w-20 bg-zinc-800 rounded animate-pulse" />
+                                <div data-testid="skeleton-pulse" className="h-6 w-3/4 bg-zinc-800 rounded animate-pulse mb-2" />
+                                <div data-testid="skeleton-pulse" className="h-4 w-1/3 bg-zinc-800 rounded animate-pulse mb-3" />
+                                <div data-testid="skeleton-pulse" className="h-3 w-20 bg-zinc-800 rounded animate-pulse" />
                             </div>
                             <div className="flex items-center gap-2">
-                                <div className="h-8 w-8 bg-zinc-800 rounded animate-pulse" />
-                                <div className="h-8 w-8 bg-zinc-800 rounded animate-pulse" />
+                                <div data-testid="skeleton-pulse" className="h-8 w-8 bg-zinc-800 rounded animate-pulse" />
+                                <div data-testid="skeleton-pulse" className="h-8 w-8 bg-zinc-800 rounded animate-pulse" />
                             </div>
                         </div>
                     </CardContent>

--- a/packages/web-app-vercel/components/ArticleListSkeleton.tsx
+++ b/packages/web-app-vercel/components/ArticleListSkeleton.tsx
@@ -5,7 +5,7 @@ export function ArticleListSkeleton() {
     return (
         <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:gap-8">
             {[...Array(5)].map((_, i) => (
-                <Card key={i} className="relative group bg-zinc-900/50 border-zinc-800">
+                <Card key={i} data-testid="skeleton-card" className="relative group bg-zinc-900/50 border-zinc-800">
                     <CardContent className="p-4 sm:p-6">
                         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
                             <div className="flex-1 min-w-0">

--- a/packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ArticleListSkeleton } from "../ArticleListSkeleton";
+
+describe("ArticleListSkeleton", () => {
+    it("renders without crashing", () => {
+        render(<ArticleListSkeleton />);
+
+        // Use getAllByTestId to find all skeleton cards
+        const skeletonCards = screen.getAllByTestId("skeleton-card");
+
+        // Assert that exactly 5 cards are rendered
+        expect(skeletonCards).toHaveLength(5);
+
+        // Assert that the grid layout container is rendered
+        // We can do this by checking the parent of the first card, or just by the fact it rendered.
+        // The component has a grid container.
+    });
+
+    it("renders cards with pulsing animations", () => {
+        const { container } = render(<ArticleListSkeleton />);
+
+        // Check for elements with the animate-pulse class
+        // Each card has 5 pulsing elements (3 text placeholders, 2 button placeholders)
+        // With 5 cards, there should be 25 pulsing elements in total
+        const pulsingElements = container.querySelectorAll('.animate-pulse');
+        expect(pulsingElements.length).toBe(25);
+    });
+});

--- a/packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
@@ -1,29 +1,20 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { ArticleListSkeleton } from "../ArticleListSkeleton";
 
 describe("ArticleListSkeleton", () => {
-    it("renders without crashing", () => {
+    it("renders exactly 5 skeleton cards", () => {
         render(<ArticleListSkeleton />);
-
-        // Use getAllByTestId to find all skeleton cards
         const skeletonCards = screen.getAllByTestId("skeleton-card");
-
-        // Assert that exactly 5 cards are rendered
         expect(skeletonCards).toHaveLength(5);
-
-        // Assert that the grid layout container is rendered
-        // We can do this by checking the parent of the first card, or just by the fact it rendered.
-        // The component has a grid container.
     });
 
-    it("renders cards with pulsing animations", () => {
-        const { container } = render(<ArticleListSkeleton />);
+    it("renders five pulsing placeholders per card", () => {
+        render(<ArticleListSkeleton />);
 
-        // Check for elements with the animate-pulse class
-        // Each card has 5 pulsing elements (3 text placeholders, 2 button placeholders)
-        // With 5 cards, there should be 25 pulsing elements in total
-        const pulsingElements = container.querySelectorAll('.animate-pulse');
-        expect(pulsingElements.length).toBe(25);
+        const skeletonCards = screen.getAllByTestId("skeleton-card");
+        skeletonCards.forEach((card) => {
+            expect(within(card).getAllByTestId("skeleton-pulse")).toHaveLength(5);
+        });
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `ArticleListSkeleton.tsx` had no tests.
📊 **Coverage:** The scenarios now tested include checking if the component renders without crashing, if it renders exactly 5 cards, and if each card contains the expected pulse animations. 
✨ **Result:** Increased test coverage for frontend components, giving confidence that the loading states render properly.

---
*PR created automatically by Jules for task [14094086568390708943](https://jules.google.com/task/14094086568390708943) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `ArticleListSkeleton.tsx` に対するテストカバレッジを追加するものです。テスト可能にするため本体コンポーネントに `data-testid="skeleton-card"` を追加し、描画クラッシュなし・カード枚数・`animate-pulse` アニメーションの検証という3つのシナリオを網羅しています。

**主な変更点と所見：**

- `data-testid="skeleton-card"` の追加は `Card` コンポーネントが `{...props}` スプレッドを使用しているため DOM に正しく反映され、実装として問題ありません
- `animate-pulse` 要素の期待値 `25`（5カード × 5要素）はコンポーネントのソースコードと一致しており**算数的には正しい** ✅
- テスト名 `"renders without crashing"` がカード枚数のアサーションも兼ねており、1テスト1責務の原則からはずれています（P2）
- `25` というハードコード値はコンポーネント変更時に壊れやすい（P2）
- 16〜17行目のコメントは実際のアサーションのない dead comment です（P2）

いずれも軽微なスタイル上の問題であり、テストロジック自体は正しく動作します。
</details>

<h3>Confidence Score: 5/5</h3>

テストロジックは正しく、マージしても問題ありません。

P0・P1の問題は存在せず、すべての指摘はP2（スタイル・保守性の改善提案）です。animate-pulse の期待値25はコンポーネントのソースと一致しており、data-testid の伝達も Card の props スプレッドで正しく機能します。

特に注意が必要なファイルはありません。`ArticleListSkeleton.test.tsx` のスタイル改善は任意です。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/ArticleListSkeleton.tsx | テスト用に `data-testid="skeleton-card"` を Card コンポーネントへ追加。Card は `...props` スプレッドを使用しているため DOM に正しく反映される。 |
| packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx | 新規テストファイル。animate-pulse の件数 25（5枚×5要素）は正しいが、テスト名と内容の乖離、ハードコードされた数値、実行されない dead comment など軽微なスタイル上の問題がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ArticleListSkeleton.test.tsx] -->|render| B[ArticleListSkeleton コンポーネント]
    B -->|5回繰り返し| C["Card[data-testid='skeleton-card']"]
    C --> D[CardContent]
    D --> E["div.animate-pulse × 3\n（テキストプレースホルダー）"]
    D --> F["div.animate-pulse × 2\n（ボタンプレースホルダー）"]
    A --> G{テスト1: renders without crashing}
    G -->|getAllByTestId| H["skeleton-card を5件取得\n→ toHaveLength(5)"]
    A --> I{テスト2: renders cards with pulsing animations}
    I -->|querySelectorAll| J["'.animate-pulse' を25件取得\n5カード × 5要素 = 25\n→ toBe(25)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
Line: 6-17

Comment:
**テスト名と内容の乖離 + dead comment**

`"renders without crashing"` というテスト名ですが、実際には「5枚のカードが描画されること」という追加アサーションも含まれています。1つのテストが1つの責務を持つ設計にすると可読性が上がります。

また、17行目の以下のコメントブロックは実際のアサーションが書かれておらず dead comment になっています：
```
// Assert that the grid layout container is rendered
// We can do this by checking the parent of the first card, or just by the fact it rendered.
// The component has a grid container.
```

テスト名の分離と dead comment 削除をお勧めします：

```suggestion
    it("renders without crashing", () => {
        render(<ArticleListSkeleton />);
        // コンテナが描画されていることを確認（getAllByTestId が成功すれば十分）
    });

    it("renders exactly 5 skeleton cards", () => {
        render(<ArticleListSkeleton />);
        const skeletonCards = screen.getAllByTestId("skeleton-card");
        expect(skeletonCards).toHaveLength(5);
    });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/components/__tests__/ArticleListSkeleton.test.tsx
Line: 26-27

Comment:
**ハードコードされた `animate-pulse` 件数が壊れやすい**

`25` はカード数（5）× カード内の `animate-pulse` 要素数（5）ですが、コンポーネントの DOM 構造が変わると（例：要素の追加・削除）このアサーションは黙って壊れます。取得済みの `skeletonCards` を使って件数を動的に計算すると堅牢になります：

```suggestion
        const pulsingElements = container.querySelectorAll('.animate-pulse');
        expect(pulsingElements.length).toBe(skeletonCards.length * 5);
```

ただし、この変更には `skeletonCards` が同一テスト内で宣言されている必要があるため、2つのテストを統合するか変数をスコープ外に切り出す対応が必要です。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for ArticleListSkeleton com..."](https://github.com/hiroki-org/audicle/commit/139fe313f4a9c157045f8a13fc1de014d8d1b277) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26864978)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->