### PR TITLE
🧹 Extract inline switch statement for downloadButtonLabel to pure function

### DIFF
--- a/packages/web-app-vercel/components/ReaderView.tsx
+++ b/packages/web-app-vercel/components/ReaderView.tsx
@@ -19,6 +19,20 @@ interface ReaderViewProps {
   onChunkClick?: (chunkId: string) => void;
 }
 
+
+function getDownloadButtonLabel(status: string): string {
+  switch (status) {
+    case "downloading":
+      return "音声を準備中...";
+    case "error":
+      return "再試行";
+    case "cancelled":
+      return "もう一度ダウンロード";
+    default:
+      return "全文をダウンロード";
+  }
+}
+
 export default function ReaderView({
   chunks = [],
   currentChunkId,
@@ -172,18 +186,7 @@ export default function ReaderView({
     };
   }, [chunkSignature]);
 
-  const downloadButtonLabel = useMemo(() => {
-    switch (downloadStatus) {
-      case "downloading":
-        return "音声を準備中...";
-      case "error":
-        return "再試行";
-      case "cancelled":
-        return "もう一度ダウンロード";
-      default:
-        return "全文をダウンロード";
-    }
-  }, [downloadStatus]);
+  const downloadButtonLabel = useMemo(() => getDownloadButtonLabel(downloadStatus), [downloadStatus]);
 
   return (
     <div


### PR DESCRIPTION
🎯 **What:** Extracted the inline switch statement that maps `downloadStatus` to its corresponding label into a top-level pure function `getDownloadButtonLabel`.
💡 **Why:** This improves the maintainability and readability of `ReaderView.tsx` by moving self-contained logic outside of the main component and keeping `useMemo` clean.
✅ **Verification:** Ran format, lint, and test suites successfully. Verified the function is used correctly.
✨ **Result:** `ReaderView` component logic is simplified and easier to read.

---
*PR created automatically by Jules for task [8354376017211526475](https://jules.google.com/task/8354376017211526475) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

PR #644 は `ReaderView.tsx` 内のインライン switch 文を、トップレベルの純粋関数 `getDownloadButtonLabel` に抽出するリファクタリング PR です。動作上の変更はなく、コードの可読性・保守性が向上しています。

主な変更点:
- `downloadStatus` をラベル文字列にマッピングするロジックを `useMemo` 内から独立した純粋関数へ移動
- 関数のシグネチャは `(status: string): string` — 実際の `DownloadStatus` ユニオン型を使うとより型安全になる
- `interface ReaderViewProps` の直後に空行が2行連続している（軽微なスタイル上の問題）
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージして安全です。純粋なリファクタリングであり、動作上の変更はありません。

すべての指摘事項はP2（スタイル/推奨）レベルです。ロジックの変更はなく、テスト・lint・フォーマットも通過済みとのことです。

特になし。`ReaderView.tsx` の型定義（`string` → `DownloadStatus`）のみ軽微な改善余地があります。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/ReaderView.tsx | `downloadStatus` → ラベルの変換ロジックをインラインの `useMemo` からトップレベルの純粋関数 `getDownloadButtonLabel` へ抽出する、小規模なリファクタリング。軽微な型安全性の改善余地あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[downloadStatus<br/>DownloadStatus] -->|useMemo| B[getDownloadButtonLabel]
    B --> C{status}
    C -->|downloading| D[音声を準備中...]
    C -->|error| E[再試行]
    C -->|cancelled| F[もう一度ダウンロード]
    C -->|default<br/>idle / completed| G[全文をダウンロード]
    D & E & F & G --> H[downloadButtonLabel]
    H --> I[UI レンダリング]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/components/ReaderView.tsx
Line: 23

Comment:
**`DownloadStatus` 型を使用することを推奨**

`status` パラメーターの型が `string` になっていますが、`useDownload` フックが返す実際の型は `DownloadStatus = 'idle' | 'downloading' | 'completed' | 'error' | 'cancelled'` というユニオン型です。`string` を使うと型の安全性が失われ、TypeScript コンパイラーによる網羅性チェックも効かなくなります。`DownloadStatus` をインポートして使用することを推奨します。

```suggestion
function getDownloadButtonLabel(status: DownloadStatus): string {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/components/ReaderView.tsx
Line: 22

Comment:
**連続した空行**

インターフェース定義の後に空行が2行連続しています。1行に統一することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/components/ReaderView.tsx
Line: 189

Comment:
**`useMemo` の必要性について**

`getDownloadButtonLabel` は純粋関数であり、単純な switch 文（O(1)）しか実行しません。関数が外部に切り出された今、`useMemo` のオーバーヘッドがメモ化の恩恵を上回る可能性があります。以下のようにシンプルに書くことも検討できます。

```suggestion
  const downloadButtonLabel = getDownloadButtonLabel(downloadStatus);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract inline switch statement for d..."](https://github.com/hiroki-org/audicle/commit/c4c3e8e4c9f013e5f0715493e65753d64d34c297) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27548904)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->