### PR TITLE
🧪 Add tests for Spinner component

### DIFF
--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import Spinner from "../Spinner";
+
+describe("Spinner", () => {
+  it("renders with default props", () => {
+    const { container } = render(<Spinner />);
+    const span = container.firstChild as HTMLElement;
+
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveClass(
+      "inline-block",
+      "animate-spin",
+      "rounded-full",
+      "border-2",
+      "border-current",
+      "border-t-transparent",
+    );
+    expect(span).toHaveStyle({ width: "32px", height: "32px" });
+    expect(span).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("applies custom size correctly", () => {
+    const { container } = render(<Spinner size={48} />);
+    const span = container.firstChild as HTMLElement;
+
+    expect(span).toHaveStyle({ width: "48px", height: "48px" });
+  });
+
+  it("appends custom className", () => {
+    const { container } = render(<Spinner className="text-red-500" />);
+    const span = container.firstChild as HTMLElement;
+
+    expect(span).toHaveClass("text-red-500");
+    expect(span).toHaveClass("animate-spin"); // Ensure base classes are still there
+  });
+});

--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -5,7 +5,7 @@ import Spinner from "../Spinner";
 describe("Spinner", () => {
   it("renders with default props", () => {
     const { container } = render(<Spinner />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
 
     expect(span).toBeInTheDocument();
     expect(span).toHaveClass(
@@ -22,16 +22,21 @@ describe("Spinner", () => {
 
   it("applies custom size correctly", () => {
     const { container } = render(<Spinner size={48} />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
 
     expect(span).toHaveStyle({ width: "48px", height: "48px" });
   });
 
   it("appends custom className", () => {
     const { container } = render(<Spinner className="text-red-500" />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
 
     expect(span).toHaveClass("text-red-500");
-    expect(span).toHaveClass("animate-spin"); // Ensure base classes are still there
+    expect(span).toHaveClass(
+      "animate-spin",
+      "rounded-full",
+      "border-2",
+      "border-t-transparent",
+    );
   });
 });

--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -5,7 +5,7 @@ import Spinner from "../Spinner";
 describe("Spinner", () => {
   it("renders with default props", () => {
     const { container } = render(<Spinner />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.querySelector('span');
 
     expect(span).toBeInTheDocument();
     expect(span).toHaveClass(
@@ -22,21 +22,16 @@ describe("Spinner", () => {
 
   it("applies custom size correctly", () => {
     const { container } = render(<Spinner size={48} />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.querySelector('span');
 
     expect(span).toHaveStyle({ width: "48px", height: "48px" });
   });
 
   it("appends custom className", () => {
     const { container } = render(<Spinner className="text-red-500" />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.querySelector('span');
 
     expect(span).toHaveClass("text-red-500");
-    expect(span).toHaveClass(
-      "animate-spin",
-      "rounded-full",
-      "border-2",
-      "border-t-transparent",
-    );
+    expect(span).toHaveClass("animate-spin"); // Ensure base classes are still there
   });
 });


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `Spinner` component to verify its rendering and props handling.
📊 **Coverage:** Covered rendering with default props, custom sizing, and custom classes.
✨ **Result:** Improved test coverage and ensured the Spinner component correctly applies its CSS and ARIA attributes.

---
*PR created automatically by Jules for task [9356466230589195457](https://jules.google.com/task/9356466230589195457) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`Spinner` コンポーネントに対するユニットテストを新規追加するPRです。デフォルトprops・カスタムサイズ・カスタムclassNameの3ケースをカバーしており、実装（`Spinner.tsx`）の挙動と正確に一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- テストのみの変更であり、マージに問題ありません。
- P0/P1の問題はなく、テストの内容はコンポーネント実装と正確に一致しています。唯一のコメントはP2レベルのスタイル提案のみです。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/__tests__/Spinner.test.tsx | Spinner コンポーネントのユニットテストを追加。デフォルトprops・カスタムサイズ・カスタムclassNameの3ケースをカバーしており、実装と一致している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Spinner.test.tsx] --> B[describe: Spinner]
    B --> C[it: renders with default props]
    B --> D[it: applies custom size correctly]
    B --> E[it: appends custom className]

    C --> C1[render Spinner /]
    C1 --> C2[toBeInTheDocument]
    C1 --> C3[toHaveClass - 6 base classes]
    C1 --> C4[toHaveStyle - width/height 32px]
    C1 --> C5[toHaveAttribute aria-hidden true]

    D --> D1[render Spinner size=48]
    D1 --> D2[toHaveStyle - width/height 48px]

    E --> E1[render Spinner className=text-red-500]
    E1 --> E2[toHaveClass text-red-500]
    E1 --> E3[toHaveClass animate-spin]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/components/__tests__/Spinner.test.tsx
Line: 29-35

Comment:
**カスタム `className` のベースクラス検証が不十分**

`className` テストでは `animate-spin` 1つしか確認していませんが、`text-red-500` を渡した際にその他のベースクラス（`rounded-full`、`border-t-transparent` など）も上書きされていないかどうか一緒に確認するとより堅牢になります。

```suggestion
  it("appends custom className", () => {
    const { container } = render(<Spinner className="text-red-500" />);
    const span = container.firstChild as HTMLElement;

    expect(span).toHaveClass("text-red-500");
    // ベースクラスが残っていることを確認
    expect(span).toHaveClass(
      "inline-block",
      "animate-spin",
      "rounded-full",
      "border-2",
      "border-current",
      "border-t-transparent",
    );
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for Spinner component"](https://github.com/hiroki-org/audicle/commit/1a4a443a1a8462ee96e3430beaff4950e291bc1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->