### PR TITLE
🧪 Add tests for resizeChunksIfNeeded edge cases

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -1,190 +1,234 @@
 import {
-    parseHTMLToParagraphs,
-    // 内部関数をテスト用にエクスポートする必要があるため、
-    // テストファイルを別の形式で作成
-} from '../paragraphParser';
+  parseHTMLToParagraphs,
+  resizeChunksIfNeeded,
+  // 内部関数をテスト用にエクスポートする必要があるため、
+  // テストファイルを別の形式で作成
+} from "../paragraphParser";
 
 /**
  * paragraphParser のチャンクリサイズ機能のテスト
  */
-describe('paragraphParser', () => {
-    describe('parseHTMLToParagraphs', () => {
-        it('should parse simple HTML to paragraphs', () => {
-            const html = '<p>こんにちは</p><p>世界</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThan(0);
-        });
+describe("paragraphParser", () => {
+  describe("parseHTMLToParagraphs", () => {
+    it("should parse simple HTML to paragraphs", () => {
+      const html = "<p>こんにちは</p><p>世界</p>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThan(0);
+    });
 
-        it('should handle empty HTML', () => {
-            const result = parseHTMLToParagraphs('');
-            expect(result.paragraphs).toEqual([]);
-        });
+    it("should handle empty HTML", () => {
+      const result = parseHTMLToParagraphs("");
+      expect(result.paragraphs).toEqual([]);
+    });
 
-        it('should not duplicate content from p tags inside blockquotes', () => {
-            const html = '<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(2);
-            expect(paragraphs[0].type).toBe('blockquote');
-            expect(paragraphs[0].originalText).toBe('This is a quote.');
-            expect(paragraphs[1].type).toBe('p');
-            expect(paragraphs[1].originalText).toBe('This is a paragraph.');
-        });
+    it("should not duplicate content from p tags inside blockquotes", () => {
+      const html =
+        "<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(2);
+      expect(paragraphs[0].type).toBe("blockquote");
+      expect(paragraphs[0].originalText).toBe("This is a quote.");
+      expect(paragraphs[1].type).toBe("p");
+      expect(paragraphs[1].originalText).toBe("This is a paragraph.");
+    });
 
-        it('should handle nested blockquote with multiple p tags', () => {
-            const html = '<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].type).toBe('blockquote');
-            expect(paragraphs[0].originalText).toContain('Quote line 1');
-            expect(paragraphs[0].originalText).toContain('Quote line 2');
-        });
+    it("should handle nested blockquote with multiple p tags", () => {
+      const html =
+        "<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].type).toBe("blockquote");
+      expect(paragraphs[0].originalText).toContain("Quote line 1");
+      expect(paragraphs[0].originalText).toContain("Quote line 2");
+    });
 
-        it('should extract code blocks (pre elements)', () => {
-            const html = '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(3);
-            expect(paragraphs[0].originalText).toBe('コード例：');
-            expect(paragraphs[1].type).toBe('pre');
-            expect(paragraphs[1].originalText).toContain('function hello()');
-            expect(paragraphs[2].originalText).toBe('以上です。');
-        });
+    it("should extract code blocks (pre elements)", () => {
+      const html =
+        '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(3);
+      expect(paragraphs[0].originalText).toBe("コード例：");
+      expect(paragraphs[1].type).toBe("pre");
+      expect(paragraphs[1].originalText).toContain("function hello()");
+      expect(paragraphs[2].originalText).toBe("以上です。");
+    });
 
-        it('コードブロックを含む日本語記事でjaと判定されること', () => {
-            const html = `
+    it("コードブロックを含む日本語記事でjaと判定されること", () => {
+      const html = `
                 <p>これはJavaScriptの解説です。</p>
                 <pre><code>function test() { return 1; }</code></pre>
                 <p>以上です。</p>
             `;
-            const result = parseHTMLToParagraphs(html);
-            expect(result.detectedLanguage).toBe('ja');
-        });
+      const result = parseHTMLToParagraphs(html);
+      expect(result.detectedLanguage).toBe("ja");
+    });
 
-        it('コードブロックのみでも誤判定しないこと', () => {
-            const html = `
+    it("コードブロックのみでも誤判定しないこと", () => {
+      const html = `
                 <p>コード例：</p>
                 <pre><code>const a = 1; const b = 2; const c = a + b;</code></pre>
             `;
-            const result = parseHTMLToParagraphs(html);
-            expect(result.detectedLanguage).toBe('ja');
-        });
-
-        it('should extract table cells (td/th elements)', () => {
-            const html = '<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThanOrEqual(4);
-            const texts = paragraphs.map(p => p.originalText);
-            expect(texts).toContain('項目');
-            expect(texts).toContain('値');
-            expect(texts).toContain('名前');
-            expect(texts).toContain('テスト');
-        });
-
-        it('should extract figcaption', () => {
-            const html = '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].type).toBe('figcaption');
-            expect(paragraphs[0].originalText).toBe('図1: テスト画像');
-        });
-
-        it('should fallback to body text when no block elements found', () => {
-            const html = '<div>直接のテキスト内容</div>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThanOrEqual(1);
-            expect(paragraphs.some(p => p.originalText.includes('直接のテキスト内容'))).toBe(true);
-        });
+      const result = parseHTMLToParagraphs(html);
+      expect(result.detectedLanguage).toBe("ja");
     });
 
-    describe('chunk resizing', () => {
-        it('should split text exceeding 5000 bytes at punctuation', () => {
-            // 日本語の「あ」は3バイト、1667文字で約5000バイト
-            // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
-            const longJapaneseText = 'あ'.repeat(1700); // 約5100バイト
-            const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
-
-            const html = `<p>${longTextWithPunctuation}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // リサイズされて複数のチャンクに分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should split text by commas when no period is available', () => {
-            // 句点なしで読点ありのテキスト
-            const longText = 'あ'.repeat(500) + '、' + 'い'.repeat(500) + '、' + 'う'.repeat(500) + '、' + 'え'.repeat(500);
-
-            const html = `<p>${longText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 複数のチャンクに分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-        });
-
-        it('should force split text without any delimiters', () => {
-            // 区切り文字なしの長いテキスト（日本語のみ）
-            const longTextNoDelimiter = 'あ'.repeat(2000); // 約6000バイト
-
-            const html = `<p>${longTextNoDelimiter}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // フォーススプリットで分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should not split text under 4800 bytes', () => {
-            // 短いテキスト（安全上限以下）
-            const shortText = 'こんにちは世界';
-
-            const html = `<p>${shortText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 1つのチャンクのまま
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].cleanedText).toBe(shortText);
-        });
-
-        it('should handle mixed Japanese and English text', () => {
-            // 日英混合の長いテキスト
-            const mixedText = ('日本語テキスト. English text. ' + 'あ'.repeat(200)).repeat(10);
-
-            const html = `<p>${mixedText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should preserve delimiter priority (。 > 、 > .)', () => {
-            // 句点、読点、ピリオドを含むテキスト
-            // 約5000バイト超えになるようにして、句点で分割されることを確認
-            const text = 'あ'.repeat(800) + '。' + 'い'.repeat(800) + '、' + 'う'.repeat(800);
-
-            const html = `<p>${text}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 分割されているはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 最初のチャンクは句点で終わるはず（優先度が高いため）
-            if (paragraphs.length >= 2) {
-                expect(paragraphs[0].cleanedText.endsWith('。')).toBe(true);
-            }
-        });
+    it("should extract table cells (td/th elements)", () => {
+      const html =
+        "<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThanOrEqual(4);
+      const texts = paragraphs.map((p) => p.originalText);
+      expect(texts).toContain("項目");
+      expect(texts).toContain("値");
+      expect(texts).toContain("名前");
+      expect(texts).toContain("テスト");
     });
+
+    it("should extract figcaption", () => {
+      const html =
+        '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].type).toBe("figcaption");
+      expect(paragraphs[0].originalText).toBe("図1: テスト画像");
+    });
+
+    it("should fallback to body text when no block elements found", () => {
+      const html = "<div>直接のテキスト内容</div>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThanOrEqual(1);
+      expect(
+        paragraphs.some((p) => p.originalText.includes("直接のテキスト内容")),
+      ).toBe(true);
+    });
+  });
+
+  describe("chunk resizing", () => {
+    it("should split text exceeding 5000 bytes at punctuation", () => {
+      // 日本語の「あ」は3バイト、1667文字で約5000バイト
+      // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
+      const longJapaneseText = "あ".repeat(1700); // 約5100バイト
+      const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
+
+      const html = `<p>${longTextWithPunctuation}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // リサイズされて複数のチャンクに分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should split text by commas when no period is available", () => {
+      // 句点なしで読点ありのテキスト
+      const longText =
+        "あ".repeat(500) +
+        "、" +
+        "い".repeat(500) +
+        "、" +
+        "う".repeat(500) +
+        "、" +
+        "え".repeat(500);
+
+      const html = `<p>${longText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 複数のチャンクに分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+    });
+
+    it("should force split text without any delimiters", () => {
+      // 区切り文字なしの長いテキスト（日本語のみ）
+      const longTextNoDelimiter = "あ".repeat(2000); // 約6000バイト
+
+      const html = `<p>${longTextNoDelimiter}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // フォーススプリットで分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should not split text under 4800 bytes", () => {
+      // 短いテキスト（安全上限以下）
+      const shortText = "こんにちは世界";
+
+      const html = `<p>${shortText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 1つのチャンクのまま
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].cleanedText).toBe(shortText);
+    });
+
+    it("should handle mixed Japanese and English text", () => {
+      // 日英混合の長いテキスト
+      const mixedText = (
+        "日本語テキスト. English text. " + "あ".repeat(200)
+      ).repeat(10);
+
+      const html = `<p>${mixedText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should preserve delimiter priority (。 > 、 > .)", () => {
+      // 句点、読点、ピリオドを含むテキスト
+      // 約5000バイト超えになるようにして、句点で分割されることを確認
+      const text =
+        "あ".repeat(800) + "。" + "い".repeat(800) + "、" + "う".repeat(800);
+
+      const html = `<p>${text}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 分割されているはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 最初のチャンクは句点で終わるはず（優先度が高いため）
+      if (paragraphs.length >= 2) {
+        expect(paragraphs[0].cleanedText.endsWith("。")).toBe(true);
+      }
+    });
+  });
+
+  describe("resizeChunksIfNeeded edge cases", () => {
+    it("should handle empty paragraphs array", () => {
+      const result = resizeChunksIfNeeded([]);
+      expect(result).toEqual([]);
+    });
+
+    it("should handle paragraphs already within safe limits", () => {
+      const input = [
+        { id: "old-1", type: "p", originalText: "Hello", cleanedText: "Hello" },
+        { id: "old-2", type: "p", originalText: "World", cleanedText: "World" },
+      ];
+      const result = resizeChunksIfNeeded(input);
+      expect(result.length).toBe(2);
+      expect(result[0]).toEqual({
+        ...input[0],
+        id: "para-0",
+        isSplitChunk: false,
+      });
+      expect(result[1]).toEqual({
+        ...input[1],
+        id: "para-1",
+        isSplitChunk: false,
+      });
+    });
+  });
 });

--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -1,7 +1,6 @@
 import {
     parseHTMLToParagraphs,
-    // 内部関数をテスト用にエクスポートする必要があるため、
-    // テストファイルを別の形式で作成
+    resizeChunksIfNeeded,
 } from '../paragraphParser';
 
 /**
@@ -154,6 +153,23 @@ describe('paragraphParser', () => {
             // 1つのチャンクのまま
             expect(paragraphs.length).toBe(1);
             expect(paragraphs[0].cleanedText).toBe(shortText);
+        });
+
+        it('should split oversized paragraphs when resizeChunksIfNeeded is called directly', () => {
+            const oversized = 'あ'.repeat(1700); // 約5100バイト
+            const resized = resizeChunksIfNeeded([
+                {
+                    id: '0',
+                    type: 'p',
+                    originalText: oversized,
+                    cleanedText: oversized,
+                },
+            ]);
+
+            expect(resized.length).toBeGreaterThan(1);
+            for (const chunk of resized) {
+                expect(Buffer.byteLength(chunk.cleanedText, 'utf-8')).toBeLessThanOrEqual(4800);
+            }
         });
 
         it('should handle mixed Japanese and English text', () => {

--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -1,234 +1,190 @@
 import {
-  parseHTMLToParagraphs,
-  resizeChunksIfNeeded,
-  // 内部関数をテスト用にエクスポートする必要があるため、
-  // テストファイルを別の形式で作成
-} from "../paragraphParser";
+    parseHTMLToParagraphs,
+    // 内部関数をテスト用にエクスポートする必要があるため、
+    // テストファイルを別の形式で作成
+} from '../paragraphParser';
 
 /**
  * paragraphParser のチャンクリサイズ機能のテスト
  */
-describe("paragraphParser", () => {
-  describe("parseHTMLToParagraphs", () => {
-    it("should parse simple HTML to paragraphs", () => {
-      const html = "<p>こんにちは</p><p>世界</p>";
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBeGreaterThan(0);
-    });
+describe('paragraphParser', () => {
+    describe('parseHTMLToParagraphs', () => {
+        it('should parse simple HTML to paragraphs', () => {
+            const html = '<p>こんにちは</p><p>世界</p>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBeGreaterThan(0);
+        });
 
-    it("should handle empty HTML", () => {
-      const result = parseHTMLToParagraphs("");
-      expect(result.paragraphs).toEqual([]);
-    });
+        it('should handle empty HTML', () => {
+            const result = parseHTMLToParagraphs('');
+            expect(result.paragraphs).toEqual([]);
+        });
 
-    it("should not duplicate content from p tags inside blockquotes", () => {
-      const html =
-        "<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>";
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBe(2);
-      expect(paragraphs[0].type).toBe("blockquote");
-      expect(paragraphs[0].originalText).toBe("This is a quote.");
-      expect(paragraphs[1].type).toBe("p");
-      expect(paragraphs[1].originalText).toBe("This is a paragraph.");
-    });
+        it('should not duplicate content from p tags inside blockquotes', () => {
+            const html = '<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBe(2);
+            expect(paragraphs[0].type).toBe('blockquote');
+            expect(paragraphs[0].originalText).toBe('This is a quote.');
+            expect(paragraphs[1].type).toBe('p');
+            expect(paragraphs[1].originalText).toBe('This is a paragraph.');
+        });
 
-    it("should handle nested blockquote with multiple p tags", () => {
-      const html =
-        "<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>";
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
-      expect(paragraphs.length).toBe(1);
-      expect(paragraphs[0].type).toBe("blockquote");
-      expect(paragraphs[0].originalText).toContain("Quote line 1");
-      expect(paragraphs[0].originalText).toContain("Quote line 2");
-    });
+        it('should handle nested blockquote with multiple p tags', () => {
+            const html = '<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
+            expect(paragraphs.length).toBe(1);
+            expect(paragraphs[0].type).toBe('blockquote');
+            expect(paragraphs[0].originalText).toContain('Quote line 1');
+            expect(paragraphs[0].originalText).toContain('Quote line 2');
+        });
 
-    it("should extract code blocks (pre elements)", () => {
-      const html =
-        '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBe(3);
-      expect(paragraphs[0].originalText).toBe("コード例：");
-      expect(paragraphs[1].type).toBe("pre");
-      expect(paragraphs[1].originalText).toContain("function hello()");
-      expect(paragraphs[2].originalText).toBe("以上です。");
-    });
+        it('should extract code blocks (pre elements)', () => {
+            const html = '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBe(3);
+            expect(paragraphs[0].originalText).toBe('コード例：');
+            expect(paragraphs[1].type).toBe('pre');
+            expect(paragraphs[1].originalText).toContain('function hello()');
+            expect(paragraphs[2].originalText).toBe('以上です。');
+        });
 
-    it("コードブロックを含む日本語記事でjaと判定されること", () => {
-      const html = `
+        it('コードブロックを含む日本語記事でjaと判定されること', () => {
+            const html = `
                 <p>これはJavaScriptの解説です。</p>
                 <pre><code>function test() { return 1; }</code></pre>
                 <p>以上です。</p>
             `;
-      const result = parseHTMLToParagraphs(html);
-      expect(result.detectedLanguage).toBe("ja");
-    });
+            const result = parseHTMLToParagraphs(html);
+            expect(result.detectedLanguage).toBe('ja');
+        });
 
-    it("コードブロックのみでも誤判定しないこと", () => {
-      const html = `
+        it('コードブロックのみでも誤判定しないこと', () => {
+            const html = `
                 <p>コード例：</p>
                 <pre><code>const a = 1; const b = 2; const c = a + b;</code></pre>
             `;
-      const result = parseHTMLToParagraphs(html);
-      expect(result.detectedLanguage).toBe("ja");
+            const result = parseHTMLToParagraphs(html);
+            expect(result.detectedLanguage).toBe('ja');
+        });
+
+        it('should extract table cells (td/th elements)', () => {
+            const html = '<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBeGreaterThanOrEqual(4);
+            const texts = paragraphs.map(p => p.originalText);
+            expect(texts).toContain('項目');
+            expect(texts).toContain('値');
+            expect(texts).toContain('名前');
+            expect(texts).toContain('テスト');
+        });
+
+        it('should extract figcaption', () => {
+            const html = '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBe(1);
+            expect(paragraphs[0].type).toBe('figcaption');
+            expect(paragraphs[0].originalText).toBe('図1: テスト画像');
+        });
+
+        it('should fallback to body text when no block elements found', () => {
+            const html = '<div>直接のテキスト内容</div>';
+            const { paragraphs } = parseHTMLToParagraphs(html);
+            expect(paragraphs.length).toBeGreaterThanOrEqual(1);
+            expect(paragraphs.some(p => p.originalText.includes('直接のテキスト内容'))).toBe(true);
+        });
     });
 
-    it("should extract table cells (td/th elements)", () => {
-      const html =
-        "<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>";
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBeGreaterThanOrEqual(4);
-      const texts = paragraphs.map((p) => p.originalText);
-      expect(texts).toContain("項目");
-      expect(texts).toContain("値");
-      expect(texts).toContain("名前");
-      expect(texts).toContain("テスト");
+    describe('chunk resizing', () => {
+        it('should split text exceeding 5000 bytes at punctuation', () => {
+            // 日本語の「あ」は3バイト、1667文字で約5000バイト
+            // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
+            const longJapaneseText = 'あ'.repeat(1700); // 約5100バイト
+            const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
+
+            const html = `<p>${longTextWithPunctuation}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // リサイズされて複数のチャンクに分割されるはず
+            expect(paragraphs.length).toBeGreaterThan(1);
+
+            // 各チャンクが安全サイズ内であることを確認
+            for (const chunk of paragraphs) {
+                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
+                expect(byteSize).toBeLessThanOrEqual(4800);
+            }
+        });
+
+        it('should split text by commas when no period is available', () => {
+            // 句点なしで読点ありのテキスト
+            const longText = 'あ'.repeat(500) + '、' + 'い'.repeat(500) + '、' + 'う'.repeat(500) + '、' + 'え'.repeat(500);
+
+            const html = `<p>${longText}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // 複数のチャンクに分割されるはず
+            expect(paragraphs.length).toBeGreaterThan(1);
+        });
+
+        it('should force split text without any delimiters', () => {
+            // 区切り文字なしの長いテキスト（日本語のみ）
+            const longTextNoDelimiter = 'あ'.repeat(2000); // 約6000バイト
+
+            const html = `<p>${longTextNoDelimiter}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // フォーススプリットで分割されるはず
+            expect(paragraphs.length).toBeGreaterThan(1);
+
+            // 各チャンクが安全サイズ内であることを確認
+            for (const chunk of paragraphs) {
+                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
+                expect(byteSize).toBeLessThanOrEqual(4800);
+            }
+        });
+
+        it('should not split text under 4800 bytes', () => {
+            // 短いテキスト（安全上限以下）
+            const shortText = 'こんにちは世界';
+
+            const html = `<p>${shortText}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // 1つのチャンクのまま
+            expect(paragraphs.length).toBe(1);
+            expect(paragraphs[0].cleanedText).toBe(shortText);
+        });
+
+        it('should handle mixed Japanese and English text', () => {
+            // 日英混合の長いテキスト
+            const mixedText = ('日本語テキスト. English text. ' + 'あ'.repeat(200)).repeat(10);
+
+            const html = `<p>${mixedText}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // 各チャンクが安全サイズ内であることを確認
+            for (const chunk of paragraphs) {
+                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
+                expect(byteSize).toBeLessThanOrEqual(4800);
+            }
+        });
+
+        it('should preserve delimiter priority (。 > 、 > .)', () => {
+            // 句点、読点、ピリオドを含むテキスト
+            // 約5000バイト超えになるようにして、句点で分割されることを確認
+            const text = 'あ'.repeat(800) + '。' + 'い'.repeat(800) + '、' + 'う'.repeat(800);
+
+            const html = `<p>${text}</p>`;
+            const { paragraphs } = parseHTMLToParagraphs(html);
+
+            // 分割されているはず
+            expect(paragraphs.length).toBeGreaterThan(1);
+
+            // 最初のチャンクは句点で終わるはず（優先度が高いため）
+            if (paragraphs.length >= 2) {
+                expect(paragraphs[0].cleanedText.endsWith('。')).toBe(true);
+            }
+        });
     });
-
-    it("should extract figcaption", () => {
-      const html =
-        '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBe(1);
-      expect(paragraphs[0].type).toBe("figcaption");
-      expect(paragraphs[0].originalText).toBe("図1: テスト画像");
-    });
-
-    it("should fallback to body text when no block elements found", () => {
-      const html = "<div>直接のテキスト内容</div>";
-      const { paragraphs } = parseHTMLToParagraphs(html);
-      expect(paragraphs.length).toBeGreaterThanOrEqual(1);
-      expect(
-        paragraphs.some((p) => p.originalText.includes("直接のテキスト内容")),
-      ).toBe(true);
-    });
-  });
-
-  describe("chunk resizing", () => {
-    it("should split text exceeding 5000 bytes at punctuation", () => {
-      // 日本語の「あ」は3バイト、1667文字で約5000バイト
-      // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
-      const longJapaneseText = "あ".repeat(1700); // 約5100バイト
-      const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
-
-      const html = `<p>${longTextWithPunctuation}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // リサイズされて複数のチャンクに分割されるはず
-      expect(paragraphs.length).toBeGreaterThan(1);
-
-      // 各チャンクが安全サイズ内であることを確認
-      for (const chunk of paragraphs) {
-        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
-        expect(byteSize).toBeLessThanOrEqual(4800);
-      }
-    });
-
-    it("should split text by commas when no period is available", () => {
-      // 句点なしで読点ありのテキスト
-      const longText =
-        "あ".repeat(500) +
-        "、" +
-        "い".repeat(500) +
-        "、" +
-        "う".repeat(500) +
-        "、" +
-        "え".repeat(500);
-
-      const html = `<p>${longText}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // 複数のチャンクに分割されるはず
-      expect(paragraphs.length).toBeGreaterThan(1);
-    });
-
-    it("should force split text without any delimiters", () => {
-      // 区切り文字なしの長いテキスト（日本語のみ）
-      const longTextNoDelimiter = "あ".repeat(2000); // 約6000バイト
-
-      const html = `<p>${longTextNoDelimiter}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // フォーススプリットで分割されるはず
-      expect(paragraphs.length).toBeGreaterThan(1);
-
-      // 各チャンクが安全サイズ内であることを確認
-      for (const chunk of paragraphs) {
-        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
-        expect(byteSize).toBeLessThanOrEqual(4800);
-      }
-    });
-
-    it("should not split text under 4800 bytes", () => {
-      // 短いテキスト（安全上限以下）
-      const shortText = "こんにちは世界";
-
-      const html = `<p>${shortText}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // 1つのチャンクのまま
-      expect(paragraphs.length).toBe(1);
-      expect(paragraphs[0].cleanedText).toBe(shortText);
-    });
-
-    it("should handle mixed Japanese and English text", () => {
-      // 日英混合の長いテキスト
-      const mixedText = (
-        "日本語テキスト. English text. " + "あ".repeat(200)
-      ).repeat(10);
-
-      const html = `<p>${mixedText}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // 各チャンクが安全サイズ内であることを確認
-      for (const chunk of paragraphs) {
-        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
-        expect(byteSize).toBeLessThanOrEqual(4800);
-      }
-    });
-
-    it("should preserve delimiter priority (。 > 、 > .)", () => {
-      // 句点、読点、ピリオドを含むテキスト
-      // 約5000バイト超えになるようにして、句点で分割されることを確認
-      const text =
-        "あ".repeat(800) + "。" + "い".repeat(800) + "、" + "う".repeat(800);
-
-      const html = `<p>${text}</p>`;
-      const { paragraphs } = parseHTMLToParagraphs(html);
-
-      // 分割されているはず
-      expect(paragraphs.length).toBeGreaterThan(1);
-
-      // 最初のチャンクは句点で終わるはず（優先度が高いため）
-      if (paragraphs.length >= 2) {
-        expect(paragraphs[0].cleanedText.endsWith("。")).toBe(true);
-      }
-    });
-  });
-
-  describe("resizeChunksIfNeeded edge cases", () => {
-    it("should handle empty paragraphs array", () => {
-      const result = resizeChunksIfNeeded([]);
-      expect(result).toEqual([]);
-    });
-
-    it("should handle paragraphs already within safe limits", () => {
-      const input = [
-        { id: "old-1", type: "p", originalText: "Hello", cleanedText: "Hello" },
-        { id: "old-2", type: "p", originalText: "World", cleanedText: "World" },
-      ];
-      const result = resizeChunksIfNeeded(input);
-      expect(result.length).toBe(2);
-      expect(result[0]).toEqual({
-        ...input[0],
-        id: "para-0",
-        isSplitChunk: false,
-      });
-      expect(result[1]).toEqual({
-        ...input[1],
-        id: "para-1",
-        isSplitChunk: false,
-      });
-    });
-  });
 });

--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -1,206 +1,234 @@
 import {
-    parseHTMLToParagraphs,
-    resizeChunksIfNeeded,
-} from '../paragraphParser';
+  parseHTMLToParagraphs,
+  resizeChunksIfNeeded,
+  // 内部関数をテスト用にエクスポートする必要があるため、
+  // テストファイルを別の形式で作成
+} from "../paragraphParser";
 
 /**
  * paragraphParser のチャンクリサイズ機能のテスト
  */
-describe('paragraphParser', () => {
-    describe('parseHTMLToParagraphs', () => {
-        it('should parse simple HTML to paragraphs', () => {
-            const html = '<p>こんにちは</p><p>世界</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThan(0);
-        });
+describe("paragraphParser", () => {
+  describe("parseHTMLToParagraphs", () => {
+    it("should parse simple HTML to paragraphs", () => {
+      const html = "<p>こんにちは</p><p>世界</p>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThan(0);
+    });
 
-        it('should handle empty HTML', () => {
-            const result = parseHTMLToParagraphs('');
-            expect(result.paragraphs).toEqual([]);
-        });
+    it("should handle empty HTML", () => {
+      const result = parseHTMLToParagraphs("");
+      expect(result.paragraphs).toEqual([]);
+    });
 
-        it('should not duplicate content from p tags inside blockquotes', () => {
-            const html = '<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(2);
-            expect(paragraphs[0].type).toBe('blockquote');
-            expect(paragraphs[0].originalText).toBe('This is a quote.');
-            expect(paragraphs[1].type).toBe('p');
-            expect(paragraphs[1].originalText).toBe('This is a paragraph.');
-        });
+    it("should not duplicate content from p tags inside blockquotes", () => {
+      const html =
+        "<blockquote><p>This is a quote.</p></blockquote><p>This is a paragraph.</p>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(2);
+      expect(paragraphs[0].type).toBe("blockquote");
+      expect(paragraphs[0].originalText).toBe("This is a quote.");
+      expect(paragraphs[1].type).toBe("p");
+      expect(paragraphs[1].originalText).toBe("This is a paragraph.");
+    });
 
-        it('should handle nested blockquote with multiple p tags', () => {
-            const html = '<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].type).toBe('blockquote');
-            expect(paragraphs[0].originalText).toContain('Quote line 1');
-            expect(paragraphs[0].originalText).toContain('Quote line 2');
-        });
+    it("should handle nested blockquote with multiple p tags", () => {
+      const html =
+        "<blockquote><p>Quote line 1</p><p>Quote line 2</p></blockquote>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      // blockquote全体が1つの段落として抽出される（内部のpは個別に抽出されない）
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].type).toBe("blockquote");
+      expect(paragraphs[0].originalText).toContain("Quote line 1");
+      expect(paragraphs[0].originalText).toContain("Quote line 2");
+    });
 
-        it('should extract code blocks (pre elements)', () => {
-            const html = '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(3);
-            expect(paragraphs[0].originalText).toBe('コード例：');
-            expect(paragraphs[1].type).toBe('pre');
-            expect(paragraphs[1].originalText).toContain('function hello()');
-            expect(paragraphs[2].originalText).toBe('以上です。');
-        });
+    it("should extract code blocks (pre elements)", () => {
+      const html =
+        '<p>コード例：</p><pre><code>function hello() {\n  console.log("Hello");\n}</code></pre><p>以上です。</p>';
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(3);
+      expect(paragraphs[0].originalText).toBe("コード例：");
+      expect(paragraphs[1].type).toBe("pre");
+      expect(paragraphs[1].originalText).toContain("function hello()");
+      expect(paragraphs[2].originalText).toBe("以上です。");
+    });
 
-        it('コードブロックを含む日本語記事でjaと判定されること', () => {
-            const html = `
+    it("コードブロックを含む日本語記事でjaと判定されること", () => {
+      const html = `
                 <p>これはJavaScriptの解説です。</p>
                 <pre><code>function test() { return 1; }</code></pre>
                 <p>以上です。</p>
             `;
-            const result = parseHTMLToParagraphs(html);
-            expect(result.detectedLanguage).toBe('ja');
-        });
+      const result = parseHTMLToParagraphs(html);
+      expect(result.detectedLanguage).toBe("ja");
+    });
 
-        it('コードブロックのみでも誤判定しないこと', () => {
-            const html = `
+    it("コードブロックのみでも誤判定しないこと", () => {
+      const html = `
                 <p>コード例：</p>
                 <pre><code>const a = 1; const b = 2; const c = a + b;</code></pre>
             `;
-            const result = parseHTMLToParagraphs(html);
-            expect(result.detectedLanguage).toBe('ja');
-        });
-
-        it('should extract table cells (td/th elements)', () => {
-            const html = '<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThanOrEqual(4);
-            const texts = paragraphs.map(p => p.originalText);
-            expect(texts).toContain('項目');
-            expect(texts).toContain('値');
-            expect(texts).toContain('名前');
-            expect(texts).toContain('テスト');
-        });
-
-        it('should extract figcaption', () => {
-            const html = '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].type).toBe('figcaption');
-            expect(paragraphs[0].originalText).toBe('図1: テスト画像');
-        });
-
-        it('should fallback to body text when no block elements found', () => {
-            const html = '<div>直接のテキスト内容</div>';
-            const { paragraphs } = parseHTMLToParagraphs(html);
-            expect(paragraphs.length).toBeGreaterThanOrEqual(1);
-            expect(paragraphs.some(p => p.originalText.includes('直接のテキスト内容'))).toBe(true);
-        });
+      const result = parseHTMLToParagraphs(html);
+      expect(result.detectedLanguage).toBe("ja");
     });
 
-    describe('chunk resizing', () => {
-        it('should split text exceeding 5000 bytes at punctuation', () => {
-            // 日本語の「あ」は3バイト、1667文字で約5000バイト
-            // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
-            const longJapaneseText = 'あ'.repeat(1700); // 約5100バイト
-            const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
-
-            const html = `<p>${longTextWithPunctuation}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // リサイズされて複数のチャンクに分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should split text by commas when no period is available', () => {
-            // 句点なしで読点ありのテキスト
-            const longText = 'あ'.repeat(500) + '、' + 'い'.repeat(500) + '、' + 'う'.repeat(500) + '、' + 'え'.repeat(500);
-
-            const html = `<p>${longText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 複数のチャンクに分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-        });
-
-        it('should force split text without any delimiters', () => {
-            // 区切り文字なしの長いテキスト（日本語のみ）
-            const longTextNoDelimiter = 'あ'.repeat(2000); // 約6000バイト
-
-            const html = `<p>${longTextNoDelimiter}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // フォーススプリットで分割されるはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should not split text under 4800 bytes', () => {
-            // 短いテキスト（安全上限以下）
-            const shortText = 'こんにちは世界';
-
-            const html = `<p>${shortText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 1つのチャンクのまま
-            expect(paragraphs.length).toBe(1);
-            expect(paragraphs[0].cleanedText).toBe(shortText);
-        });
-
-        it('should split oversized paragraphs when resizeChunksIfNeeded is called directly', () => {
-            const oversized = 'あ'.repeat(1700); // 約5100バイト
-            const resized = resizeChunksIfNeeded([
-                {
-                    id: '0',
-                    type: 'p',
-                    originalText: oversized,
-                    cleanedText: oversized,
-                },
-            ]);
-
-            expect(resized.length).toBeGreaterThan(1);
-            for (const chunk of resized) {
-                expect(Buffer.byteLength(chunk.cleanedText, 'utf-8')).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should handle mixed Japanese and English text', () => {
-            // 日英混合の長いテキスト
-            const mixedText = ('日本語テキスト. English text. ' + 'あ'.repeat(200)).repeat(10);
-
-            const html = `<p>${mixedText}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 各チャンクが安全サイズ内であることを確認
-            for (const chunk of paragraphs) {
-                const byteSize = Buffer.byteLength(chunk.cleanedText, 'utf-8');
-                expect(byteSize).toBeLessThanOrEqual(4800);
-            }
-        });
-
-        it('should preserve delimiter priority (。 > 、 > .)', () => {
-            // 句点、読点、ピリオドを含むテキスト
-            // 約5000バイト超えになるようにして、句点で分割されることを確認
-            const text = 'あ'.repeat(800) + '。' + 'い'.repeat(800) + '、' + 'う'.repeat(800);
-
-            const html = `<p>${text}</p>`;
-            const { paragraphs } = parseHTMLToParagraphs(html);
-
-            // 分割されているはず
-            expect(paragraphs.length).toBeGreaterThan(1);
-
-            // 最初のチャンクは句点で終わるはず（優先度が高いため）
-            if (paragraphs.length >= 2) {
-                expect(paragraphs[0].cleanedText.endsWith('。')).toBe(true);
-            }
-        });
+    it("should extract table cells (td/th elements)", () => {
+      const html =
+        "<table><tr><th>項目</th><th>値</th></tr><tr><td>名前</td><td>テスト</td></tr></table>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThanOrEqual(4);
+      const texts = paragraphs.map((p) => p.originalText);
+      expect(texts).toContain("項目");
+      expect(texts).toContain("値");
+      expect(texts).toContain("名前");
+      expect(texts).toContain("テスト");
     });
+
+    it("should extract figcaption", () => {
+      const html =
+        '<figure><img src="test.png" /><figcaption>図1: テスト画像</figcaption></figure>';
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].type).toBe("figcaption");
+      expect(paragraphs[0].originalText).toBe("図1: テスト画像");
+    });
+
+    it("should fallback to body text when no block elements found", () => {
+      const html = "<div>直接のテキスト内容</div>";
+      const { paragraphs } = parseHTMLToParagraphs(html);
+      expect(paragraphs.length).toBeGreaterThanOrEqual(1);
+      expect(
+        paragraphs.some((p) => p.originalText.includes("直接のテキスト内容")),
+      ).toBe(true);
+    });
+  });
+
+  describe("chunk resizing", () => {
+    it("should split text exceeding 5000 bytes at punctuation", () => {
+      // 日本語の「あ」は3バイト、1667文字で約5000バイト
+      // 安全上限は4800バイトなので、1600文字を超える場合はリサイズされる
+      const longJapaneseText = "あ".repeat(1700); // 約5100バイト
+      const longTextWithPunctuation = `${longJapaneseText.slice(0, 800)}。${longJapaneseText.slice(801)}`;
+
+      const html = `<p>${longTextWithPunctuation}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // リサイズされて複数のチャンクに分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should split text by commas when no period is available", () => {
+      // 句点なしで読点ありのテキスト
+      const longText =
+        "あ".repeat(500) +
+        "、" +
+        "い".repeat(500) +
+        "、" +
+        "う".repeat(500) +
+        "、" +
+        "え".repeat(500);
+
+      const html = `<p>${longText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 複数のチャンクに分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+    });
+
+    it("should force split text without any delimiters", () => {
+      // 区切り文字なしの長いテキスト（日本語のみ）
+      const longTextNoDelimiter = "あ".repeat(2000); // 約6000バイト
+
+      const html = `<p>${longTextNoDelimiter}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // フォーススプリットで分割されるはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should not split text under 4800 bytes", () => {
+      // 短いテキスト（安全上限以下）
+      const shortText = "こんにちは世界";
+
+      const html = `<p>${shortText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 1つのチャンクのまま
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0].cleanedText).toBe(shortText);
+    });
+
+    it("should handle mixed Japanese and English text", () => {
+      // 日英混合の長いテキスト
+      const mixedText = (
+        "日本語テキスト. English text. " + "あ".repeat(200)
+      ).repeat(10);
+
+      const html = `<p>${mixedText}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 各チャンクが安全サイズ内であることを確認
+      for (const chunk of paragraphs) {
+        const byteSize = Buffer.byteLength(chunk.cleanedText, "utf-8");
+        expect(byteSize).toBeLessThanOrEqual(4800);
+      }
+    });
+
+    it("should preserve delimiter priority (。 > 、 > .)", () => {
+      // 句点、読点、ピリオドを含むテキスト
+      // 約5000バイト超えになるようにして、句点で分割されることを確認
+      const text =
+        "あ".repeat(800) + "。" + "い".repeat(800) + "、" + "う".repeat(800);
+
+      const html = `<p>${text}</p>`;
+      const { paragraphs } = parseHTMLToParagraphs(html);
+
+      // 分割されているはず
+      expect(paragraphs.length).toBeGreaterThan(1);
+
+      // 最初のチャンクは句点で終わるはず（優先度が高いため）
+      if (paragraphs.length >= 2) {
+        expect(paragraphs[0].cleanedText.endsWith("。")).toBe(true);
+      }
+    });
+  });
+
+  describe("resizeChunksIfNeeded edge cases", () => {
+    it("should handle empty paragraphs array", () => {
+      const result = resizeChunksIfNeeded([]);
+      expect(result).toEqual([]);
+    });
+
+    it("should handle paragraphs already within safe limits", () => {
+      const input = [
+        { id: "old-1", type: "p", originalText: "Hello", cleanedText: "Hello" },
+        { id: "old-2", type: "p", originalText: "World", cleanedText: "World" },
+      ];
+      const result = resizeChunksIfNeeded(input);
+      expect(result.length).toBe(2);
+      expect(result[0]).toEqual({
+        ...input[0],
+        id: "para-0",
+        isSplitChunk: false,
+      });
+      expect(result[1]).toEqual({
+        ...input[1],
+        id: "para-1",
+        isSplitChunk: false,
+      });
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `resizeChunksIfNeeded` in `paragraphParser.ts`.
📊 **Coverage:** Covered edge cases such as an empty array and inputs that are already within safe size limits (verifying id reassignment).
✨ **Result:** Improved test coverage and provided a safety net for paragraph chunk resizing logic.

---
*PR created automatically by Jules for task [8598099598798902234](https://jules.google.com/task/8598099598798902234) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`resizeChunksIfNeeded` を直接呼び出すエッジケーステスト（空配列、安全サイズ内のチャンクによるID再採番確認）を新規追加し、既存テストのインデントをスペース2に統一しています。追加されたテスト自体は実装と一致しており正しいですが、4800バイト超の入力を `resizeChunksIfNeeded` に直接渡すテストケースがなく（現在は `parseHTMLToParagraphs` 経由でのみ間接的にカバー）、直接ユニットテストとしてはやや不完全です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- このPRはマージしても安全です。テストファイルのみの変更で、プロダクションコードへの影響はありません。
- 新規追加された2つのテストケースは実装と正確に一致しており、ロジックエラーはありません。唯一のフィードバックは超過サイズ入力の直接テスト追加という P2 の提案のみで、マージをブロックする問題はありません。
- 特になし。変更はテストファイル1件のみです。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts | 空配列と安全サイズ内チャンクのエッジケースを `resizeChunksIfNeeded` 直接呼び出しでテスト追加。既存テストのインデントをスペース2に統一。新テストのロジックに誤りはないが、超過サイズ入力の直接テストが欠けている（既存の間接テストでは補完されている）。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resizeChunksIfNeeded(paragraphs)"] --> B{paragraphs が空?}
    B -- Yes --> C["[] を返す ✅ テスト済み"]
    B -- No --> D{各 para を処理}
    D --> E{cleanedText が\n4800バイト以下?}
    E -- Yes --> F["id = para-N, isSplitChunk = false\nで追加 ✅ テスト済み"]
    E -- No --> G["splitTextByByteSize()\nで分割"]
    G --> H["各チャンクを\nisSplitChunk = true で追加\n⚠️ 直接テスト未実装"]
    F --> I["結果を返す"]
    H --> I
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
Line: 209-233

Comment:
**`resizeChunksIfNeeded` の分割ケースを直接テストしていない**

新しい `describe` ブロックは空配列と安全サイズ内のケースをカバーしていますが、4800バイトを超えるチャンクを直接 `resizeChunksIfNeeded` に渡した場合の分割動作が未テストです。現状ではその挙動が `parseHTMLToParagraphs` 経由でのみ検証されており、関数の直接テストとして不完全です。`isSplitChunk: true` になること・元のIDが上書きされること・各チャンクが制限内に収まることを直接検証するケースを追加すると、リグレッション安全網として強固になります。

```suggestion
  describe("resizeChunksIfNeeded edge cases", () => {
    it("should handle empty paragraphs array", () => {
      const result = resizeChunksIfNeeded([]);
      expect(result).toEqual([]);
    });

    it("should handle paragraphs already within safe limits", () => {
      const input = [
        { id: "old-1", type: "p", originalText: "Hello", cleanedText: "Hello" },
        { id: "old-2", type: "p", originalText: "World", cleanedText: "World" },
      ];
      const result = resizeChunksIfNeeded(input);
      expect(result.length).toBe(2);
      expect(result[0]).toEqual({
        ...input[0],
        id: "para-0",
        isSplitChunk: false,
      });
      expect(result[1]).toEqual({
        ...input[1],
        id: "para-1",
        isSplitChunk: false,
      });
    });

    it("should split oversized paragraphs and set isSplitChunk: true", () => {
      const largeText = "あ".repeat(2000); // 約6000バイト、4800バイト上限を超える
      const input = [
        { id: "old-1", type: "p", originalText: largeText, cleanedText: largeText },
      ];
      const result = resizeChunksIfNeeded(input);
      expect(result.length).toBeGreaterThan(1);
      for (const chunk of result) {
        expect(Buffer.byteLength(chunk.cleanedText, "utf-8")).toBeLessThanOrEqual(4800);
        expect(chunk.isSplitChunk).toBe(true);
      }
      // IDが通し番号で採番されていること
      result.forEach((chunk, i) => {
        expect(chunk.id).toBe(`para-${i}`);
      });
    });
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for resizeChunksIfNeeded ed..."](https://github.com/hiroki-org/audicle/commit/00d2411b5c15d4c7e1d0abbbb8249aaf18d6925f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308425)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->