### PR TITLE
🧹 [code health improvement] Refactor run_benchmark to reduce complexity

### DIFF
--- a/packages/db/benchmarks/measure_lock_contention.py
+++ b/packages/db/benchmarks/measure_lock_contention.py
@@ -77,6 +77,89 @@ async def worker(pool, playlist_id, bookmark_ids):
                 except Exception as e:
                     print(f"Error inserting {bm_id}: {e}")
 
+
+async def execute_benchmark(pool, playlist_id, all_bm_ids):
+    print(f"Starting benchmark: {CONCURRENCY} workers, {ITEMS_PER_WORKER} items each.")
+
+    # Split bookmarks among workers
+    worker_tasks = []
+    chunk_size = ITEMS_PER_WORKER
+
+    start_time = time.time()
+
+    for i in range(CONCURRENCY):
+        chunk = all_bm_ids[i*chunk_size : (i+1)*chunk_size]
+        worker_tasks.append(worker(pool, playlist_id, chunk))
+
+    await asyncio.gather(*worker_tasks)
+
+    end_time = time.time()
+    duration = end_time - start_time
+    total_items = CONCURRENCY * ITEMS_PER_WORKER
+
+    print(f"Benchmark finished in {duration:.2f} seconds.")
+    print(f"Throughput: {total_items / duration:.2f} items/sec")
+
+
+async def verify_positions(pool, playlist_id):
+    # Verify positions
+    async with pool.acquire() as conn:
+        positions = await conn.fetch("""
+            SELECT position FROM playlist_items
+            WHERE playlist_id = $1
+            ORDER BY position
+        """, playlist_id)
+
+        pos_list = [r['position'] for r in positions]
+
+        count = len(pos_list)
+        unique_count = len(set(pos_list))
+
+        print(f"Total items inserted: {count}")
+
+        if count != unique_count:
+            print(f"❌ DUPLICATE POSITIONS DETECTED! Unique: {unique_count}, Total: {count}")
+        else:
+            print("✅ No duplicate positions.")
+
+        if count > 0:
+            min_pos = min(pos_list)
+            max_pos = max(pos_list)
+            print(f"Position range: {min_pos} to {max_pos}")
+
+            # Check for gaps
+            if max_pos - min_pos + 1 == count:
+                 print("✅ Positions are contiguous.")
+            else:
+                 print("⚠️ Positions have gaps.")
+
+
+async def cleanup_data(pool, playlist_id, user_email):
+    # Cleanup test data
+    if pool and playlist_id and user_email:
+        try:
+            print("Cleaning up test data...")
+            async with pool.acquire() as conn:
+                # Delete playlist items
+                await conn.execute("""
+                    DELETE FROM playlist_items WHERE playlist_id = $1
+                """, playlist_id)
+
+                # Delete bookmarks created by this benchmark run
+                await conn.execute("""
+                    DELETE FROM bookmarks WHERE owner_email = $1
+                """, user_email)
+
+                # Delete playlist
+                await conn.execute("""
+                    DELETE FROM playlists WHERE id = $1
+                """, playlist_id)
+
+            print("✅ Test data cleaned up successfully.")
+        except Exception as cleanup_error:
+            print(f"⚠️ Error during cleanup: {cleanup_error}")
+
+
 async def run_benchmark():
     if not asyncpg:
         print("❌ Error: 'asyncpg' library is required.")
@@ -98,84 +181,13 @@ async def run_benchmark():
         async with pool.acquire() as conn:
             playlist_id, all_bm_ids, user_email = await setup_data(conn)
 
-        print(f"Starting benchmark: {CONCURRENCY} workers, {ITEMS_PER_WORKER} items each.")
-
-        # Split bookmarks among workers
-        worker_tasks = []
-        chunk_size = ITEMS_PER_WORKER
-
-        start_time = time.time()
-
-        for i in range(CONCURRENCY):
-            chunk = all_bm_ids[i*chunk_size : (i+1)*chunk_size]
-            worker_tasks.append(worker(pool, playlist_id, chunk))
-
-        await asyncio.gather(*worker_tasks)
-
-        end_time = time.time()
-        duration = end_time - start_time
-        total_items = CONCURRENCY * ITEMS_PER_WORKER
-
-        print(f"Benchmark finished in {duration:.2f} seconds.")
-        print(f"Throughput: {total_items / duration:.2f} items/sec")
-
-        # Verify positions
-        async with pool.acquire() as conn:
-            positions = await conn.fetch("""
-                SELECT position FROM playlist_items
-                WHERE playlist_id = $1
-                ORDER BY position
-            """, playlist_id)
-
-            pos_list = [r['position'] for r in positions]
-
-            count = len(pos_list)
-            unique_count = len(set(pos_list))
-
-            print(f"Total items inserted: {count}")
-
-            if count != unique_count:
-                print(f"❌ DUPLICATE POSITIONS DETECTED! Unique: {unique_count}, Total: {count}")
-            else:
-                print("✅ No duplicate positions.")
-
-            if count > 0:
-                min_pos = min(pos_list)
-                max_pos = max(pos_list)
-                print(f"Position range: {min_pos} to {max_pos}")
-
-                # Check for gaps
-                if max_pos - min_pos + 1 == count:
-                     print("✅ Positions are contiguous.")
-                else:
-                     print("⚠️ Positions have gaps.")
+        await execute_benchmark(pool, playlist_id, all_bm_ids)
+        await verify_positions(pool, playlist_id)
 
     except Exception as e:
         print(f"An error occurred during the benchmark: {e}")
     finally:
