### PR TITLE
🧪 [Testing] Add unit tests for usePlaylistSelection hooks

### DIFF
--- a/packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx
@@ -1,0 +1,190 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    usePlaylistItemPlaylists,
+    useArticlePlaylists,
+    useUpdateArticlePlaylistsMutation,
+} from "../usePlaylistSelection";
+
+jest.mock("next-auth/react", () => ({
+    useSession: jest.fn(),
+}));
+
+global.fetch = jest.fn();
+
+describe("usePlaylistSelection hooks", () => {
+    let queryClient: QueryClient;
+    const mockSession = {
+        data: { user: { email: "test@example.com" } },
+        status: "authenticated",
+    };
+
+    beforeEach(() => {
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                },
+                mutations: {
+                    retry: false,
+                },
+            },
+        });
+        jest.clearAllMocks();
+        const { useSession } = require("next-auth/react");
+        useSession.mockReturnValue(mockSession);
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    describe("usePlaylistItemPlaylists", () => {
+        it("should fetch playlist item playlists successfully", async () => {
+            const mockData = [{ id: "1", name: "Test Playlist" }];
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockData,
+            });
+
+            const { result } = renderHook(() => usePlaylistItemPlaylists("item123"), { wrapper });
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+            expect(result.current.data).toEqual(mockData);
+            expect(global.fetch).toHaveBeenCalledWith("/api/playlist-items/item123/playlists");
+        });
+
+        it("should not fetch when userEmail is undefined", () => {
+            const { useSession } = require("next-auth/react");
+            useSession.mockReturnValue({ data: null, status: "unauthenticated" });
+
+            const { result } = renderHook(() => usePlaylistItemPlaylists("item123"), { wrapper });
+
+            expect(result.current.isPending).toBe(true);
+            expect(result.current.fetchStatus).toBe("idle");
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it("should respect options.enabled", () => {
+            const { result } = renderHook(() => usePlaylistItemPlaylists("item123", { enabled: false }), { wrapper });
+
+            expect(result.current.isPending).toBe(true);
+            expect(result.current.fetchStatus).toBe("idle");
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it("should throw error when fetch fails", async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+            });
+
+            const { result } = renderHook(() => usePlaylistItemPlaylists("item123"), { wrapper });
+
+            await waitFor(() => expect(result.current.isError).toBe(true));
+            expect(result.current.error?.message).toBe("プレイリストアイテムが所属するプレイリストの取得に失敗しました");
+        });
+    });
+
+    describe("useArticlePlaylists", () => {
+        it("should fetch article playlists successfully", async () => {
+            const mockData = [{ id: "1", name: "Test Playlist" }];
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockData,
+            });
+
+            const { result } = renderHook(() => useArticlePlaylists("article123"), { wrapper });
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+            expect(result.current.data).toEqual(mockData);
+            expect(global.fetch).toHaveBeenCalledWith("/api/articles/article123/playlists");
+        });
+
+        it("should not fetch when userEmail is undefined", () => {
+            const { useSession } = require("next-auth/react");
+            useSession.mockReturnValue({ data: null, status: "unauthenticated" });
+
+            const { result } = renderHook(() => useArticlePlaylists("article123"), { wrapper });
+
+            expect(result.current.isPending).toBe(true);
+            expect(result.current.fetchStatus).toBe("idle");
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it("should respect options.enabled", () => {
+            const { result } = renderHook(() => useArticlePlaylists("article123", { enabled: false }), { wrapper });
+
+            expect(result.current.isPending).toBe(true);
+            expect(result.current.fetchStatus).toBe("idle");
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it("should throw error when fetch fails", async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+            });
+
+            const { result } = renderHook(() => useArticlePlaylists("article123"), { wrapper });
+
+            await waitFor(() => expect(result.current.isError).toBe(true));
+            expect(result.current.error?.message).toBe("Failed to fetch playlists");
+        });
+    });
+
+    describe("useUpdateArticlePlaylistsMutation", () => {
+        it("should call update API and invalidate queries", async () => {
+            const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ success: true }),
+            });
+
+            const { result } = renderHook(() => useUpdateArticlePlaylistsMutation(), { wrapper });
+
+            result.current.mutate({
+                articleId: "article123",
+                addToPlaylistIds: ["p1"],
+                removeFromPlaylistIds: ["p2"],
+            });
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            expect(global.fetch).toHaveBeenCalledWith("/api/playlists/bulk_update", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    articleId: "article123",
+                    addToPlaylistIds: ["p1"],
+                    removeFromPlaylistIds: ["p2"],
+                }),
+            });
+
+            expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+                queryKey: ["article", "playlists", "article123", "test@example.com"],
+            });
+            expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+                queryKey: ["playlist-item-playlists"],
+            });
+            expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+                queryKey: ["playlists", "test@example.com"],
+            });
+        });
+
+        it("should throw error when fetch fails", async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+            });
+
+            const { result } = renderHook(() => useUpdateArticlePlaylistsMutation(), { wrapper });
+
+            result.current.mutate({
+                articleId: "article123",
+                addToPlaylistIds: ["p1"],
+                removeFromPlaylistIds: [],
+            });
+
+            await waitFor(() => expect(result.current.isError).toBe(true));
+            expect(result.current.error?.message).toBe("プレイリストの更新に失敗しました");
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `usePlaylistSelection` hooks (`usePlaylistItemPlaylists`, `useArticlePlaylists`, `useUpdateArticlePlaylistsMutation`).
📊 **Coverage:** Tests cover successful fetching, mutation, undefined user sessions, disabled hook states, and error handling for all functions.
✨ **Result:** Increased test coverage and ensured the reliability of playlist selection hooks.

