### PR TITLE
🧪 [testing improvement] Add missing tests for resizeChunksIfNeeded edge cases

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -196,40 +196,19 @@ describe('paragraphParser', () => {
         });
 
         it('should handle paragraphs already meeting size requirements', () => {
-            const text = 'こんにちは世界'.repeat(5);
             const paragraphs = [
                 {
                     id: 'test-1',
                     type: 'p',
-                    originalText: text,
-                    cleanedText: text
+                    originalText: 'Hello',
+                    cleanedText: 'Hello'
                 }
             ];
             const result = resizeChunksIfNeeded(paragraphs);
             expect(result.length).toBe(1);
             expect(result[0].id).toBe('para-0');
             expect(result[0].isSplitChunk).toBe(false);
-            expect(result[0].originalText).toBe(text);
-            expect(result[0].cleanedText).toBe(text);
-        });
-
-        it('should split oversized paragraphs into safe chunks', () => {
-            const oversized = 'あ'.repeat(1700); // 約5100バイト
-            const paragraphs = [
-                {
-                    id: 'test-oversized',
-                    type: 'p',
-                    originalText: oversized,
-                    cleanedText: oversized
-                }
-            ];
-
-            const result = resizeChunksIfNeeded(paragraphs);
-            expect(result.length).toBeGreaterThan(1);
-            expect(result.some(p => p.isSplitChunk)).toBe(true);
-            for (const chunk of result) {
-                expect(Buffer.byteLength(chunk.cleanedText, 'utf-8')).toBeLessThanOrEqual(4800);
-            }
+            expect(result[0].originalText).toBe('Hello');
         });
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -196,19 +196,40 @@ describe('paragraphParser', () => {
         });
 
         it('should handle paragraphs already meeting size requirements', () => {
+            const text = 'こんにちは世界'.repeat(5);
             const paragraphs = [
                 {
                     id: 'test-1',
                     type: 'p',
-                    originalText: 'Hello',
-                    cleanedText: 'Hello'
+                    originalText: text,
+                    cleanedText: text
                 }
             ];
             const result = resizeChunksIfNeeded(paragraphs);
             expect(result.length).toBe(1);
             expect(result[0].id).toBe('para-0');
             expect(result[0].isSplitChunk).toBe(false);
-            expect(result[0].originalText).toBe('Hello');
+            expect(result[0].originalText).toBe(text);
+            expect(result[0].cleanedText).toBe(text);
+        });
+
+        it('should split oversized paragraphs into safe chunks', () => {
+            const oversized = 'あ'.repeat(1700); // 約5100バイト
+            const paragraphs = [
+                {
+                    id: 'test-oversized',
+                    type: 'p',
+                    originalText: oversized,
+                    cleanedText: oversized
+                }
+            ];
+
+            const result = resizeChunksIfNeeded(paragraphs);
+            expect(result.length).toBeGreaterThan(1);
+            expect(result.some(p => p.isSplitChunk)).toBe(true);
+            for (const chunk of result) {
+                expect(Buffer.byteLength(chunk.cleanedText, 'utf-8')).toBeLessThanOrEqual(4800);
+            }
         });
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
@@ -1,5 +1,6 @@
 import {
     parseHTMLToParagraphs,
+    resizeChunksIfNeeded,
     // 内部関数をテスト用にエクスポートする必要があるため、
     // テストファイルを別の形式で作成
 } from '../paragraphParser';
@@ -185,6 +186,29 @@ describe('paragraphParser', () => {
             if (paragraphs.length >= 2) {
                 expect(paragraphs[0].cleanedText.endsWith('。')).toBe(true);
             }
+        });
+    });
+
+    describe('resizeChunksIfNeeded', () => {
+        it('should return empty array for empty input', () => {
+            const result = resizeChunksIfNeeded([]);
+            expect(result).toEqual([]);
+        });
+
+        it('should handle paragraphs already meeting size requirements', () => {
+            const paragraphs = [
+                {
+                    id: 'test-1',
+                    type: 'p',
+                    originalText: 'Hello',
+                    cleanedText: 'Hello'
+                }
+            ];
+            const result = resizeChunksIfNeeded(paragraphs);
+            expect(result.length).toBe(1);
+            expect(result[0].id).toBe('para-0');
+            expect(result[0].isSplitChunk).toBe(false);
+            expect(result[0].originalText).toBe('Hello');
         });
     });
 });


### PR DESCRIPTION
🧪 [testing improvement] Add missing tests for resizeChunksIfNeeded edge cases

🎯 **What:** 
Added unit tests to `packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts` to directly verify edge cases for the `resizeChunksIfNeeded` function.

