### PR TITLE
🧪 Add unit tests for validateUrl function

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/validation.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/validation.test.ts
@@ -12,6 +12,12 @@ describe('validateUrl', () => {
         expect(validateUrl('https://sub.example.com/path')).toBe(true);
     });
 
+    it('should be case-insensitive for the protocol', () => {
+        expect(validateUrl('HTTP://example.com')).toBe(true);
+        expect(validateUrl('HTTPS://example.com')).toBe(true);
+        expect(validateUrl('Http://example.com')).toBe(true);
+    });
+
     it('should return false for invalid URLs', () => {
         expect(validateUrl('not-a-url')).toBe(false);
         expect(validateUrl('example.com')).toBe(false); // missing scheme
@@ -19,20 +25,23 @@ describe('validateUrl', () => {
         expect(validateUrl(' ')).toBe(false);
     });
 
-    it('should return false for unsupported or dangerous protocols', () => {
-        expect(validateUrl('javascript:alert(1)')).toBe(false);
-        expect(validateUrl('data:text/html,<h1>test</h1>')).toBe(false);
-        expect(validateUrl('file:///etc/passwd')).toBe(false);
-        expect(validateUrl('ftp://example.com')).toBe(false);
-        expect(validateUrl('ws://example.com')).toBe(false);
-        expect(validateUrl('wss://example.com')).toBe(false);
-        expect(validateUrl('chrome://settings')).toBe(false);
-        expect(validateUrl('mailto:test@example.com')).toBe(false);
+    it.each([
+        ['javascript:alert(1)', 'javascript'],
+        ['data:text/html,<h1>test</h1>', 'data'],
+        ['file:///etc/passwd', 'file'],
+        ['ftp://example.com', 'ftp'],
+        ['ws://example.com', 'ws'],
+        ['wss://example.com', 'wss'],
+        ['chrome://settings', 'chrome'],
+        ['mailto:test@example.com', 'mailto'],
+    ])('should return false for %s (%s protocol)', (url) => {
+        expect(validateUrl(url)).toBe(false);
     });
 
     it('should return false for malformed URLs that throw during parsing', () => {
-        expect(validateUrl('http://%')).toBe(false); // Valid scheme but might fail URL constructor in some environments depending on strictness
-        // Node's URL parser throws on this:
+        // URLs without a valid host after the scheme
+        expect(validateUrl('http://')).toBe(false);
+        // Unmatched brackets in IPv6
         expect(validateUrl('http://[::1')).toBe(false);
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/validation.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/validation.test.ts
@@ -1,0 +1,38 @@
+import { validateUrl } from '../validation';
+
+describe('validateUrl', () => {
+    it('should return true for valid http URLs', () => {
+        expect(validateUrl('http://example.com')).toBe(true);
+        expect(validateUrl('http://localhost:3000')).toBe(true);
+        expect(validateUrl('http://example.com/path?query=1#hash')).toBe(true);
+    });
+
+    it('should return true for valid https URLs', () => {
+        expect(validateUrl('https://example.com')).toBe(true);
+        expect(validateUrl('https://sub.example.com/path')).toBe(true);
+    });
+
+    it('should return false for invalid URLs', () => {
+        expect(validateUrl('not-a-url')).toBe(false);
+        expect(validateUrl('example.com')).toBe(false); // missing scheme
+        expect(validateUrl('')).toBe(false);
+        expect(validateUrl(' ')).toBe(false);
+    });
+
+    it('should return false for unsupported or dangerous protocols', () => {
+        expect(validateUrl('javascript:alert(1)')).toBe(false);
+        expect(validateUrl('data:text/html,<h1>test</h1>')).toBe(false);
+        expect(validateUrl('file:///etc/passwd')).toBe(false);
+        expect(validateUrl('ftp://example.com')).toBe(false);
+        expect(validateUrl('ws://example.com')).toBe(false);
+        expect(validateUrl('wss://example.com')).toBe(false);
+        expect(validateUrl('chrome://settings')).toBe(false);
+        expect(validateUrl('mailto:test@example.com')).toBe(false);
+    });
+
+    it('should return false for malformed URLs that throw during parsing', () => {
+        expect(validateUrl('http://%')).toBe(false); // Valid scheme but might fail URL constructor in some environments depending on strictness
+        // Node's URL parser throws on this:
+        expect(validateUrl('http://[::1')).toBe(false);
+    });
+});


### PR DESCRIPTION
🎯 **What:** The `validateUrl` function in `lib/validation.ts` was previously untested.\n📊 **Coverage:** Added test coverage for valid HTTP/HTTPS URLs, missing/invalid schemes, malformed URLs, and dangerous protocols (javascript:, data:).\n✨ **Result:** Increased test coverage and confidence when refactoring URL validation logic.

---
*PR created automatically by Jules for task [11434738291587266428](https://jules.google.com/task/11434738291587266428) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `lib/validation.ts` の `validateUrl` 関数に対するユニットテストを追加します。有効な HTTP/HTTPS URL、不正スキーム、危険なプロトコル（`javascript:`、`data:` など）、および不正形式 URL の5つのテストスイートがカバーされており、実装の動作と期待値が一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、マージは安全です。

追加されたテストケースはすべて `validateUrl` の実装と正しく対応しており、期待値に誤りは見当たりません。P0/P1 の問題は存在せず、テストのみの変更のためマージリスクはありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/__tests__/validation.test.ts | `validateUrl` のユニットテストを追加。有効な HTTP/HTTPS URL・不正スキーム・危険なプロトコル・不正形式 URL のケースをカバー。全テストケースの期待値は実装と一致しており、論理的な誤りは見当たらない。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["validateUrl(url)"] --> B["new URL(url) を実行"]
    B -- 例外スロー --> C["return false"]
    B -- 成功 --> D{"protocol が http: または https: ?"}
    D -- Yes --> E["return true"]
    D -- No --> F["return false"]
```

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for validateUrl fun..."](https://github.com/hiroki-org/audicle/commit/7e94b46f162e8efbd9cbef1b79280120a55395bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29093062)</sub>

<!-- /greptile_comment -->