-        # Cleanup test data
-        if pool and playlist_id and user_email:
-            try:
-                print("Cleaning up test data...")
-                async with pool.acquire() as conn:
-                    # Delete playlist items
-                    await conn.execute("""
-                        DELETE FROM playlist_items WHERE playlist_id = $1
-                    """, playlist_id)
-                    
-                    # Delete bookmarks created by this benchmark run
-                    await conn.execute("""
-                        DELETE FROM bookmarks WHERE owner_email = $1
-                    """, user_email)
-                    
-                    # Delete playlist
-                    await conn.execute("""
-                        DELETE FROM playlists WHERE id = $1
-                    """, playlist_id)
-                
-                print("✅ Test data cleaned up successfully.")
-            except Exception as cleanup_error:
-                print(f"⚠️ Error during cleanup: {cleanup_error}")
+        await cleanup_data(pool, playlist_id, user_email)
         
         if pool:
             print("Closing DB pool...")

--- a/packages/db/benchmarks/measure_lock_contention.py
+++ b/packages/db/benchmarks/measure_lock_contention.py
@@ -85,7 +85,7 @@ async def execute_benchmark(pool, playlist_id, all_bm_ids):
     worker_tasks = []
     chunk_size = ITEMS_PER_WORKER
 
-    start_time = time.perf_counter()
+    start_time = time.time()
 
     for i in range(CONCURRENCY):
         chunk = all_bm_ids[i*chunk_size : (i+1)*chunk_size]
@@ -93,9 +93,9 @@ async def execute_benchmark(pool, playlist_id, all_bm_ids):
 
     await asyncio.gather(*worker_tasks)
 
-    end_time = time.perf_counter()
+    end_time = time.time()
     duration = end_time - start_time
-    total_items = len(all_bm_ids)
+    total_items = CONCURRENCY * ITEMS_PER_WORKER
 
     print(f"Benchmark finished in {duration:.2f} seconds.")
     print(f"Throughput: {total_items / duration:.2f} items/sec")
@@ -123,15 +123,15 @@ async def verify_positions(pool, playlist_id):
             print("✅ No duplicate positions.")
 
         if count > 0:
-            min_pos = pos_list[0]
-            max_pos = pos_list[-1]
+            min_pos = min(pos_list)
+            max_pos = max(pos_list)
             print(f"Position range: {min_pos} to {max_pos}")
 
             # Check for gaps
             if max_pos - min_pos + 1 == count:
-                print("✅ Positions are contiguous.")
+                 print("✅ Positions are contiguous.")
             else:
-                print("⚠️ Positions have gaps.")
+                 print("⚠️ Positions have gaps.")
 
 
 async def cleanup_data(pool, playlist_id, user_email):
@@ -187,8 +187,7 @@ async def run_benchmark():
     except Exception as e:
         print(f"An error occurred during the benchmark: {e}")
     finally:
-        if pool and playlist_id and user_email:
-            await cleanup_data(pool, playlist_id, user_email)
+        await cleanup_data(pool, playlist_id, user_email)
         
         if pool:
             print("Closing DB pool...")

--- a/packages/db/benchmarks/measure_lock_contention.py
+++ b/packages/db/benchmarks/measure_lock_contention.py
@@ -85,7 +85,7 @@ async def execute_benchmark(pool, playlist_id, all_bm_ids):
     worker_tasks = []
     chunk_size = ITEMS_PER_WORKER
 
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     for i in range(CONCURRENCY):
         chunk = all_bm_ids[i*chunk_size : (i+1)*chunk_size]
@@ -93,9 +93,9 @@ async def execute_benchmark(pool, playlist_id, all_bm_ids):
 
     await asyncio.gather(*worker_tasks)
 
-    end_time = time.time()
+    end_time = time.perf_counter()
     duration = end_time - start_time
-    total_items = CONCURRENCY * ITEMS_PER_WORKER
+    total_items = len(all_bm_ids)
 
     print(f"Benchmark finished in {duration:.2f} seconds.")
     print(f"Throughput: {total_items / duration:.2f} items/sec")
@@ -123,15 +123,15 @@ async def verify_positions(pool, playlist_id):
             print("✅ No duplicate positions.")
 
         if count > 0:
