### PR TITLE
🧪 [testing improvement] Add validation coverage for validateUrl

### DIFF
--- a/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { GET, POST } from '../route'
-import { validateUrl } from '../../../lib/validation'
+import { validateUrl } from '@/lib/validation'
 
 // モックを定義
 jest.mock('@/lib/auth', () => ({
@@ -338,40 +338,40 @@ describe('Share Target Route Handlers', () => {
     })
 
     describe('validateUrl function', () => {
-        it('valid http URL returns true', () => {
+        it('http URL は true を返す', () => {
             expect(validateUrl('http://example.com')).toBe(true)
         })
 
-        it('valid https URL returns true', () => {
+        it('https URL は true を返す', () => {
             expect(validateUrl('https://example.com/path?query=1#hash')).toBe(true)
         })
 
-        it('invalid url format returns false', () => {
+        it('URL形式が不正な場合は false を返す', () => {
             expect(validateUrl('not-a-url')).toBe(false)
         })
 
-        it('javascript scheme returns false', () => {
+        it('javascript スキームは false を返す', () => {
             expect(validateUrl('javascript:alert(1)')).toBe(false)
         })
 
-        it('data scheme returns false', () => {
+        it('data スキームは false を返す', () => {
             expect(validateUrl('data:text/html,<h1>test</h1>')).toBe(false)
         })
 
-        it('ftp scheme returns false', () => {
+        it('ftp スキームは false を返す', () => {
             expect(validateUrl('ftp://example.com')).toBe(false)
         })
 
-        it('file scheme returns false', () => {
+        it('file スキームは false を返す', () => {
             expect(validateUrl('file:///etc/passwd')).toBe(false)
         })
 
-        it('empty string returns false', () => {
+        it('空文字は false を返す', () => {
             expect(validateUrl('')).toBe(false)
         })
 
         // new URL() automatically trims spaces, so this returns true, which is acceptable
-        it('URL with leading/trailing spaces returns true because new URL trims it', () => {
+        it('前後スペース付きURLは new URL の仕様により true を返す', () => {
             expect(validateUrl(' https://example.com ')).toBe(true)
         })
     })

--- a/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { GET, POST } from '../route'
+import { validateUrl } from '../../../lib/validation'
 
 // モックを定義
 jest.mock('@/lib/auth', () => ({
@@ -270,7 +271,7 @@ describe('Share Target Route Handlers', () => {
         })
     })
 
-    describe('URL validation', () => {
+    describe('URL validation during GET request', () => {
         it('http:// スキームは許可される', async () => {
             mockAuth.mockResolvedValue({
                 user: { id: 'test-user', email: 'test@example.com' },
@@ -333,6 +334,45 @@ describe('Share Target Route Handlers', () => {
 
             expect(response.status).toBe(307)
             expect(response.headers.get('Location')).toContain('/share-target/error')
+        })
+    })
+
+    describe('validateUrl function', () => {
+        it('valid http URL returns true', () => {
+            expect(validateUrl('http://example.com')).toBe(true)
+        })
+
+        it('valid https URL returns true', () => {
+            expect(validateUrl('https://example.com/path?query=1#hash')).toBe(true)
+        })
+
+        it('invalid url format returns false', () => {
+            expect(validateUrl('not-a-url')).toBe(false)
+        })
+
+        it('javascript scheme returns false', () => {
+            expect(validateUrl('javascript:alert(1)')).toBe(false)
+        })
+
+        it('data scheme returns false', () => {
+            expect(validateUrl('data:text/html,<h1>test</h1>')).toBe(false)
+        })
+
+        it('ftp scheme returns false', () => {
+            expect(validateUrl('ftp://example.com')).toBe(false)
+        })
+
+        it('file scheme returns false', () => {
+            expect(validateUrl('file:///etc/passwd')).toBe(false)
+        })
+
+        it('empty string returns false', () => {
+            expect(validateUrl('')).toBe(false)
+        })
+
+        // new URL() automatically trims spaces, so this returns true, which is acceptable
+        it('URL with leading/trailing spaces returns true because new URL trims it', () => {
+            expect(validateUrl(' https://example.com ')).toBe(true)
         })
     })
 })

--- a/packages/web-app-vercel/app/share-target/route.ts
+++ b/packages/web-app-vercel/app/share-target/route.ts
@@ -4,22 +4,7 @@ import { supabase } from '@/lib/supabase'
 import * as supabaseLocal from '@/lib/supabaseLocal'
 import { getOrCreateDefaultPlaylist } from '@/lib/playlist-utils'
 import type { Article } from '@/types/playlist'
-
-/**
- * 共有されたURLを検証する
- * @param url 検証対象のURL
- * @returns URLが有効な場合はtrue、無効な場合はfalse
- */
-function validateUrl(url: string): boolean {
-    try {
-        const parsedUrl = new URL(url)
-        // http/httpsスキームのみ許可（javascript:, data:などの危険なスキームを拒否）
-        const allowedProtocols = ['http:', 'https:']
-        return allowedProtocols.includes(parsedUrl.protocol)
-    } catch {
-        return false
-    }
-}
+import { validateUrl } from "@/lib/validation"
 
 /**
  * GET リクエスト: 後方互換性のため（既存のブックマークなど）

--- a/packages/web-app-vercel/app/share-target/route.ts
+++ b/packages/web-app-vercel/app/share-target/route.ts
@@ -4,7 +4,7 @@ import { supabase } from '@/lib/supabase'
 import * as supabaseLocal from '@/lib/supabaseLocal'
 import { getOrCreateDefaultPlaylist } from '@/lib/playlist-utils'
 import type { Article } from '@/types/playlist'
-import { validateUrl } from "@/lib/validation"
+import { validateUrl } from '@/lib/validation'
 
 /**
  * GET リクエスト: 後方互換性のため（既存のブックマークなど）

--- a/packages/web-app-vercel/lib/validation.ts
+++ b/packages/web-app-vercel/lib/validation.ts
@@ -1,0 +1,15 @@
+/**
+ * 共有されたURLを検証する
+ * @param url 検証対象のURL
+ * @returns URLが有効な場合はtrue、無効な場合はfalse
+ */
+export function validateUrl(url: string): boolean {
+    try {
+        const parsedUrl = new URL(url)
+        // http/httpsスキームのみ許可（javascript:, data:などの危険なスキームを拒否）
+        const allowedProtocols = ['http:', 'https:']
+        return allowedProtocols.includes(parsedUrl.protocol)
+    } catch {
+        return false
+    }
+}

--- a/packages/web-app-vercel/lib/validation.ts
+++ b/packages/web-app-vercel/lib/validation.ts
@@ -1,3 +1,5 @@
+const ALLOWED_PROTOCOLS = ['http:', 'https:'] as const
+
 /**
  * 共有されたURLを検証する
  * @param url 検証対象のURL
@@ -7,8 +9,7 @@ export function validateUrl(url: string): boolean {
     try {
         const parsedUrl = new URL(url)
         // http/httpsスキームのみ許可（javascript:, data:などの危険なスキームを拒否）
-        const allowedProtocols = ['http:', 'https:']
-        return allowedProtocols.includes(parsedUrl.protocol)
+        return ALLOWED_PROTOCOLS.includes(parsedUrl.protocol as (typeof ALLOWED_PROTOCOLS)[number])
     } catch {
         return false
     }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `validateUrl` function in `packages/web-app-vercel/app/share-target/route.ts` was not independently tested. Because it is a pure function, testing it directly makes it easier to catch edge cases without testing Next Request mocks. Additionally, extracting the function to `packages/web-app-vercel/lib/validation.ts` safely unblocks testing since `route.ts` can't export custom helpers for tests without causing build errors in Next.js.

📊 **Coverage:** What scenarios are now tested
Added comprehensive tests covering:
- Valid URLs (`http://`, `https://`)
- Invalid URLs (`not-a-url`)
- Dangerous/unsupported schemes (`javascript:`, `data:`, `ftp:`, `file:`)
- Empty strings
- URLs with leading/trailing spaces (which are parsed validly by `new URL()`)

✨ **Result:** The improvement in test coverage
The pure logic for URL validation is now fully decoupled from Next.js request handling, and is safely tested. Test suite completes successfully without build regressions.

---
*PR created automatically by Jules for task [2597493225848694169](https://jules.google.com/task/2597493225848694169) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`validateUrl` 関数を `route.ts` から `lib/validation.ts` に切り出し、Next.js のビルド制約を回避しながら純粋関数として独立したユニットテストを追加するリファクタリングです。ロジックの変更はなく、テストカバレッジ（http/https 許可、危険なスキーム拒否、空文字、前後スペースなど）も十分です。残る指摘はすべて P2 のスタイル改善（クォートスタイルの不統一、テスト名の言語統一、インポートパスの統一）のみで、マージをブロックするものはありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- マージ可能。すべての指摘は P2 のスタイル改善のみ。
- 関数のロジックは変わらず、テストカバレッジも十分。残る問題はクォートスタイル・言語統一・インポートパスの P2 スタイル不統一のみで、動作に影響しない。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/validation.ts | 新規作成ファイル。`validateUrl` 関数を `route.ts` から切り出してエクスポート。ロジックは元と完全に同一で、問題なし。 |
| packages/web-app-vercel/app/share-target/route.ts | インライン定義していた `validateUrl` を削除し `@/lib/validation` からインポートに変更。インポート文のダブルクォートがスタイル不統一（P2）。 |
| packages/web-app-vercel/app/share-target/__tests__/route.test.ts | `validateUrl` の直接ユニットテストを追加。テスト名が英語（既存は日本語）、インポートパスが相対パス（既存は `@/` エイリアス）という P2 スタイル不統一あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["route.ts (GET/POST)"] -->|import| B["lib/validation.ts\nvalidateUrl()"]
    C["route.test.ts"] -->|直接インポート & テスト| B
    B --> D{URL パース成功?}
    D -- No --> E["false を返す"]
    D -- Yes --> F{protocol が http: or https:?}
    F -- No --> E
    F -- Yes --> G["true を返す"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/app/share-target/route.ts
Line: 7

Comment:
**クォートスタイルの不統一**

このファイルの他のインポート文はすべてシングルクォートを使っていますが、この行だけダブルクォートになっています。プロジェクトのコーディングスタイルに合わせてシングルクォートに統一することを推奨します。

```suggestion
import { validateUrl } from '@/lib/validation'
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/share-target/__tests__/route.test.ts
Line: 341-377

Comment:
**テスト名の言語が統一されていない**

新しく追加された `validateUrl function` ブロック内のテスト名（`'valid http URL returns true'` など）が英語になっていますが、既存のテストはすべて日本語で記述されています（例: `'URLパラメータがない場合はホームにリダイレクト'`）。ファイル全体の一貫性のために日本語に統一することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/share-target/__tests__/route.test.ts
Line: 3

Comment:
**インポートパスのスタイル不統一**

同ファイル内の他のインポート（`@/lib/auth` など）は `@/` エイリアスを使っていますが、この行だけ相対パス `'../../../lib/validation'` になっています。テスト内で実際の実装を使う意図であっても、Jest の設定で `@/` エイリアスが解決されているなら合わせる方が一貫性が保たれます。

```suggestion
import { validateUrl } from '@/lib/validation'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add validation coverage for valida..."](https://github.com/hiroki-org/audicle/commit/c5b144ee485136021fc623740b72dc32ae6a616e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28308966)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->