### PR TITLE
🧹 Remove console.log from extract route

### DIFF
--- a/packages/web-app-vercel/app/api/extract/route.ts
+++ b/packages/web-app-vercel/app/api/extract/route.ts
@@ -1,150 +1,150 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getCorsHeaders } from '@/lib/cors';
-import { Readability } from '@mozilla/readability';
-import { normalizeArticleText } from '@/lib/parseArticle';
-import { parseHTML } from 'linkedom';
-import { ExtractResponse } from '@/types/api';
-import { isSafeUrl } from '@/lib/ssrf';
+import { NextRequest, NextResponse } from "next/server";
+import { getCorsHeaders } from "@/lib/cors";
+import { Readability } from "@mozilla/readability";
+import { normalizeArticleText } from "@/lib/parseArticle";
+import { parseHTML } from "linkedom";
+import { ExtractResponse } from "@/types/api";
+import { isSafeUrl } from "@/lib/ssrf";
 
 // Node.js runtimeを明示的に指定（JSDOMはEdge Runtimeで動作しない）
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 // 動的レンダリングを強制（キャッシュを無効化）
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export async function OPTIONS(request: NextRequest) {
-    return NextResponse.json({}, {
-        headers: getCorsHeaders(request),
-    });
+  return NextResponse.json(
+    {},
+    {
+      headers: getCorsHeaders(request),
+    },
+  );
 }
 
 export async function POST(request: NextRequest) {
-    console.log('[Extract API] POST request received');
+  const corsHeaders = getCorsHeaders(request);
 
-    const corsHeaders = getCorsHeaders(request);
-
-    try {
-        const { url } = await request.json();
-        console.log('[Extract API] Extracting content from:', url);
-
-        if (!url || typeof url !== 'string') {
-            return NextResponse.json(
-                { error: 'URL is required' },
-                { status: 400, headers: corsHeaders }
-            );
-        }
-
-        // URLのバリデーション
-        try {
-            new URL(url);
-        } catch {
-            return NextResponse.json(
-                { error: 'Invalid URL format' },
-                { status: 400, headers: corsHeaders }
-            );
-        }
-
-        // SSRFチェック (initial check)
-        if (!(await isSafeUrl(url))) {
-            console.warn('[Extract API] SSRF attempt blocked:', url);
-            return NextResponse.json(
-                { error: 'Access to this URL is restricted for security reasons' },
-                { status: 403, headers: corsHeaders }
-            );
-        }
-
-        // HTMLを取得 (with secure redirect handling)
-        const html = await fetchWithTimeout(url);
-
-        // linkedomでパース
-        const { document } = parseHTML(html);
-
-        // Readabilityで本文抽出
-        const article = new Readability(document).parse();
-
-        if (!article) {
-            return NextResponse.json(
-                { error: 'Failed to extract content from URL' },
-                { status: 422, headers: corsHeaders }
-            );
-        }
-
-        // テキストコンテンツの取得（重複やUIテキスト混入を防ぐため normalizeArticleText を利用）
-        const textContent = normalizeArticleText(article.content || '') || (article.textContent || '');
-
-        const response: ExtractResponse = {
-            title: article.title || '',
-            content: article.content || textContent,
-            textLength: textContent.length,
-            author: article.byline || undefined,
-            siteName: article.siteName || undefined,
-        };
-
-        console.log('[Extract API] Successfully extracted:', {
-            title: response.title,
-            textLength: response.textLength,
-        });
-
-        return NextResponse.json(response, {
-            headers: corsHeaders,
-        });
-    } catch (error) {
-
-        if (error instanceof SyntaxError) {
-            return NextResponse.json(
-                { error: 'Invalid request body' },
-                { status: 400, headers: corsHeaders }
-            );
-        }
-
-        if (error instanceof TimeoutError) {
-            return NextResponse.json(
-                { error: 'Request timeout - URL took too long to fetch' },
-                { status: 408, headers: corsHeaders }
-            );
-        }
-
-        if (error instanceof AuthenticationRequiredError) {
-            return NextResponse.json(
-                { error: 'このURLは認証が必要なサイトです。ログインが必要なページは読み込めません。' },
-                { status: error.statusCode, headers: corsHeaders }
-            );
-        }
-
-        if (error instanceof SSRFBlockedError) {
-            return NextResponse.json(
-                { error: 'Access to the redirect URL is restricted for security reasons' },
-                { status: 403, headers: corsHeaders }
-            );
-        }
-
-        if (error instanceof TooManyRedirectsError) {
-            return NextResponse.json(
-                { error: 'Too many redirects' },
-                { status: 400, headers: corsHeaders }
-            );
-        }
-
-        console.error('Extract error:', error);
-        return NextResponse.json(
-            { error: 'Failed to extract content' },
-            { status: 500, headers: corsHeaders }
-        );
+  try {
+    const { url } = await request.json();
+    if (!url || typeof url !== "string") {
+      return NextResponse.json(
+        { error: "URL is required" },
+        { status: 400, headers: corsHeaders },
+      );
     }
+
+    // URLのバリデーション
+    try {
+      new URL(url);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid URL format" },
+        { status: 400, headers: corsHeaders },
+      );
+    }
+
+    // SSRFチェック (initial check)
+    if (!(await isSafeUrl(url))) {
+      console.warn("[Extract API] SSRF attempt blocked:", url);
+      return NextResponse.json(
+        { error: "Access to this URL is restricted for security reasons" },
+        { status: 403, headers: corsHeaders },
+      );
+    }
+
+    // HTMLを取得 (with secure redirect handling)
+    const html = await fetchWithTimeout(url);
+
+    // linkedomでパース
+    const { document } = parseHTML(html);
+
+    // Readabilityで本文抽出
+    const article = new Readability(document).parse();
+
+    if (!article) {
+      return NextResponse.json(
+        { error: "Failed to extract content from URL" },
+        { status: 422, headers: corsHeaders },
+      );
+    }
+
+    // テキストコンテンツの取得（重複やUIテキスト混入を防ぐため normalizeArticleText を利用）
+    const textContent =
+      normalizeArticleText(article.content || "") || article.textContent || "";
+
+    const response: ExtractResponse = {
+      title: article.title || "",
+      content: article.content || textContent,
+      textLength: textContent.length,
+      author: article.byline || undefined,
+      siteName: article.siteName || undefined,
+    };
+
+    return NextResponse.json(response, {
+      headers: corsHeaders,
+    });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: "Invalid request body" },
+        { status: 400, headers: corsHeaders },
+      );
+    }
+
+    if (error instanceof TimeoutError) {
+      return NextResponse.json(
+        { error: "Request timeout - URL took too long to fetch" },
+        { status: 408, headers: corsHeaders },
+      );
+    }
+
+    if (error instanceof AuthenticationRequiredError) {
+      return NextResponse.json(
+        {
+          error:
+            "このURLは認証が必要なサイトです。ログインが必要なページは読み込めません。",
+        },
+        { status: error.statusCode, headers: corsHeaders },
+      );
+    }
+
+    if (error instanceof SSRFBlockedError) {
+      return NextResponse.json(
+        {
+          error:
+            "Access to the redirect URL is restricted for security reasons",
+        },
+        { status: 403, headers: corsHeaders },
+      );
+    }
+
+    if (error instanceof TooManyRedirectsError) {
+      return NextResponse.json(
+        { error: "Too many redirects" },
+        { status: 400, headers: corsHeaders },
+      );
+    }
+
+    console.error("Extract error:", error);
+    return NextResponse.json(
+      { error: "Failed to extract content" },
+      { status: 500, headers: corsHeaders },
+    );
+  }
 }
 
 // Configure undici agent for custom fetch behavior
 // In test/CI environments, we might need to ignore SSL errors for internal services or proxies
