### PR TITLE
🧪 Add test for error path in generateShuffledIndices

### DIFF
--- a/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
+++ b/packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx
@@ -369,6 +369,11 @@ describe("generateShuffledIndices", () => {
     expect(result).toEqual([]);
   });
 
+  test("handles negative length", () => {
+    const result = generateShuffledIndices(-5);
+    expect(result).toEqual([]);
+  });
+
   test("handles single element", () => {
     const result = generateShuffledIndices(1, 0);
     expect(result).toEqual([0]);


### PR DESCRIPTION
🎯 **What:** The testing gap in `generateShuffledIndices` where it returns an empty array for `length < 0` was addressed.

📊 **Coverage:** The scenario where the length is negative (e.g., `-5`) is now tested.

✨ **Result:** The test coverage for the error path and edge cases in `generateShuffledIndices` has improved, ensuring proper handling of negative array lengths.

---
*PR created automatically by Jules for task [7361161102712930328](https://jules.google.com/task/7361161102712930328) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`generateShuffledIndices` に負の `length` を渡した際の動作を検証するテストを1件追加するPRです。実装では `Array.from({ length: -5 })` が空配列を返すため、`expect(result).toEqual([])` というアサーションは正しい挙動を捉えています。既存のエッジケーステスト群（`length = 0`、単一要素、範囲外 `currentIndex`）に自然な形で組み込まれており、コードの問題はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- テスト追加のみの変更であり、プロダクションコードへの影響はなく、安全にマージ可能です。
- 変更はテストファイル1件への1テストケース追加のみ。アサーションは実装の挙動と正しく対応しており、P0/P1 の問題は存在しない。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/contexts/__tests__/PlaylistPlaybackContext.test.tsx | `generateShuffledIndices` に負の長さ（例: `-5`）を渡した場合のテストケースを1件追加。実装の挙動（`Array.from({ length: -5 })` が `[]` を返す）と整合しており、アサーションも正しい。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateShuffledIndices(length, currentIndex?)"] --> B{length < 0?}
    B -- "Yes (e.g. -5)" --> C["Array.from({length: -5}) → []"]
    C --> D["return []"]
    B -- "No (length = 0)" --> E["Array.from({length: 0}) → []"]
    E --> D
    B -- "No (length > 0)" --> F["indices = [0, 1, ..., length-1]"]
    F --> G["Fisher-Yates シャッフル"]
    G --> H{currentIndex が有効範囲内?}
    H -- "Yes" --> I["currentIndex を先頭に移動"]
    I --> J["return shuffled indices"]
    H -- "No" --> J

    style C fill:#90EE90,stroke:#333
    style D fill:#90EE90,stroke:#333
```

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for error path in generateSh..."](https://github.com/hiroki-org/audicle/commit/bf6c678657597435a6526b9a457799e9218b444a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308874)</sub>

<!-- /greptile_comment -->