-            min_pos = min(pos_list)
-            max_pos = max(pos_list)
+            min_pos = pos_list[0]
+            max_pos = pos_list[-1]
             print(f"Position range: {min_pos} to {max_pos}")
 
             # Check for gaps
             if max_pos - min_pos + 1 == count:
-                 print("✅ Positions are contiguous.")
+                print("✅ Positions are contiguous.")
             else:
-                 print("⚠️ Positions have gaps.")
+                print("⚠️ Positions have gaps.")
 
 
 async def cleanup_data(pool, playlist_id, user_email):
@@ -187,7 +187,8 @@ async def run_benchmark():
     except Exception as e:
         print(f"An error occurred during the benchmark: {e}")
     finally:
-        await cleanup_data(pool, playlist_id, user_email)
+        if pool and playlist_id and user_email:
+            await cleanup_data(pool, playlist_id, user_email)
         
         if pool:
             print("Closing DB pool...")


### PR DESCRIPTION
🎯 What: Extracted execute_benchmark, verify_positions, and cleanup_data into separate helper functions.
💡 Why: The run_benchmark function was excessively long and combining setup, execution, verification, and cleanup logic. Splitting it into smaller helper functions drastically improves readability and maintainability.
✅ Verification: Ran the benchmark wrapper script to ensure successful completion. Ran full api-server tests to verify no regressions. Verified code changes exactly matched the desired behavior.
✨ Result: Reduced complexity in the measure_lock_contention.py main benchmark entry point while preserving all functionality.

---
*PR created automatically by Jules for task [6570392396736362818](https://jules.google.com/task/6570392396736362818) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

肥大化していた `run_benchmark` 関数から `execute_benchmark`・`verify_positions`・`cleanup_data` の3つの非同期ヘルパー関数を抽出したリファクタリングです。タイミング計測・例外処理・クリーンアップのロジックはすべて元のコードと機能的に同等であることを確認しました。残る指摘は P2 のスタイル改善（既存コードから持ち越されたインデントの余分なスペース、`finally` 側でのガード条件の明示化）のみで、マージを妨げるものはありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- マージ安全。機能的な変更はなく、純粋なリファクタリングです。
- 抽出された3つのヘルパー関数はいずれも元のインラインコードと動作が完全に一致しており、例外処理・クリーンアップのロジックも保持されています。残る指摘はすべて P2 のスタイル改善のみで、マージを妨げる問題はありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/db/benchmarks/measure_lock_contention.py | `run_benchmark` から `execute_benchmark`・`verify_positions`・`cleanup_data` の3つのヘルパー関数を抽出。機能的には元のコードと同等で、P2レベルのスタイル指摘（余分なインデント、`finally` のガード配置）のみ。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_benchmark] --> B{asyncpg あり？}
    B -- No --> C[エラー出力して終了]
    B -- Yes --> D[asyncpg.create_pool]
    D --> E[setup_data\nプレイリスト・ブックマーク作成]
    E --> F[execute_benchmark\nワーカー分散 & 計測]
    F --> G[verify_positions\n重複・ギャップ確認]
    G --> H{例外?}
    H -- Yes --> I[エラー出力]
    H -- No --> J[finally: cleanup_data\nテストデータ削除]
    I --> J
    J --> K[pool.close]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/db/benchmarks/measure_lock_contention.py
Line: 131-134

Comment:
**インデント余分なスペース（移植された既存の問題）**

`print` 文のインデントが 4 スペースではなく 5 スペースになっています。これはリファクタリング前のコードから持ち越された問題ですが、このタイミングで修正することを推奨します。

```suggestion
            if max_pos - min_pos + 1 == count:
                print("✅ Positions are contiguous.")
            else:
                print("⚠️ Positions have gaps.")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/db/benchmarks/measure_lock_contention.py
Line: 137-160

Comment:
**`cleanup_data` が `pool=None` でも常に呼ばれる**

`run_benchmark` の `finally` ブロックでは、接続失敗時でも `await cleanup_data(None, None, None)` が呼ばれます。`cleanup_data` 内の `if pool and playlist_id and user_email:` ガードで正しくスキップされるため動作上の問題はありませんが、元のコードでは `if pool and playlist_id and user_email:` の判定が `finally` ブロック側にあったため、そもそも不要な関数呼び出し自体が発生しませんでした。`None` の場合に早期リターンするのは既存ロジックで担保されており機能的に同等ですが、呼び出し側で同じガードを維持する方がより明示的です。

```python
finally:
    if pool and playlist_id and user_email:
        await cleanup_data(pool, playlist_id, user_email)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 \[code health improvement\] Refactor ru..."](https://github.com/hiroki-org/audicle/commit/4242fce24c79875a3610d9aa6b3b6c2ea88b1f1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28309058)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->