📊 **Coverage:** 
- Tested behavior when an empty array `[]` is passed as input.
- Tested behavior when paragraphs already meet the size requirements, verifying that they pass through without unnecessary splits and with accurate values.

✨ **Result:** 
Increased testing coverage for the `paragraphParser.ts` file, specifically the branches in `resizeChunksIfNeeded` handling un-chunked paragraphs and empty states. This increases confidence in future refactoring of this file.

---
*PR created automatically by Jules for task [9085592339343197302](https://jules.google.com/task/9085592339343197302) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`resizeChunksIfNeeded` を直接テストするための `describe` ブロックを追加し、空配列とサイズ制限内の段落という 2 つのエッジケースをカバーします。追加されたテストは実装ロジックと一致しており、正しく動作します。

残る指摘はすべて P2（スタイル・改善提案）レベルです。`cleanedText` フィールドのアサーション追加と、4800 バイト超過時の分割パスを `resizeChunksIfNeeded` の `describe` ブロックで直接テストすることを検討してください。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- 残る指摘はすべて P2 レベルのため、このままマージ可能です。
- 追加されたテストは実装と論理的に一致しており、正しく動作します。`cleanedText` アサーションの欠落と分割パスの直接テスト不足は改善提案ですが、いずれも動作上の問題ではありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts | 空配列とサイズ制限内のケースをテストする2つのケースを追加。テストの正確性は実装と一致しているが、`cleanedText` アサーションの欠落と分割パスの未テストという P2 レベルの改善点あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resizeChunksIfNeeded(paragraphs)"] --> B{paragraphs が空?}
    B -- はい --> C["return []<br/><b>✅ Test 1 でカバー済み</b>"]
    B -- いいえ --> D[各 paragraph を反復処理]
    D --> E{"cleanedByteSize<br/>≤ 4800 バイト?"}
    E -- はい --> F["{ ...para, id: 'para-N', isSplitChunk: false } を追加<br/><b>✅ Test 2 でカバー済み</b>"]
    E -- いいえ --> G["splitTextByByteSize(cleanedText)"]
    G --> H["各チャンクを<br/>isSplitChunk: true で追加<br/><b>⚠️ 直接テスト未カバー</b>"]
    F --> D
    H --> D
    D --> I["result 配列を返す"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
Line: 198-212

Comment:
**`cleanedText` の検証が欠落しています**

`resizeChunksIfNeeded` はサイズ制限内の段落に対して `...para` でスプレッドするため、`cleanedText` はそのまま引き継がれるはずです。`originalText` は検証されているのに `cleanedText` が検証されていないため、将来この関数がスプレッド処理を変更した場合に検出できません。

```suggestion
        it('should handle paragraphs already meeting size requirements', () => {
            const paragraphs = [
                {
                    id: 'test-1',
                    type: 'p',
                    originalText: 'Hello',
                    cleanedText: 'Hello'
                }
            ];
            const result = resizeChunksIfNeeded(paragraphs);
            expect(result.length).toBe(1);
            expect(result[0].id).toBe('para-0');
            expect(result[0].isSplitChunk).toBe(false);
            expect(result[0].originalText).toBe('Hello');
            expect(result[0].cleanedText).toBe('Hello');
        });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/lib/__tests__/paragraphParser.test.ts
Line: 192-213

Comment:
**分割パスの直接テストが不足しています**

PR の目的は「`resizeChunksIfNeeded` のエッジケースを直接検証する」ことですが、4800 バイトを超える段落が複数チャンクに分割される主要な分岐が、この新しい `describe` ブロックでテストされていません。現状では分割パスは `parseHTMLToParagraphs` 経由の間接テストにのみ依存しています。

直接テストの例：
```ts
it('should split paragraphs exceeding size limit', () => {
    const longText = 'あ'.repeat(1700); // ~5100 バイト (SAFE_MAX_TTS_BYTES=4800 を超過)
    const paragraphs = [{
        id: 'test-1',
        type: 'p',
        originalText: longText,
        cleanedText: longText
    }];
    const result = resizeChunksIfNeeded(paragraphs);
    expect(result.length).toBeGreaterThan(1);
    expect(result[0].isSplitChunk).toBe(true);
    for (const chunk of result) {
        expect(Buffer.byteLength(chunk.cleanedText, 'utf-8')).toBeLessThanOrEqual(4800);
    }
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for resizeChunksIfNeeded ed..."](https://github.com/hiroki-org/audicle/commit/a00a1520ee72c70cb83c7fde1105b678ecfa0783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28309019)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->