### PR TITLE
⚡ Optimize test data seeding by replacing N+1 updates with batch upsert

### DIFF
--- a/packages/web-app-vercel/scripts/seed-test-data.ts
+++ b/packages/web-app-vercel/scripts/seed-test-data.ts
@@ -293,26 +293,39 @@ async function seedTestData() {
     }
 
     // 既存記事を更新
-    for (const article of toUpdate) {
-        const key = article.owner_email + "||" + article.url;
-        const existing = existingMap.get(key);
-        if (existing) {
-            const { data: updated, error: updateError } = await supabase
-                .from("articles")
-                .update({
-                    owner_email: article.owner_email,
-                    title: article.title,
-                    thumbnail_url: article.thumbnail_url,
-                })
-                .eq("id", existing.id)
-                .select()
-                .single();
+    if (toUpdate.length > 0) {
+        const batchUpdateData = toUpdate.map((article) => {
+            const key = article.owner_email + "||" + article.url;
+            const existing = existingMap.get(key);
 
-            if (updateError) {
-                console.error("記事の更新に失敗:", updateError);
-                process.exit(1);
+            if (!existing) {
+                // This shouldn't happen due to the logic above, but added for safety and TS
+                return null;
             }
-            if (updated) createdArticlesMap.set(updated.owner_email + "||" + updated.url, updated as Article);
+
+            return {
+                id: existing.id,
+                owner_email: article.owner_email,
+                title: article.title,
+                thumbnail_url: article.thumbnail_url,
+                url: article.url, // required if we are mapping createdArticlesMap with url below
+            };
+        }).filter((item) => item !== null) as { id: string; owner_email: string; title: string; thumbnail_url: string; url: string }[];
+
+        const { data: updatedItems, error: updateError } = await supabase
+            .from("articles")
+            .upsert(batchUpdateData, { onConflict: "id" })
+            .select();
+
+        if (updateError) {
+            console.error("記事の更新に失敗:", updateError);
+            process.exit(1);
+        }
+
+        if (updatedItems) {
+            for (const updated of updatedItems) {
+                createdArticlesMap.set(updated.owner_email + "||" + updated.url, updated as Article);
+            }
         }
     }
 


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for` loop of individual `supabase.from("articles").update(...)` calls with a single bulk `.upsert(batchUpdateData, { onConflict: "id" })` operation. The mapping ensures only `id`, `owner_email`, `title`, `thumbnail_url`, and `url` are explicitly specified to update existing records efficiently without affecting other columns.

🎯 **Why:** The previous implementation executed `UPDATE` statements inside a `for` loop, causing an N+1 database problem. This generated unnecessary overhead and sequential network round-trips for every existing article that needed to be updated.

📊 **Measured Improvement:** I cannot measure the exact latency improvement locally because the script connects to a remote Supabase instance requiring credentials I lack in this test sandbox. However, by replacing an O(N) sequence of `await` network requests with a single O(1) batch network request, latency is objectively and measurably reduced by entirely eliminating (N-1) database network round-trips. This significantly speeds up the execution time of test data seeding, especially when the number of existing articles (`N`) increases.

---
*PR created automatically by Jules for task [5866672096176306679](https://jules.google.com/task/5866672096176306679) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

テストデータシードスクリプトにおいて、既存記事を更新する際のN+1データベース問題を解消するため、個別の `update` ループを単一の `upsert` バッチ操作に置き換えました。

- **パフォーマンス改善**: N回の逐次 `UPDATE` ネットワークラウンドトリップを1回の `UPSERT` に削減し、記事数が増加した場合もスケールしやすい構造になっています。
- **`url` フィールドの追加**: 元の更新対象は `owner_email`・`title`・`thumbnail_url` のみでしたが、新実装では `url` も含まれます。`url` はルックアップキーと同値のため実質的な変更はありません。
- **セマンティクスの変化**: 元の `.update().eq("id", ...)` と異なり、`.upsert(..., { onConflict: "id" })` はレコードが存在しない場合に INSERT を試みます。`toUpdate` リストは直前の SELECT で存在確認済みのため通常の実行では問題ありませんが、軽微なセマンティクスの差異として留意が必要です。
- **エラーハンドリング**: 更新失敗時の `process.exit(1)` および結果の `createdArticlesMap` への反映は適切に維持されています。
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージ可能です。P2レベルの軽微な指摘のみで、重大な問題はありません。

変更はシンプルかつ明確で、N+1問題を正しく解消しています。upsertのセマンティクスに関する軽微なスタイル指摘（P2）のみで、バグや破壊的変更は見当たりません。エラーハンドリングも適切に維持されており、安全にマージできます。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/scripts/seed-test-data.ts | 既存記事のN+1更新をバッチupsertに置き換え。エラーハンドリングと結果マッピングも適切に維持されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Script as seed-test-data.ts
    participant DB as Supabase (articles)

    Note over Script,DB: 変更前（N+1問題）
    Script->>DB: SELECT WHERE url IN (...) AND owner_email IN (...)
    DB-->>Script: 既存記事一覧
    loop toUpdate内の各記事（N回）
        Script->>DB: UPDATE articles SET owner_email, title, thumbnail_url WHERE id = ?
        DB-->>Script: 更新結果（1件）
    end

    Note over Script,DB: 変更後（バッチupsert）
    Script->>DB: SELECT WHERE url IN (...) AND owner_email IN (...)
    DB-->>Script: 既存記事一覧
    Script->>DB: UPSERT articles（N件まとめて）ON CONFLICT (id)
    DB-->>Script: 更新結果一覧（1回のみ）
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/scripts/seed-test-data.ts
Line: 315-318

Comment:
**`update` の代わりに `upsert` を使うことによるセマンティクスの差異**

`.upsert(..., { onConflict: "id" })` は、指定した `id` を持つレコードが存在しない場合に新規 INSERT を試みます。`toUpdate` に含まれるすべての記事は直前の SELECT で存在確認済みのため、通常の実行フローでは INSERT パスが走ることはありません。

ただし、SELECT と upsert の間にレコードが削除されるレースコンディションが発生した場合、`id`・`owner_email`・`title`・`thumbnail_url`・`url` の5カラムのみで新規レコードが挿入されるため、他の NOT NULL カラムが存在する場合に制約違反エラーが発生するリスクがあります。現状のエラーハンドリング（`if (updateError)`）が適切に機能するため致命的ではありませんが、意図として「更新のみ」であることをコメントで明示しておくと可読性が向上します。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["⚡ refactor(seed): optimize test data see..."](https://github.com/hiroki-org/audicle/commit/76a2b02f87704a44ff660e730d15e9e01c6d7a20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27549259)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->