### PR TITLE
🧪 Add tests for Spinner component

### DIFF
--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import Spinner from "../Spinner";
+
+describe("Spinner Component", () => {
+  it("renders with default props correctly", () => {
+    const { container } = render(<Spinner />);
+    const span = container.firstChild as HTMLElement;
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveClass("inline-block animate-spin rounded-full border-2 border-current border-t-transparent");
+    expect(span).toHaveStyle({ width: "32px", height: "32px" });
+    expect(span).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("applies custom size correctly", () => {
+    const customSize = 48;
+    const { container } = render(<Spinner size={customSize} />);
+    const span = container.firstChild as HTMLElement;
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveStyle({ width: `${customSize}px`, height: `${customSize}px` });
+  });
+
+  it("applies custom className correctly", () => {
+    const customClass = "text-red-500 custom-margin";
+    const { container } = render(<Spinner className={customClass} />);
+    const span = container.firstChild as HTMLElement;
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveClass("text-red-500 custom-margin");
+    // Ensure default classes are still there
+    expect(span).toHaveClass("inline-block animate-spin");
+  });
+});

--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -5,16 +5,9 @@ import Spinner from "../Spinner";
 describe("Spinner Component", () => {
   it("renders with default props correctly", () => {
     const { container } = render(<Spinner />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.firstChild as HTMLElement;
     expect(span).toBeInTheDocument();
-    expect(span).toHaveClass(
-      "inline-block",
-      "animate-spin",
-      "rounded-full",
-      "border-2",
-      "border-current",
-      "border-t-transparent",
-    );
+    expect(span).toHaveClass("inline-block animate-spin rounded-full border-2 border-current border-t-transparent");
     expect(span).toHaveStyle({ width: "32px", height: "32px" });
     expect(span).toHaveAttribute("aria-hidden", "true");
   });
@@ -22,7 +15,7 @@ describe("Spinner Component", () => {
   it("applies custom size correctly", () => {
     const customSize = 48;
     const { container } = render(<Spinner size={customSize} />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.firstChild as HTMLElement;
     expect(span).toBeInTheDocument();
     expect(span).toHaveStyle({ width: `${customSize}px`, height: `${customSize}px` });
   });
@@ -30,10 +23,10 @@ describe("Spinner Component", () => {
   it("applies custom className correctly", () => {
     const customClass = "text-red-500 custom-margin";
     const { container } = render(<Spinner className={customClass} />);
-    const span = container.querySelector("span") as HTMLElement;
+    const span = container.firstChild as HTMLElement;
     expect(span).toBeInTheDocument();
-    expect(span).toHaveClass("text-red-500", "custom-margin");
+    expect(span).toHaveClass("text-red-500 custom-margin");
     // Ensure default classes are still there
-    expect(span).toHaveClass("inline-block", "animate-spin");
+    expect(span).toHaveClass("inline-block animate-spin");
   });
 });

--- a/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/Spinner.test.tsx
@@ -5,9 +5,16 @@ import Spinner from "../Spinner";
 describe("Spinner Component", () => {
   it("renders with default props correctly", () => {
     const { container } = render(<Spinner />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
     expect(span).toBeInTheDocument();
-    expect(span).toHaveClass("inline-block animate-spin rounded-full border-2 border-current border-t-transparent");
+    expect(span).toHaveClass(
+      "inline-block",
+      "animate-spin",
+      "rounded-full",
+      "border-2",
+      "border-current",
+      "border-t-transparent",
+    );
     expect(span).toHaveStyle({ width: "32px", height: "32px" });
     expect(span).toHaveAttribute("aria-hidden", "true");
   });
@@ -15,7 +22,7 @@ describe("Spinner Component", () => {
   it("applies custom size correctly", () => {
     const customSize = 48;
     const { container } = render(<Spinner size={customSize} />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
     expect(span).toBeInTheDocument();
     expect(span).toHaveStyle({ width: `${customSize}px`, height: `${customSize}px` });
   });
@@ -23,10 +30,10 @@ describe("Spinner Component", () => {
   it("applies custom className correctly", () => {
     const customClass = "text-red-500 custom-margin";
     const { container } = render(<Spinner className={customClass} />);
-    const span = container.firstChild as HTMLElement;
+    const span = container.querySelector("span") as HTMLElement;
     expect(span).toBeInTheDocument();
-    expect(span).toHaveClass("text-red-500 custom-margin");
+    expect(span).toHaveClass("text-red-500", "custom-margin");
     // Ensure default classes are still there
-    expect(span).toHaveClass("inline-block animate-spin");
+    expect(span).toHaveClass("inline-block", "animate-spin");
   });
 });

--- a/packages/web-app-vercel/jest.config.js
+++ b/packages/web-app-vercel/jest.config.js
@@ -25,7 +25,6 @@ const customJestConfig = {
   collectCoverageFrom: [
     "lib/**/*.{js,jsx,ts,tsx}",
     "components/DomainBadge.tsx",
-    "components/Spinner.tsx",
     "!lib/**/__tests__/**",
     "!**/*.d.ts",
     "!**/node_modules/**",

--- a/packages/web-app-vercel/jest.config.js
+++ b/packages/web-app-vercel/jest.config.js
@@ -25,6 +25,7 @@ const customJestConfig = {
   collectCoverageFrom: [
     "lib/**/*.{js,jsx,ts,tsx}",
     "components/DomainBadge.tsx",
+    "components/Spinner.tsx",
     "!lib/**/__tests__/**",
     "!**/*.d.ts",
     "!**/node_modules/**",


### PR DESCRIPTION
🎯 **What:** Added a new unit test suite for the `Spinner` UI component which previously had no test coverage.
📊 **Coverage:** Added tests to cover default rendering, custom sizes, and custom class names.
✨ **Result:** Improves test coverage and ensures UI consistency for the Spinner component.

---
*PR created automatically by Jules for task [7476247911218422873](https://jules.google.com/task/7476247911218422873) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`Spinner` コンポーネントに対するユニットテストを新規追加した PR です。デフォルトレンダリング・カスタムサイズ・カスタムクラス名の 3 ケースをカバーしており、テストロジック自体は実装と一致しています。`jest.config.js` の `collectCoverageFrom` に `components/Spinner.tsx` が含まれていないため、カバレッジレポート上は数値が変化しない点のみ気になります。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- テストのロジックは正確で、マージしても安全です。
- 残っている指摘は P2（カバレッジ設定の未更新）のみで、機能的・実行時の問題はありません。全テストケースは Spinner コンポーネントの実装と一致しており、ブロッカーとなる問題はありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/__tests__/Spinner.test.tsx | Spinner コンポーネントのユニットテストを新規追加。デフォルトプロップ・カスタムサイズ・カスタムクラス名の3ケースをカバーしており、テストロジック自体は正しい。ただし jest.config.js の collectCoverageFrom に Spinner.tsx が含まれていないため、カバレッジメトリクスには反映されない。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Spinner.test.tsx"] -->|"render(<Spinner />)"| B["デフォルト props テスト\nsize=32, className=''"]
    A -->|"render(<Spinner size={48} />)"| C["カスタムサイズ テスト\nwidth/height: 48px"]
    A -->|"render(<Spinner className='text-red-500 custom-margin' />)"| D["カスタムクラス テスト\nデフォルトクラスも維持"]
    B --> E["✅ aria-hidden, style, className を検証"]
    C --> F["✅ style を検証"]
    D --> G["✅ className を検証"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/components/__tests__/Spinner.test.tsx
Line: 1-3

Comment:
**カバレッジ計測の対象外になっています**

`jest.config.js` の `collectCoverageFrom` には `components/DomainBadge.tsx` しか含まれておらず、`components/Spinner.tsx` が除外されています。このため、PR の説明にある「テストカバレッジの向上」は Jest のカバレッジレポート上では反映されません。`Spinner.tsx` をカバレッジ対象に追加するには、`jest.config.js` を更新する必要があります。

```js
// jest.config.js
collectCoverageFrom: [
  "lib/**/*.{js,jsx,ts,tsx}",
  "components/DomainBadge.tsx",
  "components/Spinner.tsx",   // 追加
  ...
]
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for Spinner component"](https://github.com/hiroki-org/audicle/commit/1600191f01755bb781ca5958e9d04e7846829e36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308226)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->