### PR TITLE
🧹 Remove dead comments in urlBuilder.test.ts

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/urlBuilder.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/urlBuilder.test.ts
@@ -36,10 +36,6 @@ describe('createReaderUrl', () => {
   });
 
   it('should not include index if playlistId is missing', () => {
-    // Note: The current implementation doesn't explicitly prevent index without playlist,
-    // but the logic shows nested if:
-    // if (params.playlistId) { ... if (params.playlistIndex !== undefined) ... }
-    // So if playlistId is missing, index should be ignored even if provided.
     const params: ReaderUrlParams = {
       playlistIndex: 5,
     };


### PR DESCRIPTION
## 🎯 What

Removed a block of commented-out notes in `packages/web-app-vercel/lib/__tests__/urlBuilder.test.ts` within the `'should not include index if playlistId is missing'` test case.

## 💡 Why

The commented-out code was serving as a multi-line explanatory note regarding implementation details that are already obvious from the logic and the test description itself. Removing such "dead code/comments" improves readability and maintainability by keeping the test concise and focused purely on the setup and assertions. 

## ✅ Verification

- Verified the exact lines were deleted without altering the test logic.
- Ran the test suite specifically for `urlBuilder.test.ts`, and all 8 tests passed.
- No other functionality or behavior is affected as the changes are strictly within a test block and remove non-executable notes.
- Formatting and type checking passed.

## ✨ Result

A cleaner and more readable test case for `createReaderUrl`.

---
*PR created automatically by Jules for task [4654902605740344839](https://jules.google.com/task/4654902605740344839) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`urlBuilder.test.ts` の `'should not include index if playlistId is missing'` テストケース内にあったコメントアウトされた実装説明4行を削除するクリーンアップPRです。テストロジック・アサーション・動作への影響は一切ありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- コメント削除のみの変更であり、マージに問題はありません。
- テストロジックやアサーションへの変更は一切なく、コメントアウトされた説明文の削除のみです。全8テストが引き続きパスしており、機能への影響はありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/__tests__/urlBuilder.test.ts | コメントアウトされた説明文4行を削除したのみ。テストロジックへの影響はなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createReaderUrl params] --> B{articleId?}
    B -- あり --> C[id を追加]
    B -- なし --> D{articleUrl?}
    C --> D
    D -- あり --> E[url を追加]
    D -- なし --> F{playlistId?}
    E --> F
    F -- あり --> G[playlist を追加]
    G --> H{playlistIndex?}
    H -- あり --> I[index を追加]
    H -- なし --> J{autoplay?}
    I --> J
    F -- なし --> J
    J -- あり --> K[autoplay を追加]
    J -- なし --> L[URLを返す]
    K --> L
```

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove dead comments in urlBuilder.te..."](https://github.com/hiroki-org/audicle/commit/77cd6a11edb56ef011f21fde3faf595cb01ec9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308450)</sub>

<!-- /greptile_comment -->