-import { Agent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+import { Agent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
 
 // Initialize global dispatcher if needed (safe to call multiple times)
 // This ensures fetch uses our custom agent settings
-if (process.env.NODE_ENV === 'test' || process.env.CI === 'true') {
-    const agent = new Agent({
-        connect: {
-            rejectUnauthorized: false
-        }
-    });
-    setGlobalDispatcher(agent);
+if (process.env.NODE_ENV === "test" || process.env.CI === "true") {
+  const agent = new Agent({
+    connect: {
+      rejectUnauthorized: false,
+    },
+  });
+  setGlobalDispatcher(agent);
 }
 
 /**
@@ -153,106 +153,112 @@ if (process.env.NODE_ENV === 'test' || process.env.CI === 'true') {
  *
  * NOTE: SSRF保護のため、リダイレクトは手動で処理し、ホップごとに `isSafeUrl` をチェックします。
  */
-async function fetchWithTimeout(url: string, timeout: number = 8000): Promise<string> {
-    const controller = new AbortController();
-    const id = setTimeout(() => controller.abort(), timeout);
-    const maxRedirects = 5;
-    let currentUrl = url;
-    let redirectCount = 0;
+async function fetchWithTimeout(
+  url: string,
+  timeout: number = 8000,
+): Promise<string> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  const maxRedirects = 5;
+  let currentUrl = url;
+  let redirectCount = 0;
 
-    try {
-        while (redirectCount < maxRedirects) {
-            // Use standard fetch (which now respects global dispatcher in Node 18+)
-            const response = await fetch(currentUrl, {
-                signal: controller.signal,
-                redirect: 'manual', // 自動リダイレクトを無効化
-                headers: {
-                    'User-Agent':
-                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-                },
-                // @ts-ignore - duplex is needed for some fetch implementations but not in standard type
-                duplex: 'half', 
-            });
+  try {
+    while (redirectCount < maxRedirects) {
+      // Use standard fetch (which now respects global dispatcher in Node 18+)
+      const response = await fetch(currentUrl, {
+        signal: controller.signal,
+        redirect: "manual", // 自動リダイレクトを無効化
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        },
+        // @ts-ignore - duplex is needed for some fetch implementations but not in standard type
+        duplex: "half",
+      });
 
-            // 認証が必要なサイトの場合は専用エラーをスロー
-            if (response.status === 401 || response.status === 403) {
-                throw new AuthenticationRequiredError(
-                    `このURLには認証が必要です（HTTP ${response.status}）`,
-                    response.status
-                );
-            }
+      // 認証が必要なサイトの場合は専用エラーをスロー
+      if (response.status === 401 || response.status === 403) {
+        throw new AuthenticationRequiredError(
+          `このURLには認証が必要です（HTTP ${response.status}）`,
+          response.status,
+        );
+      }
 
-            // リダイレクト処理
-            if (response.status >= 300 && response.status < 400) {
-                // レスポンスボディを破棄してリソースを解放
-                // biome-ignore lint/suspicious/noExplicitAny: response.body might be missing in some environments
-                await response.body?.cancel();
+      // リダイレクト処理
+      if (response.status >= 300 && response.status < 400) {
+        // レスポンスボディを破棄してリソースを解放
+        // biome-ignore lint/suspicious/noExplicitAny: response.body might be missing in some environments
+        await response.body?.cancel();
 
-                const location = response.headers.get('Location');
-                if (!location) {
-                    throw new Error(`HTTP ${response.status} Redirect without Location header`);
-                }
-
-                // 相対パスの場合は絶対パスに変換
-                const nextUrlObj = new URL(location, currentUrl);
-                const nextUrl = nextUrlObj.toString();
-
-                // SSRFチェック（リダイレクト先もチェック）
-                if (!(await isSafeUrl(nextUrl))) {
-                    console.warn('[Extract API] Blocked unsafe redirect to:', nextUrl);
-                    throw new SSRFBlockedError('Access to the redirect URL is restricted for security reasons');
-                }
-
-                currentUrl = nextUrl;
-                redirectCount++;
-                continue;
-            }
-
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-            }
-
-            return await response.text();
+        const location = response.headers.get("Location");
+        if (!location) {
+          throw new Error(
+            `HTTP ${response.status} Redirect without Location header`,
+          );
         }
 
-        throw new TooManyRedirectsError('Too many redirects');
+        // 相対パスの場合は絶対パスに変換
+        const nextUrlObj = new URL(location, currentUrl);
+        const nextUrl = nextUrlObj.toString();
 
-    } catch (error) {
-        if (error instanceof Error && error.name === 'AbortError') {
-            throw new TimeoutError('Fetch timeout');
+        // SSRFチェック（リダイレクト先もチェック）
+        if (!(await isSafeUrl(nextUrl))) {
+          console.warn("[Extract API] Blocked unsafe redirect to:", nextUrl);
+          throw new SSRFBlockedError(
+            "Access to the redirect URL is restricted for security reasons",
+          );
         }
-        throw error;
-    } finally {
-        clearTimeout(id);
+
+        currentUrl = nextUrl;
+        redirectCount++;
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return await response.text();
     }
+
+    throw new TooManyRedirectsError("Too many redirects");
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new TimeoutError("Fetch timeout");
+    }
+    throw error;
+  } finally {
+    clearTimeout(id);
+  }
 }
 
 class TimeoutError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'TimeoutError';
-    }
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
 }
 
 class AuthenticationRequiredError extends Error {
-    statusCode: number;
-    constructor(message: string, statusCode: number = 403) {
-        super(message);
-        this.name = 'AuthenticationRequiredError';
-        this.statusCode = statusCode;
-    }
+  statusCode: number;
+  constructor(message: string, statusCode: number = 403) {
+    super(message);
+    this.name = "AuthenticationRequiredError";
+    this.statusCode = statusCode;
+  }
 }
 
 class SSRFBlockedError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'SSRFBlockedError';
-    }
+  constructor(message: string) {
+    super(message);
+    this.name = "SSRFBlockedError";
+  }
 }
 
 class TooManyRedirectsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'TooManyRedirectsError';
