### PR TITLE
🔒 Fix overly permissive CORS policy in API routes

### DIFF
--- a/packages/web-app-vercel/app/api/extract/route.ts
+++ b/packages/web-app-vercel/app/api/extract/route.ts
@@ -88,7 +88,6 @@ export async function POST(request: NextRequest) {
             headers: corsHeaders,
         });
     } catch (error) {
-        const corsHeaders = getCorsHeaders(request);
 
         if (error instanceof SyntaxError) {
             return NextResponse.json(

--- a/packages/web-app-vercel/app/api/extract/route.ts
+++ b/packages/web-app-vercel/app/api/extract/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getCorsHeaders } from '@/lib/cors';
 import { Readability } from '@mozilla/readability';
 import { normalizeArticleText } from '@/lib/parseArticle';
 import { parseHTML } from 'linkedom';
@@ -10,24 +11,16 @@ export const runtime = 'nodejs';
 // 動的レンダリングを強制（キャッシュを無効化）
 export const dynamic = 'force-dynamic';
 
-export async function OPTIONS() {
+export async function OPTIONS(request: NextRequest) {
     return NextResponse.json({}, {
-        headers: {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        },
+        headers: getCorsHeaders(request),
     });
 }
 
 export async function POST(request: NextRequest) {
     console.log('[Extract API] POST request received');
 
-    const corsHeaders = {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-    };
+    const corsHeaders = getCorsHeaders(request);
 
     try {
         const { url } = await request.json();
@@ -95,11 +88,7 @@ export async function POST(request: NextRequest) {
             headers: corsHeaders,
         });
     } catch (error) {
-        const corsHeaders = {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        };
+        const corsHeaders = getCorsHeaders(request);
 
         if (error instanceof SyntaxError) {
             return NextResponse.json(

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getCorsHeaders } from '@/lib/cors';
 import { randomUUID } from 'crypto';
 import { auth } from '@/lib/auth';
 import { getKv } from '@/lib/kv';
@@ -309,13 +310,9 @@ class TTSError extends Error {
     }
 }
 
-export async function OPTIONS() {
+export async function OPTIONS(request: NextRequest) {
     return NextResponse.json({}, {
-        headers: {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        },
+        headers: getCorsHeaders(request),
     });
 }
 
@@ -326,11 +323,7 @@ export async function POST(request: NextRequest) {
         console[level](JSON.stringify({ requestId, level, message, ...data }));
     };
 
-    const corsHeaders = {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-    };
+    const corsHeaders = getCorsHeaders(request);
 
     try {
         log('info', 'リクエスト受信');
@@ -678,11 +671,7 @@ export async function POST(request: NextRequest) {
             }
         );
     } catch (error) {
-        const corsHeaders = {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        };
+        const corsHeaders = getCorsHeaders(request);
 
         log('error', '音声合成エラー', {
             error,

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -671,7 +671,6 @@ export async function POST(request: NextRequest) {
             }
         );
     } catch (error) {
-        const corsHeaders = getCorsHeaders(request);
 
         log('error', '音声合成エラー', {
             error,

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 
-export function getCorsHeaders(request: NextRequest) {
-    const origin = request.headers.get('origin');
+export function getCorsHeaders(request?: NextRequest) {
+    const origin = request?.headers?.get('origin');
     const allowedOriginsStr = process.env.ALLOWED_ORIGINS || '';
     const allowedOrigins = allowedOriginsStr.split(',').map(o => o.trim()).filter(Boolean);
 

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,26 +1,20 @@
 import { NextRequest } from 'next/server';
 
 export function getCorsHeaders(request: NextRequest) {
-    const origin = request?.headers?.get?.('origin');
+    const origin = request.headers.get('origin');
     const allowedOriginsStr = process.env.ALLOWED_ORIGINS || '';
     const allowedOrigins = allowedOriginsStr.split(',').map(o => o.trim()).filter(Boolean);
 
-    // If no origin is present (e.g., server-to-server request) or allowedOrigins is not configured,
-    // we don't need to return wildcard CORS headers. Return an empty object or restricted headers.
-    // However, if we must return CORS headers, we should restrict them.
-
-    // If the origin is in the allowed list, we reflect it.
-    if (origin && allowedOrigins.includes(origin)) {
-        return {
-            'Access-Control-Allow-Origin': origin,
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        };
-    }
-
-    // Default restricted fallback
-    return {
+    const headers: Record<string, string> = {
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Credentials': 'true',
+        Vary: 'Origin',
     };
+
+    if (origin && allowedOrigins.includes(origin)) {
+        headers['Access-Control-Allow-Origin'] = origin;
+    }
+
+    return headers;
 }

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+
+export function getCorsHeaders(request: NextRequest) {
+    const origin = request?.headers?.get?.('origin');
+    const allowedOriginsStr = process.env.ALLOWED_ORIGINS || '';
+    const allowedOrigins = allowedOriginsStr.split(',').map(o => o.trim()).filter(Boolean);
+
+    // If no origin is present (e.g., server-to-server request) or allowedOrigins is not configured,
+    // we don't need to return wildcard CORS headers. Return an empty object or restricted headers.
+    // However, if we must return CORS headers, we should restrict them.
+
+    // If the origin is in the allowed list, we reflect it.
+    if (origin && allowedOrigins.includes(origin)) {
+        return {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Methods': 'POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        };
+    }
+
+    // Default restricted fallback
+    return {
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+    };
+}

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,20 +1,30 @@
 import { NextRequest } from 'next/server';
 
-export function getCorsHeaders(request?: NextRequest) {
-    const origin = request?.headers?.get('origin');
+export function getCorsHeaders(request: NextRequest) {
+    let origin: string | null = null;
+    if (request && request.headers && typeof request.headers.get === 'function') {
+        origin = request.headers.get('origin');
+    }
+
     const allowedOriginsStr = process.env.ALLOWED_ORIGINS || '';
     const allowedOrigins = allowedOriginsStr.split(',').map(o => o.trim()).filter(Boolean);
 
-    const headers: Record<string, string> = {
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Credentials': 'true',
-        Vary: 'Origin',
-    };
+    // If no origin is present (e.g., server-to-server request) or allowedOrigins is not configured,
+    // we don't need to return wildcard CORS headers. Return an empty object or restricted headers.
+    // However, if we must return CORS headers, we should restrict them.
 
+    // If the origin is in the allowed list, we reflect it.
     if (origin && allowedOrigins.includes(origin)) {
-        headers['Access-Control-Allow-Origin'] = origin;
+        return {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Methods': 'POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        };
     }
 
-    return headers;
+    // Default restricted fallback
+    return {
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+    };
 }

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,26 +1,26 @@
 import { NextRequest } from 'next/server';
 
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+if (process.env.NODE_ENV === 'production' && allowedOrigins.length === 0) {
+    throw new Error('ALLOWED_ORIGINS must be configured in production. Set it to a comma-separated list of allowed origins.');
+}
+
 export function getCorsHeaders(request: NextRequest): Record<string, string> {
-    let origin: string | null = null;
-    if (request && request.headers && typeof request.headers.get === 'function') {
-        origin = request.headers.get('origin');
-    }
-
-    const allowedOriginsStr = process.env.ALLOWED_ORIGINS || '';
-    const allowedOrigins = allowedOriginsStr.split(',').map(o => o.trim()).filter(Boolean);
-
-    // If no origin is present (e.g., server-to-server request) or allowedOrigins is not configured,
-    // we don't need to return wildcard CORS headers. Return an empty object or restricted headers.
-    // However, if we must return CORS headers, we should restrict them.
+    const origin = request?.headers?.get?.('origin') ?? null;
 
     const headers: Record<string, string> = {
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
+        Vary: 'Origin',
     };
 
-    // If the origin is in the allowed list, we reflect it.
     if (origin && allowedOrigins.includes(origin)) {
         headers['Access-Control-Allow-Origin'] = origin;
+        headers['Access-Control-Allow-Credentials'] = 'true';
     }
 
     return headers;

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,15 +1,16 @@
 import { NextRequest } from 'next/server';
 
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-    .split(',')
-    .map((origin) => origin.trim())
-    .filter(Boolean);
-
-if (process.env.NODE_ENV === 'production' && allowedOrigins.length === 0) {
-    throw new Error('ALLOWED_ORIGINS must be configured in production. Set it to a comma-separated list of allowed origins.');
-}
-
 export function getCorsHeaders(request: NextRequest): Record<string, string> {
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean);
+
+    // The check is moved inside the function to avoid throwing an error during Next.js static build phase
+    if (process.env.NODE_ENV === 'production' && allowedOrigins.length === 0) {
+        console.error('ALLOWED_ORIGINS must be configured in production. Set it to a comma-separated list of allowed origins.');
+    }
+
     const origin = request?.headers?.get?.('origin') ?? null;
 
     const headers: Record<string, string> = {

--- a/packages/web-app-vercel/lib/cors.ts
+++ b/packages/web-app-vercel/lib/cors.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 
-export function getCorsHeaders(request: NextRequest) {
+export function getCorsHeaders(request: NextRequest): Record<string, string> {
     let origin: string | null = null;
     if (request && request.headers && typeof request.headers.get === 'function') {
         origin = request.headers.get('origin');
@@ -13,18 +13,15 @@ export function getCorsHeaders(request: NextRequest) {
     // we don't need to return wildcard CORS headers. Return an empty object or restricted headers.
     // However, if we must return CORS headers, we should restrict them.
 
-    // If the origin is in the allowed list, we reflect it.
-    if (origin && allowedOrigins.includes(origin)) {
-        return {
-            'Access-Control-Allow-Origin': origin,
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
-        };
-    }
-
-    // Default restricted fallback
-    return {
+    const headers: Record<string, string> = {
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
     };
+
+    // If the origin is in the allowed list, we reflect it.
+    if (origin && allowedOrigins.includes(origin)) {
+        headers['Access-Control-Allow-Origin'] = origin;
+    }
+
+    return headers;
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The Synthesize API (`app/api/synthesize/route.ts`) and Extract API (`app/api/extract/route.ts`) were exposing an overly permissive wildcard CORS policy (`Access-Control-Allow-Origin: *`).

⚠️ **Risk:** The potential impact if left unfixed
Any website could make cross-origin requests to these API endpoints. Because these endpoints use authentication (`auth()`), an attacker might be able to read sensitive responses or abuse functionality if session cookies or credentials were sent. Even if cookies were not automatically included by default in fetch, a wildcard CORS policy violates the principle of least privilege and increases the attack surface for SSRF or other cross-site data exposure techniques.

🛡️ **Solution:** How the fix addresses the vulnerability
Created a centralized `getCorsHeaders` utility in `lib/cors.ts` that validates incoming request origins against an `ALLOWED_ORIGINS` environment variable whitelist. 
- If the origin is matched, it reflects the origin back in the CORS headers. 
- If the origin is unallowed or missing, it safely omits the `Access-Control-Allow-Origin` header, naturally rejecting the unauthorized cross-origin request. Both `POST` and `OPTIONS` endpoints across the affected routes were updated to use this new utility.

---
*PR created automatically by Jules for task [2445268369191911889](https://jules.google.com/task/2445268369191911889) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`app/api/synthesize/route.ts` と `app/api/extract/route.ts` に存在していたワイルドカード CORS ポリシー（`Access-Control-Allow-Origin: *`）を修正するセキュリティ改善です。新たに `lib/cors.ts` に集約ユーティリティ `getCorsHeaders` を作成し、`ALLOWED_ORIGINS` 環境変数によるオリジンホワイトリスト検証を導入しました。

**主な変更点:**
- `lib/cors.ts`（新規）: `ALLOWED_ORIGINS` 環境変数に基づきオリジンリフレクション方式でCORSヘッダーを生成
- `app/api/extract/route.ts` および `app/api/synthesize/route.ts`: ハードコードされた `*` ヘッダーを `getCorsHeaders(request)` に置換

**指摘事項:**
- **`Vary: Origin` ヘッダーの欠落（P1）**: オリジンリフレクションを用いる場合、`Vary: Origin` をレスポンスに含めなければ、CDN やプロキシが一つのオリジン向けレスポンスをキャッシュし他のオリジンに返すことで CORS ポリシーが無効化される可能性があります。
- **`ALLOWED_ORIGINS` 未設定時の無通知全拒否（P1）**: 環境変数が未設定の場合、すべてのクロスオリジンリクエストが `Access-Control-Allow-Origin` ヘッダーなしで返されます。変更前は `*` が返っていたため、デプロイ時に環境変数を設定し忘れると機能が壊れるリスクがあります。
- **`catch` ブロック内の冗長な `corsHeaders` 再宣言（P2）**: `extract/route.ts` 91行目・`synthesize/route.ts` 674行目で外側スコープの変数を不要に再宣言しています。
</details>

<h3>Confidence Score: 4/5</h3>

P1の問題（`Vary: Origin` 欠落・`ALLOWED_ORIGINS` 未設定時の全拒否）を修正してからマージすることを推奨します。

`Vary: Origin` の欠落はCDNキャッシュ経由でのCORSポリシー回避につながる実在する脆弱性です。また `ALLOWED_ORIGINS` 未設定時の無通知全拒否は、環境変数の設定漏れで本番環境が壊れるリスクがあります。これら2件のP1問題が残っているため4点とします。ロジックの方向性（ホワイトリスト化）自体は正しく、P2は軽微なコード品質の問題です。

`packages/web-app-vercel/lib/cors.ts` に最も注意が必要です（`Vary: Origin` 欠落・環境変数バリデーション不足）。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/cors.ts | 新規作成の CORS ユーティリティ。`ALLOWED_ORIGINS` 環境変数によるオリジンホワイトリスト検証を実装しているが、オリジンリフレクション時に `Vary: Origin` ヘッダーが欠落しており、CDN キャッシュ経由で CORS ポリシーが回避される可能性がある。また未設定時の無通知全拒否問題もある。 |
| packages/web-app-vercel/app/api/extract/route.ts | ハードコードされた `Access-Control-Allow-Origin: *` を `getCorsHeaders(request)` に置き換え。機能的な変更は問題なし。`catch` ブロック内の `corsHeaders` 再宣言が冗長だが動作に影響なし。 |
| packages/web-app-vercel/app/api/synthesize/route.ts | ハードコードされた `Access-Control-Allow-Origin: *` を `getCorsHeaders(request)` に置き換え。`catch` ブロック内の `corsHeaders` 再宣言が冗長だが動作に影響なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant B as ブラウザ (クロスオリジン)
    participant API as Next.js API Route
    participant CORS as getCorsHeaders()
    participant ENV as ALLOWED_ORIGINS (env)

    B->>API: OPTIONS preflight (Origin: https://example.com)
    API->>CORS: getCorsHeaders(request)
    CORS->>ENV: process.env.ALLOWED_ORIGINS を読み込み
    alt origin が allowedOrigins に含まれる
        CORS-->>API: { Access-Control-Allow-Origin: "https://example.com", ... }
        API-->>B: 200 OK (CORS ヘッダー付き)
    else origin が不一致 / 未設定
        CORS-->>API: { Access-Control-Allow-Methods: ..., Access-Control-Allow-Headers: ... }
        API-->>B: 200 OK (Access-Control-Allow-Origin なし → ブラウザが拒否)
    end

    B->>API: POST (with Origin header)
    API->>CORS: getCorsHeaders(request)
    CORS-->>API: ヘッダーオブジェクト
    API-->>B: レスポンス (CORS ヘッダー付き or なし)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/cors.ts
Line: 14-18

Comment:
**`Vary: Origin` ヘッダーが欠落している**

オリジンリフレクション（`Access-Control-Allow-Origin` にリクエストのオリジンをそのまま返す方式）を採用する場合、**必ず `Vary: Origin` を応答ヘッダーに含める必要があります**。

これがないと、CDN・プロキシ・ブラウザキャッシュが「あるオリジンに対して返したレスポンス」をキャッシュし、**別のオリジンからのリクエストにそのまま返してしまう**可能性があります。結果として、意図しないオリジンに CORS アクセスが許可され、ホワイトリスト制御が無効化されます。

```suggestion
        return {
            'Access-Control-Allow-Origin': origin,
            'Access-Control-Allow-Methods': 'POST, OPTIONS',
            'Access-Control-Allow-Headers': 'Content-Type',
            'Vary': 'Origin',
        };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/lib/cors.ts
Line: 5-6

Comment:
**`ALLOWED_ORIGINS` 未設定時にクロスオリジンリクエストが無通知で全拒否される**

`ALLOWED_ORIGINS` 環境変数が設定されていない場合、`allowedOrigins` は空配列になります。その結果、`Access-Control-Allow-Origin` ヘッダーが**一切返されない**ため、すべてのブラウザ起点クロスオリジンリクエストがサイレントに失敗します。変更前は `*` が返っていたため、デプロイ時に環境変数を設定し忘れると機能が壊れるリスクがあります。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/extract/route.ts
Line: 91

Comment:
**`catch` ブロック内の `corsHeaders` 再宣言が冗長**

`corsHeaders` は外側のスコープ（23行目）で既に宣言されており、`catch` ブロック内からもアクセス可能です。同じパターンが `app/api/synthesize/route.ts` の674行目にも存在します。

```suggestion
    } catch (error) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/synthesize/route.ts
Line: 674

Comment:
**`catch` ブロック内の `corsHeaders` 再宣言が冗長**

`corsHeaders` は外側のスコープ（326行目）で既に宣言されており、`catch` ブロック内からもアクセス可能です。

```suggestion
    } catch (error) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix overly permissive CORS policy in ..."](https://github.com/hiroki-org/audicle/commit/bd22f24e71e9c46206f20ee1075ff099f0f08c06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26865459)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->