### PR TITLE
🧪 Add tests for extract endpoint and fix HTTPException handling

### DIFF
--- a/packages/api-server/main.py
+++ b/packages/api-server/main.py
@@ -279,6 +279,8 @@ async def extract_content(request: ExtractRequest):
             status_code=500,
             detail="Failed to parse extraction result"
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500,
@@ -349,6 +351,8 @@ async def synthesize_speech(request: SynthesizeRequest):
             headers={"Content-Disposition": "attachment; filename=speech.mp3"}
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Synthesis error: %s", str(e))
 

--- a/packages/api-server/tests/test_extract.py
+++ b/packages/api-server/tests/test_extract.py
@@ -1,0 +1,97 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, AsyncMock
+import asyncio
+
+# Mock external missing dependencies before importing main
+sys.modules["google.api_core.exceptions"] = MagicMock()
+sys.modules["google.cloud"] = MagicMock()
+sys.modules["google.cloud.texttospeech"] = MagicMock()
+
+# Configure CORS for test environment
+os.environ["CORS_ALLOWED_ORIGINS"] = "http://localhost:3000"
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+import main
+
+class TestExtractContent(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(main.app)
+
+    @patch('asyncio.create_subprocess_exec', new_callable=AsyncMock)
+    def test_extract_happy_path(self, mock_exec):
+        # Setup mock process
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b'{"title": "Test Title", "chunks": ["Chunk 1", "Chunk 2"]}', b''))
+        mock_exec.return_value = mock_proc
+
+        # Send request
+        response = self.client.post("/extract", json={"url": "http://example.com"})
+
+        # Assertions
+        mock_exec.assert_called_once_with(
+            "node", "readability_script.js", "http://example.com",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["title"], "Test Title")
+        self.assertEqual(data["chunks"], ["Chunk 1", "Chunk 2"])
+
+    @patch('asyncio.create_subprocess_exec', new_callable=AsyncMock)
+    def test_extract_failure_non_zero_returncode(self, mock_exec):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b'', b'Readability error'))
+        mock_exec.return_value = mock_proc
+
+        response = self.client.post("/extract", json={"url": "http://example.com"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Extraction failed: Readability error")
+
+    @patch('asyncio.create_subprocess_exec', new_callable=AsyncMock)
+    def test_extract_timeout_error(self, mock_exec):
+        mock_proc = MagicMock()
+        # Mock communicate to raise TimeoutError on the first call (inside wait_for)
+        # And return a successful tuple on the second call (in the exception handler)
+        mock_proc.communicate = AsyncMock(side_effect=[asyncio.TimeoutError(), (b'', b'')])
+        mock_exec.return_value = mock_proc
+
+        response = self.client.post("/extract", json={"url": "http://example.com"})
+
+        # The exception handler catches subprocess.TimeoutExpired
+        self.assertEqual(response.status_code, 408)
+        self.assertEqual(response.json()["detail"], "Extraction timeout")
+        mock_proc.kill.assert_called_once()
+
+    @patch('asyncio.create_subprocess_exec', new_callable=AsyncMock)
+    def test_extract_json_decode_error(self, mock_exec):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b'invalid json', b''))
+        mock_exec.return_value = mock_proc
+
+        response = self.client.post("/extract", json={"url": "http://example.com"})
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["detail"], "Failed to parse extraction result")
+
+    @patch('asyncio.create_subprocess_exec', new_callable=AsyncMock)
+    def test_extract_generic_exception(self, mock_exec):
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(side_effect=Exception("Unexpected database error"))
+        mock_exec.return_value = mock_proc
+
+        response = self.client.post("/extract", json={"url": "http://example.com"})
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["detail"], "Internal server error: Unexpected database error")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Addressed untested `/extract` endpoint in `packages/api-server/main.py`. Added unit tests and fixed a generic exception handler bug that was masking intentional HTTPExceptions (e.g. 400 Bad Request and 408 Request Timeout) by transforming them into 500 Internal Server Errors.

📊 **Coverage:** What scenarios are now tested
Added `packages/api-server/tests/test_extract.py` which covers:
- Happy path (Successful extraction yielding chunks)
- Subprocess extraction failure (returncode != 0) yielding a 400 Bad Request
- Timeout expired error (asyncio.TimeoutError converted to subprocess.TimeoutExpired) yielding a 408 Timeout
- JSON Decode Error yielding a 500
- Generic internal error yielding a 500

✨ **Result:** The improvement in test coverage
The endpoint's core behaviors are now properly verified against regressions, and FastAPIs HTTPExceptions propagate to the client correctly.

