### PR TITLE
🧪 Add unit tests for /api/stats/popular GET handler

### DIFF
--- a/packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts
@@ -1,0 +1,233 @@
+
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+import { auth } from '@/lib/auth';
+import { supabase } from '@/lib/supabase';
+
+// Mock auth
+jest.mock('@/lib/auth', () => ({
+    auth: jest.fn(),
+}));
+
+// Mock Supabase chain
+const mockSelect = jest.fn().mockReturnThis();
+const mockOrder = jest.fn().mockReturnThis();
+const mockLimit = jest.fn().mockReturnThis();
+const mockGte = jest.fn().mockReturnThis();
+const mockEq = jest.fn().mockReturnThis();
+const mockQueryObj = {
+    select: mockSelect,
+    order: mockOrder,
+    limit: mockLimit,
+    gte: mockGte,
+    eq: mockEq,
+    then: jest.fn(), // Make it a thenable to mock await
+};
+
+jest.mock('@/lib/supabase', () => ({
+    supabase: {
+        from: jest.fn(() => mockQueryObj),
+    },
+}));
+
+describe('GET /api/stats/popular', () => {
+    let mockRequest: NextRequest;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Mock default successful query resolution
+        mockQueryObj.then.mockImplementation((resolve) => {
+            resolve({ data: [], error: null });
+        });
+
+        // Setup mock request
+        const url = new URL('http://localhost/api/stats/popular');
+        mockRequest = new NextRequest(url);
+
+        // Mock Date for deterministic tests
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2023-10-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        (auth as jest.Mock).mockResolvedValue(null);
+
+        const res = await GET(mockRequest);
+        expect(res.status).toBe(401);
+        const data = await res.json();
+        expect(data.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when user email is missing', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { id: '123' } });
+
+        const res = await GET(mockRequest);
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 200 with default parameters (week, limit 20)', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        const mockData = [
+            {
+                article_id: 'art1',
+                article_hash: 'hash1',
+                url: 'http://example.com/1',
+                title: 'Title 1',
+                domain: 'example.com',
+                access_count: 100,
+                unique_users: 50,
+                cache_hit_rate: 0.85,
+                is_fully_cached: true,
+                last_accessed_at: '2023-10-15T10:00:00Z'
+            }
+        ];
+
+        mockQueryObj.then.mockImplementation((resolve) => {
+            resolve({ data: mockData, error: null });
+        });
+
+        const res = await GET(mockRequest);
+
+        expect(res.status).toBe(200);
+
+        // Verify Supabase query chain
+        expect(supabase.from).toHaveBeenCalledWith('article_stats');
+        expect(mockSelect).toHaveBeenCalledWith('*');
+        expect(mockOrder).toHaveBeenCalledWith('access_count', { ascending: false });
+        expect(mockLimit).toHaveBeenCalledWith(20);
+
+        // Verify week calculation (2023-10-15 - 7 days = 2023-10-08)
+        expect(mockGte).toHaveBeenCalledWith('last_accessed_at', '2023-10-08T12:00:00.000Z');
+        expect(mockEq).not.toHaveBeenCalled();
+
+        // Verify response mapping
+        const data = await res.json();
+        expect(data.total).toBe(1);
+        expect(data.articles[0]).toEqual({
+            articleId: 'art1',
+            articleHash: 'hash1',
+            url: 'http://example.com/1',
+            title: 'Title 1',
+            domain: 'example.com',
+            accessCount: 100,
+            uniqueUsers: 50,
+            cacheHitRate: 85, // 0.85 * 100
+            isFullyCached: true,
+            lastAccessedAt: '2023-10-15T10:00:00Z'
+        });
+    });
+
+    it('handles article_id fallback to article_hash', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        mockQueryObj.then.mockImplementation((resolve) => {
+            resolve({
+                data: [{
+                    article_hash: 'hash_only',
+                    cache_hit_rate: 0
+                }],
+                error: null
+            });
+        });
+
+        const res = await GET(mockRequest);
+        const data = await res.json();
+
+        expect(data.articles[0].articleId).toBe('hash_only');
+    });
+
+    it('returns 200 with custom parameters (today, domain, custom limit)', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        const url = new URL('http://localhost/api/stats/popular?period=today&domain=test.com&limit=50');
+        const customRequest = new NextRequest(url);
+
+        const res = await GET(customRequest);
+        expect(res.status).toBe(200);
+
+        expect(mockLimit).toHaveBeenCalledWith(50);
+
+        // Verify today calculation (2023-10-15 00:00:00)
+        expect(mockGte).toHaveBeenCalledWith('last_accessed_at', '2023-10-15T00:00:00.000Z');
+        expect(mockEq).toHaveBeenCalledWith('domain', 'test.com');
+    });
+
+    it('skips gte query when period is "all"', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        const url = new URL('http://localhost/api/stats/popular?period=all');
+        const allRequest = new NextRequest(url);
+
+        const res = await GET(allRequest);
+        expect(res.status).toBe(200);
+
+        expect(mockGte).not.toHaveBeenCalled();
+    });
+
+    it('uses month period correctly', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        const url = new URL('http://localhost/api/stats/popular?period=month');
+        const monthRequest = new NextRequest(url);
+
+        const res = await GET(monthRequest);
+        expect(res.status).toBe(200);
+
+        // 2023-10-15 - 1 month = 2023-09-15
+        expect(mockGte).toHaveBeenCalledWith('last_accessed_at', '2023-09-15T12:00:00.000Z');
+    });
+
+    it('falls back to default limit when limit > 100 or <= 0 or invalid', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        const requests = [
+            new NextRequest(new URL('http://localhost/api/stats/popular?limit=150')),
+            new NextRequest(new URL('http://localhost/api/stats/popular?limit=-5')),
+            new NextRequest(new URL('http://localhost/api/stats/popular?limit=invalid')),
+        ];
+
+        for (const req of requests) {
+            jest.clearAllMocks();
+            mockQueryObj.then.mockImplementation((resolve) => resolve({ data: [], error: null }));
+
+            await GET(req);
+            expect(mockLimit).toHaveBeenCalledWith(20);
+        }
+    });
+
+    it('returns 500 when Supabase query fails', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'test@example.com' } });
+
+        mockQueryObj.then.mockImplementation((resolve) => {
+            resolve({ data: null, error: { message: 'Database error' } });
+        });
+
+        // Suppress console.error for this test
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await GET(mockRequest);
+        expect(res.status).toBe(500);
+
+        const data = await res.json();
+        expect(data.error).toBe('Failed to fetch popular articles');
+        expect(data.details).toBe('Database error');
+
+        consoleSpy.mockRestore();
+    });
+
+    it('returns 500 on unexpected exceptions', async () => {
+        (auth as jest.Mock).mockRejectedValue(new Error('Unexpected auth error'));
+
+        const res = await GET(mockRequest);
+        expect(res.status).toBe(500);
+
+        const data = await res.json();
+        expect(data.error).toBe('Internal server error');
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `/api/stats/popular` route GET handler.
📊 **Coverage:** Now covers authentication failures (401), default parameter parsing, custom parameter parsing (period, domain, limit), edge cases for limits, query builder chaining (`gte`, `eq`), and error handling (500).
✨ **Result:** Improved test coverage and reliability for the popular articles API route.

---
*PR created automatically by Jules for task [186979652363450361](https://jules.google.com/task/186979652363450361) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `/api/stats/popular` GETハンドラーのユニットテストを新規追加します。認証失敗（401）・デフォルトパラメータ・カスタムパラメータ・エラーハンドリング（500）など広範なシナリオをカバーしており、全体的に質の高いテストです。

- **P1**: `today` 期間のアサーションが `'2023-10-15T00:00:00.000Z'` とハードコードされており、実装の `setHours(0, 0, 0, 0)` はローカルタイムで動作するため、JST 等の非 UTC 環境では失敗します。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

タイムゾーン依存の P1 問題を修正すれば安全にマージできます。

テストカバレッジは広範で構造も良好ですが、`today` 期間のアサーションが UTC 固定のため、非 UTC 環境（例: JST の CI）でテストが失敗する P1 問題が残っています。修正は簡単で `todayLocal.toISOString()` を使うだけで解決できます。

packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts の 156〜158 行目（today 期間アサーション）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts | GET /api/stats/popular のユニットテストを新規追加。認証・パラメータ解析・エラーハンドリングをカバーしているが、`today` 期間のアサーションがローカルタイム依存で非 UTC 環境で失敗する P1 問題あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as route.test.ts
    participant Handler as GET handler
    participant AuthMock as auth mock
    participant SBMock as supabase mock

    Test->>AuthMock: mockResolvedValue(null)
    Test->>Handler: GET(request)
    Handler->>AuthMock: auth()
    AuthMock-->>Handler: null
    Handler-->>Test: 401 Unauthorized

    Test->>AuthMock: mockResolvedValue(session)
    Test->>Handler: GET with period and limit params
    Handler->>AuthMock: auth()
    AuthMock-->>Handler: session
    Handler->>SBMock: from().select().order().limit().gte().eq()
    SBMock-->>Handler: data or error
    Handler-->>Test: 200 or 500
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts
Line: 156-158

Comment:
**`today` 期間テストがタイムゾーン依存**

テストは `'2023-10-15T00:00:00.000Z'` という UTC 固定の文字列を検証していますが、実際のルートは `today.setHours(0, 0, 0, 0)` を**ローカルタイム**で実行します。UTC 環境（一般的な CI）では通過しますが、JST (+09:00) 環境では `setHours(0,0,0,0)` が `2023-10-15T00:00:00 JST` = `2023-10-14T15:00:00.000Z` を返すため、このアサーションは失敗します。日本語コメントが多いことから日本のタイムゾーンで動作する環境も想定されるため、注意が必要です。

```suggestion
        // Verify today calculation (2023-10-15 00:00:00 local time)
        const todayLocal = new Date('2023-10-15T12:00:00Z');
        todayLocal.setHours(0, 0, 0, 0);
        expect(mockGte).toHaveBeenCalledWith('last_accessed_at', todayLocal.toISOString());
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts
Line: 186-201

Comment:
**`limit=0` のケースが欠落**

テスト名は `limit <= 0` と記述していますが、`limit=0` のケースが含まれていません。ルート実装の条件は `parsedLimit > 0 && parsedLimit <= 100` であり、`0` は境界値として明示的にテストすべきです。

```suggestion
        const requests = [
            new NextRequest(new URL('http://localhost/api/stats/popular?limit=150')),
            new NextRequest(new URL('http://localhost/api/stats/popular?limit=0')),
            new NextRequest(new URL('http://localhost/api/stats/popular?limit=-5')),
            new NextRequest(new URL('http://localhost/api/stats/popular?limit=invalid')),
        ];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/app/api/stats/popular/__tests__/route.test.ts
Line: 13-25

Comment:
**`then` モックが `onRejected` コールバックを無視**

`mockQueryObj.then.mockImplementation((resolve) => { resolve(...) })` はシングル引数のみ受け取るため、`(resolve, reject)` という正式なシグネチャを持ちません。テスト内では `reject` を使う場面がないため現状は機能しますが、Supabase クライアントが内部的に `then` の戻り値（Promise）を参照する場合、`undefined` が返ることで予期しない挙動になる可能性があります。`Promise.resolve(...)` を返す形にするとより堅牢です。

```suggestion
const mockQueryObj = {
    select: mockSelect,
    order: mockOrder,
    limit: mockLimit,
    gte: mockGte,
    eq: mockEq,
    then: jest.fn((resolve: (v: unknown) => void) => Promise.resolve(resolve({ data: [], error: null }))),
};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for /api/stats/popu..."](https://github.com/hiroki-org/audicle/commit/3d8021163e85b57d361069c522d0f797bbdaae2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29095292)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->