---
*PR created automatically by Jules for task [5754218600906037751](https://jules.google.com/task/5754218600906037751) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`usePlaylistItemPlaylists`・`useArticlePlaylists`・`useUpdateArticlePlaylistsMutation` の 3 フックに対する単体テストを追加するPRです。フェッチ成功・失敗・未認証・`enabled` オプションのケースが概ねカバーされており、各テストのアサーションは実装と一致しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、マージは安全です。

すべての発見は P2（スタイル・カバレッジ改善提案）であり、既存動作を壊すリスクはありません。実装との整合性は確認済みで、追加テストは正しく機能します。

特になし。`usePlaylistSelection.ts` の英語エラーメッセージ（38行目）は別PRで修正を検討する価値があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx | usePlaylistSelection フックの単体テストを新規追加。正常系・エラー系・無効化ケースを網羅しており実装と整合が取れているが、`wrapper` を `beforeEach` 外で定義している点と未認証時の mutation テストが未カバーな点が改善余地あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[テスト実行] --> B[beforeEach: QueryClient生成 / モックリセット]
    B --> C{テスト対象}
    C --> D[usePlaylistItemPlaylists]
    C --> E[useArticlePlaylists]
    C --> F[useUpdateArticlePlaylistsMutation]
    D --> D1[成功]
    D --> D2[未認証]
    D --> D3[enabled=false]
    D --> D4[失敗]
    E --> E1[成功]
    E --> E2[未認証]
    E --> E3[enabled=false]
    E --> E4[失敗]
    F --> F1[成功 + invalidateQueries×3]
    F --> F2[失敗]
    F -.->|未カバー| F3[未認証時]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx
Line: 38-40

Comment:
**`wrapper` を `beforeEach` 外で定義しているパターンについて**

`wrapper` は `queryClient`（`let` 変数）を閉じ込めた関数として定義されており、呼び出し時に最新の `queryClient` を参照するため現時点では動作します。ただし、このパターンは将来的に混乱を招く可能性があります。`wrapper` を `beforeEach` 内で（または毎回生成するファクトリとして）定義するのが推奨パターンです。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx
Line: 134-171

Comment:
**未認証時のミューテーション動作がテストされていない**

`useUpdateArticlePlaylistsMutation` の `onSuccess` コールバックは、フックのクロージャから取得した `userEmail` を使って `invalidateQueries` を呼び出します（実装の 67 行目・69 行目）。`userEmail` が `undefined` の場合（未認証ユーザー）、クエリキーに `undefined` が含まれた状態でキャッシュ無効化が実行されますが、このケースに対するテストが存在しません。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/lib/hooks/__tests__/usePlaylistSelection.test.tsx
Line: 122-131

Comment:
**エラーメッセージの不整合（実装側の問題をテストが反映）**

`useArticlePlaylists` のエラーメッセージが英語（`"Failed to fetch playlists"`）であるのに対し、`usePlaylistItemPlaylists` は日本語（`"プレイリストアイテムが所属するプレイリストの取得に失敗しました"`）です。テスト自体は実装と一致しており正しいのですが、フック実装側（`usePlaylistSelection.ts` 38 行目）での統一を検討してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for usePlaylistSelection..."](https://github.com/hiroki-org/audicle/commit/87f2cc66399d8e2e1e99d98b5b382541414eb0af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29094585)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->