### PR TITLE
🧪 [Testing] Add test coverage for URL parsing in Chrome extension popup

### DIFF
--- a/packages/chrome-extension/__tests__/popup.test.js
+++ b/packages/chrome-extension/__tests__/popup.test.js
@@ -1,0 +1,31 @@
+const { getHostnameFromUrl } = require('../popup.js');
+
+describe('getHostnameFromUrl', () => {
+  beforeEach(() => {
+    // Silence console.error for expected failures in tests
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should extract hostname from valid http/https URLs', () => {
+    expect(getHostnameFromUrl('https://www.example.com/path?query=1')).toBe('www.example.com');
+    expect(getHostnameFromUrl('http://sub.domain.co.uk/')).toBe('sub.domain.co.uk');
+    expect(getHostnameFromUrl('https://localhost:3000')).toBe('localhost');
+  });
+
+  it('should return empty string for invalid URLs', () => {
+    expect(getHostnameFromUrl('not-a-url')).toBe('');
+    expect(getHostnameFromUrl('')).toBe('');
+    expect(getHostnameFromUrl(null)).toBe('');
+    expect(getHostnameFromUrl(undefined)).toBe('');
+  });
+
+  it('should handle chrome:// and other custom protocol URLs', () => {
+    expect(getHostnameFromUrl('chrome://extensions/')).toBe('extensions');
+    expect(getHostnameFromUrl('chrome-extension://abcdefghijklmnopqrstuvwxyz/')).toBe('abcdefghijklmnopqrstuvwxyz');
+    expect(getHostnameFromUrl('file:///C:/path/to/file')).toBe(''); // file protocol doesn't typically have a hostname
+  });
+});

--- a/packages/chrome-extension/popup.js
+++ b/packages/chrome-extension/popup.js
@@ -1,94 +1,4 @@
 // popup.js