-    }
+  constructor(message: string) {
+    super(message);
+    this.name = "TooManyRedirectsError";
+  }
 }


### PR DESCRIPTION
* 🎯 **What:** Removed debug `console.log` statements from `packages/web-app-vercel/app/api/extract/route.ts`.
* 💡 **Why:** `console.log` statements are debugging artifacts and removing them improves codebase readability and cleanliness. `console.warn` and `console.error` are maintained for functional observability.
* ✅ **Verification:** Checked using `grep` that no `console.log` remains in the file and ran `npm run test` in `packages/web-app-vercel` to ensure tests continue to pass without side effects.
* ✨ **Result:** Code is cleaner, noise from log output is reduced, and the extraction functionality operates safely as before.

---
*PR created automatically by Jules for task [4872194074149924590](https://jules.google.com/task/4872194074149924590) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

デバッグ用の `console.log` を3箇所削除し、セキュリティ・運用上意味のある `console.warn` / `console.error` は維持しています。加えてファイル全体のフォーマット（インデント・クォート）も変更されていますが、PRの説明には記載がありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージ安全です。すべての指摘はP2（スタイル・改善提案）であり、機能への影響はありません。

削除されたのはデバッグ用 console.log のみで、機能ロジックに変更はなし。フォーマット変更も既存の動作に影響しない。残る指摘はいずれもP2のため、スコアを5とする。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/extract/route.ts | デバッグ用 console.log を3箇所削除し、console.warn と console.error は維持。加えてファイル全体のインデント（4→2スペース）とクォートスタイル（シングル→ダブル）が変更されている。機能上の問題はなし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant POST as POST /api/extract
    participant isSafeUrl
    participant fetchWithTimeout
    participant Readability

    Client->>POST: POST { url }
    POST->>POST: URLバリデーション
    POST->>isSafeUrl: isSafeUrl(url)
    isSafeUrl-->>POST: true / false
    alt SSRF検出
        POST-->>Client: 403 Forbidden (console.warn 出力)
    end
    POST->>fetchWithTimeout: fetchWithTimeout(url)
    loop リダイレクト処理 (最大5回)
        fetchWithTimeout->>isSafeUrl: isSafeUrl(nextUrl)
        alt 安全でないリダイレクト
            fetchWithTimeout-->>POST: SSRFBlockedError (console.warn 出力)
        end
    end
    fetchWithTimeout-->>POST: HTML文字列
    POST->>Readability: parse(document)
    Readability-->>POST: article
    POST-->>Client: 200 ExtractResponse
    alt エラー発生
        POST-->>Client: 4xx / 500 (500時のみ console.error 出力)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/extract/route.ts
Line: 1-12

Comment:
**PRの説明に記載のないフォーマット変更**

このPRはデバッグ用の `console.log` 削除を目的としていますが、実際にはファイル全体のフォーマットも変更されています（インデント: 4スペース→2スペース、クォート: シングル→ダブル）。機能への影響はありませんが、PRの説明に記載のない変更がdiffに含まれているため、レビュー負荷が増し、変更の意図が分かりにくくなっています。

フォーマット変更が意図的であれば、PRの説明に明記するか、別コミット・別PRに分けることを検討してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/extract/route.ts
Line: 141-148

Comment:
**テスト環境でSSL検証を無効化している**

`rejectUnauthorized: false` は、テスト・CI環境でサーバー証明書の検証を完全にスキップします。このコードはPR以前から存在しますが、CI環境で中間者攻撃のリスクが生じる可能性があります。可能であれば、自己署名証明書を信頼する形（`ca` オプションで独自CAを指定）に変更することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove console.log statements fro..."](https://github.com/hiroki-org/audicle/commit/932d38fdcb80a771fad8968d240ae2fc79d3c59b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29094515)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->