---
*PR created automatically by Jules for task [1459319839222029140](https://jules.google.com/task/1459319839222029140) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `extract_content()` と `synthesize_speech()` において、`try` ブロック内で発生した `HTTPException` が汎用の `except Exception` ハンドラに捕捉されて意図せず HTTP 500 に変換されていたバグを修正し、`/extract` エンドポイントのユニットテストを追加します。

**主な変更点:**
- `extract_content()` と `synthesize_speech()` に `except HTTPException: raise` を追加し、400・408 等のHTTPエラーが正しくクライアントに伝播されるよう修正
- `test_extract.py` を新規追加：正常系・非ゼロ終了コード(400)・タイムアウト(408)・JSONデコードエラー(500)・汎用例外(500) の5ケースをカバー
- バグ修正は最小限かつ正確であり、既存動作への副作用なし

**改善推奨事項（P2）:**
- `synthesize_speech` の `HTTPException` 修正に対応するテストが不在
- タイムアウトテストのモックが `communicate()` の呼び出し回数という実装詳細に依存
- `sys.path.append` の代わりに pytest の `pythonpath` 設定を使用することを推奨
</details>

<h3>Confidence Score: 5/5</h3>

全ての指摘事項はP2（スタイル・改善推奨）レベルであり、マージ可能な状態です。

バグ修正（HTTPExceptionの再送出）は正確かつ最小限の変更で、機能的な正確性に問題はありません。残りの指摘はすべてP2（テストの改善推奨・スタイル）のため、スコアは5とします。

test_extract.py のモック戦略の脆弱性と synthesize_speech のテスト不在に注意。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api-server/main.py | `extract_content` と `synthesize_speech` において `HTTPException` が汎用 `except Exception` に飲み込まれるバグを修正。変更は最小限かつ正確。 |
| packages/api-server/tests/test_extract.py | `extract_content` エンドポイントの5ケースのユニットテストを新規追加。`synthesize_speech` テスト不在やモックの脆弱性など改善余地あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FastAPI
    participant NodeJS as Node.js

    Client->>FastAPI: POST /extract {"url": "..."}
    FastAPI->>NodeJS: asyncio.create_subprocess_exec("node", ...)
    NodeJS-->>FastAPI: communicate() → (stdout, stderr)

    alt 正常系 (returncode=0, JSON有効)
        FastAPI-->>Client: HTTP 200 {"title": ..., "chunks": [...]}
    else 非ゼロ終了コード
        FastAPI->>FastAPI: raise HTTPException(400)
        Note over FastAPI: except HTTPException: raise ✅
        FastAPI-->>Client: HTTP 400 Extraction failed
    else タイムアウト
        FastAPI->>FastAPI: asyncio.TimeoutError → proc.kill()
        FastAPI->>FastAPI: raise HTTPException(408)
        Note over FastAPI: except HTTPException: raise ✅
        FastAPI-->>Client: HTTP 408 Extraction timeout
    else JSONデコードエラー
        FastAPI->>FastAPI: raise HTTPException(500)
        Note over FastAPI: except HTTPException: raise ✅
        FastAPI-->>Client: HTTP 500 Failed to parse
    else 汎用例外
        FastAPI->>FastAPI: except Exception as e
        FastAPI-->>Client: HTTP 500 Internal server error
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/api-server/tests/test_extract.py
Line: 18-21

Comment:
**`synthesize_speech` のテストが不在**

このPRでは `extract_content` と `synthesize_speech` の両方に同じ `HTTPException` バグ修正（`except HTTPException: raise` の追加）を行っていますが、`synthesize_speech` エンドポイントに対応するテストが追加されていません。修正の正しさを検証するため、`synthesize_speech` にも HTTPException が正しく再送出されることを確認するテストケースの追加を推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/api-server/tests/test_extract.py
Line: 59-71

Comment:
**タイムアウトテストが実装詳細に依存**

`communicate` のモックに `side_effect=[asyncio.TimeoutError(), (b'', b'')]` を設定していますが、これは「`communicate()` がちょうど2回呼ばれる」という内部実装の詳細に強く依存しています。将来、例外ハンドラ内のクリーンアップ処理が `proc.communicate()` から `proc.wait()` などに変更された場合、このテストがサイレントに壊れるリスクがあります。

`asyncio.wait_for` 自体をモックする方法がより堅牢です：

```python
with patch('asyncio.wait_for', side_effect=asyncio.TimeoutError()):
    response = self.client.post("/extract", json={"url": "http://example.com"})
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/api-server/tests/test_extract.py
Line: 14

Comment:
**`sys.path.append` の使用は非推奨**

モジュールレベルでの `sys.path.append` はテスト間でのパス汚染や順序依存を引き起こす可能性があります。`pyproject.toml` の `pythonpath` 設定を使用する方が安全で標準的です：

```toml
# pyproject.toml
[tool.pytest.ini_options]
pythonpath = ["packages/api-server"]
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for extract endpoint and fi..."](https://github.com/hiroki-org/audicle/commit/0fbb945b00a9b4ba4eedc1e84c8081d0cad9735c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27548784)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->