-document.addEventListener("DOMContentLoaded", () => {
-  const toggleSwitch = document.getElementById("toggle-switch");
-  const pauseResumeBtn = document.getElementById("pause-resume-btn");
-  const playbackRateSlider = document.getElementById("playback-rate");
-  const playbackRateValue = document.getElementById("playback-rate-value");
-
-  // 再生速度スライダーの初期化
-  chrome.storage.local.get(["playbackRate"], (result) => {
-    const rate = result.playbackRate || 1.0;
-    playbackRateSlider.value = rate;
-    playbackRateValue.textContent = rate;
-  });
-
-  // 再生速度スライダーの変更
-  playbackRateSlider.addEventListener("input", () => {
-    const rate = parseFloat(playbackRateSlider.value);
-    playbackRateValue.textContent = rate;
-    chrome.storage.local.set({ playbackRate: rate });
-
-    // リアルタイムで再生中のオーディオに反映
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      if (tabs[0]) {
-        chrome.tabs.sendMessage(tabs[0].id, {
-          command: "updatePlaybackRate",
-          rate: rate,
-        });
-      }
-    });
-  });
-
-  // 現在のタブのURLを取得して、そのURLの状態を読み込む
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (!tabs[0]) return;
-
-    const url = tabs[0].url;
-    const hostname = getHostnameFromUrl(url);
-
-    // 無効なホスト名（空文字や'undefined'）は保存対象外として扱う
-    const isValidHostname = (h) =>
-      typeof h === "string" && h.trim() !== "" && h !== "undefined";
-
-    // URLごとの状態を読み込む
-    chrome.storage.local.get(["urlStates", "enabled"], (result) => {
-      const urlStates = result.urlStates || {};
-      // ホスト名が無効な場合はグローバルのenabledのみ使用
-      const isEnabled = isValidHostname(hostname)
-        ? hostname in urlStates
-          ? urlStates[hostname]
-          : !!result.enabled
-        : !!result.enabled;
-      toggleSwitch.checked = isEnabled;
-    });
-
-    // スイッチが操作されたら、そのURLの状態を保存
-    toggleSwitch.addEventListener("change", () => {
-      const isEnabled = toggleSwitch.checked;
-
-      // 無効なホスト名の場合は保存しない（誤って"undefined"キー等が作られるのを防ぐ）
-      if (!isValidHostname(hostname)) {
-        console.warn("popup: invalid hostname, skipping save:", hostname);
-        return;
-      }
-
-      chrome.storage.local.get(["urlStates"], (result) => {
-        const urlStates = result.urlStates || {};
-        urlStates[hostname] = isEnabled;
-        chrome.storage.local.set({ urlStates });
-      });
-    });
-  });
-
-  // 一時停止/再開ボタン
-  pauseResumeBtn.addEventListener("click", () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      if (tabs[0]) {
-        chrome.tabs.sendMessage(
-          tabs[0].id,
-          { command: "togglePauseResume" },
-          (response) => {
-            if (response && response.isPlaying !== undefined) {
-              pauseResumeBtn.textContent = response.isPlaying
-                ? "一時停止"
-                : "再開";
-            }
-          }
-        );
-      }
-    });
-  });
-});
 
 // URLからホスト名を取得するヘルパー関数
 function getHostnameFromUrl(url) {
@@ -100,4 +10,118 @@ function getHostnameFromUrl(url) {
     // 不正な URL の場合は空文字を返し、保存処理やキー作成を防ぐ
     return "";
   }
+}
+
+// テスト用にエクスポートする（Node環境の場合のみ）
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    getHostnameFromUrl
+  };
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggleSwitch = document.getElementById("toggle-switch");
+    const pauseResumeBtn = document.getElementById("pause-resume-btn");
+    const playbackRateSlider = document.getElementById("playback-rate");
+    const playbackRateValue = document.getElementById("playback-rate-value");
+
+    // 再生速度スライダーの初期化
+    if (typeof chrome !== 'undefined' && chrome.storage) {
+      chrome.storage.local.get(["playbackRate"], (result) => {
+        const rate = result.playbackRate || 1.0;
+        if (playbackRateSlider && playbackRateValue) {
+          playbackRateSlider.value = rate;
+          playbackRateValue.textContent = rate;
+        }
+      });
+    }
+
+    // 再生速度スライダーの変更
+    if (playbackRateSlider && playbackRateValue && typeof chrome !== 'undefined') {
+      playbackRateSlider.addEventListener("input", () => {
+        const rate = parseFloat(playbackRateSlider.value);
+        playbackRateValue.textContent = rate;
+        chrome.storage.local.set({ playbackRate: rate });
+
+        // リアルタイムで再生中のオーディオに反映
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          if (tabs[0]) {
+            chrome.tabs.sendMessage(tabs[0].id, {
+              command: "updatePlaybackRate",
+              rate: rate,
+            });
+          }
+        });
+      });
+    }
+
+    // 現在のタブのURLを取得して、そのURLの状態を読み込む
+    if (typeof chrome !== 'undefined' && chrome.tabs) {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (!tabs[0]) return;
+
+        const url = tabs[0].url;
+        const hostname = getHostnameFromUrl(url);
+
+        // 無効なホスト名（空文字や'undefined'）は保存対象外として扱う
+        const isValidHostname = (h) =>
+          typeof h === "string" && h.trim() !== "" && h !== "undefined";
+
+        // URLごとの状態を読み込む
+        chrome.storage.local.get(["urlStates", "enabled"], (result) => {
+          const urlStates = result.urlStates || {};
+          // ホスト名が無効な場合はグローバルのenabledのみ使用
+          const isEnabled = isValidHostname(hostname)
+            ? hostname in urlStates
+              ? urlStates[hostname]
+              : !!result.enabled
+            : !!result.enabled;
+          if (toggleSwitch) {
+            toggleSwitch.checked = isEnabled;
+          }
+        });
+
+        // スイッチが操作されたら、そのURLの状態を保存
+        if (toggleSwitch) {
+          toggleSwitch.addEventListener("change", () => {
+            const isEnabled = toggleSwitch.checked;
+
+            // 無効なホスト名の場合は保存しない（誤って"undefined"キー等が作られるのを防ぐ）
+            if (!isValidHostname(hostname)) {
+              console.warn("popup: invalid hostname, skipping save:", hostname);
+              return;
+            }
+
+            chrome.storage.local.get(["urlStates"], (result) => {
+              const urlStates = result.urlStates || {};
+              urlStates[hostname] = isEnabled;
+              chrome.storage.local.set({ urlStates });
+            });
+          });
+        }
+      });
+    }
+
+    // 一時停止/再開ボタン
+    if (pauseResumeBtn && typeof chrome !== 'undefined') {
+      pauseResumeBtn.addEventListener("click", () => {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          if (tabs[0]) {
+            chrome.tabs.sendMessage(
+              tabs[0].id,
+              { command: "togglePauseResume" },
+              (response) => {
+                if (response && response.isPlaying !== undefined) {
+                  pauseResumeBtn.textContent = response.isPlaying
+                    ? "一時停止"
+                    : "再開";
+                }
+              }
+            );
+          }
+        });
+      });
+    }
+  });
 }


