### PR TITLE
🧹 Remove unused 'io' import in server.py

### DIFF
--- a/_archive/docker-tts-server/server.py
+++ b/_archive/docker-tts-server/server.py
@@ -8,7 +8,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import edge_tts
-import asyncio
 import tempfile
 import os
 from typing import Optional

--- a/_archive/docker-tts-server/server.py
+++ b/_archive/docker-tts-server/server.py
@@ -9,7 +9,6 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import edge_tts
 import asyncio
-import io
 import tempfile
 import os
 from typing import Optional

--- a/_archive/docker-tts-server/server.py
+++ b/_archive/docker-tts-server/server.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 import edge_tts
+import asyncio
 import tempfile
 import os
 from typing import Optional


### PR DESCRIPTION
🎯 **What:** Removed unused `import io` from `_archive/docker-tts-server/server.py`.
💡 **Why:** Reduces unnecessary imports, improving code clarity and hygiene.
✅ **Verification:** Ran `py_compile` to ensure no syntax errors were introduced. Checked via `grep` that `io` is not used elsewhere in the file.
✨ **Result:** A slightly cleaner and more maintainable file.

---
*PR created automatically by Jules for task [2152287688615766970](https://jules.google.com/task/2152287688615766970) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`_archive/docker-tts-server/server.py` から使用されていない `import io` を削除するシンプルなクリーンアップ PR です。ファイル内で `io` モジュールが参照されている箇所は存在せず、変更は正確です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- マージ安全。未使用インポートの削除のみで、ロジックへの影響なし。
- 変更は1行のみで、アーカイブ済みファイルの未使用インポートを削除するだけ。P1/P0 の問題は一切なく、残る指摘事項もありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| _archive/docker-tts-server/server.py | 未使用の `import io` を削除。ファイルのどこにも `io` モジュールは使われておらず、変更は正確で安全。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FastAPI
    participant EdgeTTS
    participant TempFile

    Client->>FastAPI: "POST /synthesize {"text": "...", "voice": "...", "rate": "..."}"
    FastAPI->>TempFile: "NamedTemporaryFile(suffix=".mp3") 作成"
    FastAPI->>EdgeTTS: Communicate(text, voice, rate)
    EdgeTTS-->>TempFile: communicate.save(temp_filename)
    FastAPI->>TempFile: open(temp_filename, "rb") で読み込み
    FastAPI-->>Client: StreamingResponse (audio/mpeg)
    TempFile-->>TempFile: os.unlink(temp_filename) 削除
```

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove unused &#39;io&#39; import in server.p..."](https://github.com/hiroki-org/audicle/commit/f8a60629ed01a140d782b3a29001d6e9b45a5c36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308328)</sub>

<!-- /greptile_comment -->