### PR DESCRIPTION
🎯 **What:** Refactored `packages/chrome-extension/popup.js` to securely export the `getHostnameFromUrl` pure function for testing without breaking browser execution, and added comprehensive unit tests.
📊 **Coverage:** Covered valid HTTP/HTTPS URLs, handled invalid strings (null, undefined, non-URL), and verified behavior for custom browser protocols (chrome://, file://).
✨ **Result:** Increased test coverage for URL parsing and ensured resilient handling of edge cases without degrading project dependencies.

---
*PR created automatically by Jules for task [6378029304178188470](https://jules.google.com/task/6378029304178188470) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/chrome-extension/popup.js` の `getHostnameFromUrl` 関数をファイル先頭に移動し、Node.js 環境（Jest）でのみ `module.exports` にエクスポートするよう修正しています。あわせて `document` / `chrome` の存在チェックを追加してテスト実行時に DOM コードがスキップされるようにし、新規テストファイルで有効URL・無効URL・カスタムプロトコルの各ケースをカバーしました。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は小さく低リスク。マージしても問題ありません。

すべての残存指摘はP2（スタイル・冗長チェック）であり、機能上の問題はありません。エクスポートパターン・ガード条件ともに正しく動作します。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chrome-extension/popup.js | `getHostnameFromUrl` をファイル先頭に移動し、Node.js 環境のみで `module.exports` に追加。`document` / `chrome` の存在チェックを追加して DOM コードをテスト時にスキップ。ロジック変更なし。 |
| packages/chrome-extension/__tests__/popup.test.js | 新規テストファイル。有効 URL・無効 URL・カスタムプロトコルの3ケースをカバー。`beforeEach` で `console.error` をグローバルモックしている点が軽微な懸念。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["popup.js loaded"] --> B{"typeof module !== undefined"}
    B -- "true: Node/Jest" --> C["module.exports = getHostnameFromUrl"]
    B -- "false: Browser" --> D["No export"]
    C --> E{"typeof document !== undefined"}
    D --> E
    E -- "false: Node/Jest" --> F["Skip DOM code"]
    E -- "true: Browser" --> G["Register DOMContentLoaded listener"]
    G --> H["Check chrome API available"]
    H --> I["Call getHostnameFromUrl"]
    I --> J{"new URL succeeds"}
    J -- "Yes" --> K["Return hostname"]
    J -- "No" --> L["console.error + return empty string"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/chrome-extension/__tests__/popup.test.js
Line: 4-7

Comment:
**`console.error` のグローバルモックが予期しないエラーを隠す可能性**

`beforeEach` で `console.error` をすべてのテストに対してサイレント化しているため、テスト実装のバグ（例：予期しない例外）が発生しても気づけません。無効な URL ケースのテストケース内でのみモックするか、`jest.spyOn` の後にアサーション (`expect(console.error).toHaveBeenCalled()`) を追加してエラーが実際に呼ばれたかを検証することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/chrome-extension/popup.js
Line: 16-20

Comment:
**`module.exports` チェックが冗長**

`module.exports` は Node.js では常に `{}` (truthy) であるため、`&& module.exports` の部分は実質的に不要です。`typeof module !== 'undefined'` の確認だけで十分です。

```suggestion
if (typeof module !== 'undefined') {
  module.exports = {
    getHostnameFromUrl
  };
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for getHostnameFromUrl i..."](https://github.com/hiroki-org/audicle/commit/aeaf4b6763366724dfce3159ad34bbb02ad066cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29095086)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->