### PR TITLE
🧪 test: improve getStorageProvider tests to verify returned instance types

### DIFF
--- a/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
+++ b/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
@@ -1,6 +1,3 @@
-import { R2StorageProvider } from "../r2-provider";
-import { VercelBlobProvider } from "../vercel-blob-provider";
-
 describe("getStorageProvider", () => {
   const originalEnv = process.env;
 
@@ -18,8 +15,6 @@ describe("getStorageProvider", () => {
     delete process.env.STORAGE_PROVIDER;
 
     const storageIndex = await import("../index");
-    storageIndex.resetStorageProvider(); // Ensure fresh state
-
     const provider = storageIndex.getStorageProvider();
 
     expect(provider.constructor.name).toBe("VercelBlobProvider");
@@ -29,8 +24,6 @@ describe("getStorageProvider", () => {
     process.env.STORAGE_PROVIDER = "vercel-blob";
 
     const storageIndex = await import("../index");
-    storageIndex.resetStorageProvider();
-
     const provider = storageIndex.getStorageProvider();
 
     expect(provider.constructor.name).toBe("VercelBlobProvider");
@@ -38,15 +31,12 @@ describe("getStorageProvider", () => {
 
   it('STORAGE_PROVIDERが"r2"の場合、R2StorageProviderを返すこと', async () => {
     process.env.STORAGE_PROVIDER = "r2";
-    // Dummy environment variables needed by R2StorageProvider constructor
     process.env.R2_ACCOUNT_ID = "test-account";
     process.env.R2_ACCESS_KEY_ID = "test-key";
     process.env.R2_SECRET_ACCESS_KEY = "test-secret";
     process.env.R2_BUCKET_NAME = "test-bucket";
 
     const storageIndex = await import("../index");
-    storageIndex.resetStorageProvider();
-
     const provider = storageIndex.getStorageProvider();
 
     expect(provider.constructor.name).toBe("R2StorageProvider");
@@ -60,8 +50,6 @@ describe("getStorageProvider", () => {
     process.env.R2_BUCKET_NAME = "test-bucket";
 
     const storageIndex = await import("../index");
-    storageIndex.resetStorageProvider();
-
     const provider1 = storageIndex.getStorageProvider();
     const provider2 = storageIndex.getStorageProvider();
 
@@ -76,9 +64,8 @@ describe("getStorageProvider", () => {
     process.env.R2_BUCKET_NAME = "test-bucket";
 
     const storageIndex = await import("../index");
-    storageIndex.resetStorageProvider();
-
     const provider1 = storageIndex.getStorageProvider();
+
     storageIndex.resetStorageProvider();
     const provider2 = storageIndex.getStorageProvider();
 

--- a/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
+++ b/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
@@ -1,10 +1,7 @@
-import { R2StorageProvider } from '../r2-provider';
-import { VercelBlobProvider } from '../vercel-blob-provider';
+import { R2StorageProvider } from "../r2-provider";
+import { VercelBlobProvider } from "../vercel-blob-provider";
 
-jest.mock('../r2-provider');
-jest.mock('../vercel-blob-provider');
-
-describe('getStorageProvider', () => {
+describe("getStorageProvider", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -17,84 +14,74 @@ describe('getStorageProvider', () => {
     process.env = originalEnv;
   });
 
-  it('デフォルトでVercelBlobProviderを返すこと', async () => {
+  it("デフォルトでVercelBlobProviderを返すこと", async () => {
     delete process.env.STORAGE_PROVIDER;
 
-    // dynamically import the index so it uses the mocked modules and current env vars
-    const storageIndex = await import('../index');
+    const storageIndex = await import("../index");
     storageIndex.resetStorageProvider(); // Ensure fresh state
 
     const provider = storageIndex.getStorageProvider();
 
-    const { VercelBlobProvider: MockedVercelBlobProvider } = await import('../vercel-blob-provider');
-    const { R2StorageProvider: MockedR2StorageProvider } = await import('../r2-provider');
-
-    expect(MockedVercelBlobProvider).toHaveBeenCalledTimes(1);
-    expect(MockedR2StorageProvider).not.toHaveBeenCalled();
-    // We can check if it returns an instance created by the mock
-    expect(provider).toBeDefined();
+    expect(provider.constructor.name).toBe("VercelBlobProvider");
   });
 
   it('STORAGE_PROVIDERが"vercel-blob"の場合、VercelBlobProviderを返すこと', async () => {
-    process.env.STORAGE_PROVIDER = 'vercel-blob';
+    process.env.STORAGE_PROVIDER = "vercel-blob";
 
-    const storageIndex = await import('../index');
+    const storageIndex = await import("../index");
     storageIndex.resetStorageProvider();
 
     const provider = storageIndex.getStorageProvider();
 
-    const { VercelBlobProvider: MockedVercelBlobProvider } = await import('../vercel-blob-provider');
-    const { R2StorageProvider: MockedR2StorageProvider } = await import('../r2-provider');
-
-    expect(MockedVercelBlobProvider).toHaveBeenCalledTimes(1);
-    expect(MockedR2StorageProvider).not.toHaveBeenCalled();
-    expect(provider).toBeDefined();
+    expect(provider.constructor.name).toBe("VercelBlobProvider");
   });
 
   it('STORAGE_PROVIDERが"r2"の場合、R2StorageProviderを返すこと', async () => {
-    process.env.STORAGE_PROVIDER = 'r2';
+    process.env.STORAGE_PROVIDER = "r2";
+    // Dummy environment variables needed by R2StorageProvider constructor
+    process.env.R2_ACCOUNT_ID = "test-account";
+    process.env.R2_ACCESS_KEY_ID = "test-key";
+    process.env.R2_SECRET_ACCESS_KEY = "test-secret";
+    process.env.R2_BUCKET_NAME = "test-bucket";
 
-    const storageIndex = await import('../index');
+    const storageIndex = await import("../index");
     storageIndex.resetStorageProvider();
 
     const provider = storageIndex.getStorageProvider();
 
-    const { VercelBlobProvider: MockedVercelBlobProvider } = await import('../vercel-blob-provider');
-    const { R2StorageProvider: MockedR2StorageProvider } = await import('../r2-provider');
-
-    expect(MockedR2StorageProvider).toHaveBeenCalledTimes(1);
-    expect(MockedVercelBlobProvider).not.toHaveBeenCalled();
-    expect(provider).toBeDefined();
+    expect(provider.constructor.name).toBe("R2StorageProvider");
   });
 
-  it('一度作成されたプロバイダーインスタンスをキャッシュすること', async () => {
-    process.env.STORAGE_PROVIDER = 'r2';
+  it("一度作成されたプロバイダーインスタンスをキャッシュすること", async () => {
+    process.env.STORAGE_PROVIDER = "r2";
+    process.env.R2_ACCOUNT_ID = "test-account";
+    process.env.R2_ACCESS_KEY_ID = "test-key";
+    process.env.R2_SECRET_ACCESS_KEY = "test-secret";
+    process.env.R2_BUCKET_NAME = "test-bucket";
 
-    const storageIndex = await import('../index');
+    const storageIndex = await import("../index");
     storageIndex.resetStorageProvider();
 
     const provider1 = storageIndex.getStorageProvider();
     const provider2 = storageIndex.getStorageProvider();
 
-    const { R2StorageProvider: MockedR2StorageProvider } = await import('../r2-provider');
-
-    expect(MockedR2StorageProvider).toHaveBeenCalledTimes(1);
     expect(provider1).toBe(provider2);
   });
 
-  it('resetStorageProviderが呼ばれた後、新しいインスタンスを作成すること', async () => {
-    process.env.STORAGE_PROVIDER = 'r2';
+  it("resetStorageProviderが呼ばれた後、新しいインスタンスを作成すること", async () => {
+    process.env.STORAGE_PROVIDER = "r2";
+    process.env.R2_ACCOUNT_ID = "test-account";
+    process.env.R2_ACCESS_KEY_ID = "test-key";
+    process.env.R2_SECRET_ACCESS_KEY = "test-secret";
+    process.env.R2_BUCKET_NAME = "test-bucket";
 
-    const storageIndex = await import('../index');
+    const storageIndex = await import("../index");
     storageIndex.resetStorageProvider();
 
     const provider1 = storageIndex.getStorageProvider();
     storageIndex.resetStorageProvider();
     const provider2 = storageIndex.getStorageProvider();
 
-    const { R2StorageProvider: MockedR2StorageProvider } = await import('../r2-provider');
-
-    expect(MockedR2StorageProvider).toHaveBeenCalledTimes(2);
     expect(provider1).not.toBe(provider2);
   });
 });

--- a/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
+++ b/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
@@ -1,3 +1,6 @@
+import { R2StorageProvider } from "../r2-provider";
+import { VercelBlobProvider } from "../vercel-blob-provider";
+
 describe("getStorageProvider", () => {
   const originalEnv = process.env;
 
@@ -17,7 +20,7 @@ describe("getStorageProvider", () => {
     const storageIndex = await import("../index");
     const provider = storageIndex.getStorageProvider();
 
-    expect(provider.constructor.name).toBe("VercelBlobProvider");
+    expect(provider).toBeInstanceOf(VercelBlobProvider);
   });
 
   it('STORAGE_PROVIDERが"vercel-blob"の場合、VercelBlobProviderを返すこと', async () => {
@@ -26,7 +29,7 @@ describe("getStorageProvider", () => {
     const storageIndex = await import("../index");
     const provider = storageIndex.getStorageProvider();
 
-    expect(provider.constructor.name).toBe("VercelBlobProvider");
+    expect(provider).toBeInstanceOf(VercelBlobProvider);
   });
 
   it('STORAGE_PROVIDERが"r2"の場合、R2StorageProviderを返すこと', async () => {
@@ -39,7 +42,7 @@ describe("getStorageProvider", () => {
     const storageIndex = await import("../index");
     const provider = storageIndex.getStorageProvider();
 
-    expect(provider.constructor.name).toBe("R2StorageProvider");
+    expect(provider).toBeInstanceOf(R2StorageProvider);
   });
 
   it("一度作成されたプロバイダーインスタンスをキャッシュすること", async () => {

--- a/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
+++ b/packages/web-app-vercel/lib/storage/__tests__/index.test.ts
@@ -1,6 +1,3 @@
-import { R2StorageProvider } from "../r2-provider";
-import { VercelBlobProvider } from "../vercel-blob-provider";
-
 describe("getStorageProvider", () => {
   const originalEnv = process.env;
 
@@ -18,6 +15,7 @@ describe("getStorageProvider", () => {
     delete process.env.STORAGE_PROVIDER;
 
     const storageIndex = await import("../index");
+    const { VercelBlobProvider } = await import("../vercel-blob-provider");
     const provider = storageIndex.getStorageProvider();
 
     expect(provider).toBeInstanceOf(VercelBlobProvider);
@@ -27,6 +25,7 @@ describe("getStorageProvider", () => {
     process.env.STORAGE_PROVIDER = "vercel-blob";
 
     const storageIndex = await import("../index");
+    const { VercelBlobProvider } = await import("../vercel-blob-provider");
     const provider = storageIndex.getStorageProvider();
 
     expect(provider).toBeInstanceOf(VercelBlobProvider);
@@ -40,6 +39,7 @@ describe("getStorageProvider", () => {
     process.env.R2_BUCKET_NAME = "test-bucket";
 
     const storageIndex = await import("../index");
+    const { R2StorageProvider } = await import("../r2-provider");
     const provider = storageIndex.getStorageProvider();
 
     expect(provider).toBeInstanceOf(R2StorageProvider);


### PR DESCRIPTION
🎯 **What:** Improved the testing of the `getStorageProvider` function in `lib/storage/index.ts`. Removed module mocks and verified the exact type of the returned provider using `constructor.name`.

📊 **Coverage:** Covered the scenarios where environment variables determine the provider (`VercelBlobProvider` by default, or `R2StorageProvider` when `STORAGE_PROVIDER=r2`). Added correct setup for dummy environment variables so `R2StorageProvider` does not throw an error during test instantiation.

✨ **Result:** Enhanced test coverage quality by actually ensuring that `getStorageProvider` correctly instantiates and returns the intended class instances instead of relying solely on `jest.mock` tracking.

---
*PR created automatically by Jules for task [12726866279069351165](https://jules.google.com/task/12726866279069351165) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`getStorageProvider` のテストを改善し、`jest.mock` によるモック追跡から `constructor.name` を使った実インスタンス型の検証方式に切り替えました。R2 用ダミー環境変数の追加により、実際のコンストラクタが呼び出せるようになっています。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、マージ安全です。

すべての指摘は P2（スタイル・クリーンアップ）レベルであり、テストロジック自体は正しく動作します。未使用インポートと不要な clearAllMocks の除去は任意の後続対応で問題ありません。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/storage/__tests__/index.test.ts | jest.mock を廃止し constructor.name でインスタンス型を検証する方式に変更。未使用インポート 2 行と不要な jest.clearAllMocks() 呼び出しが残存しているが、テストロジック自体は正しい。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getStorageProvider 呼び出し] --> B{storageProvider が null?}
    B -- No --> C[キャッシュ済みインスタンスを返す]
    B -- Yes --> D{STORAGE_PROVIDER === 'r2'?}
    D -- Yes --> E[new R2StorageProvider\n環境変数: R2_ACCOUNT_ID 等が必要]
    D -- No --> F[new VercelBlobProvider\nデフォルト / 'vercel-blob']
    E --> G[storageProvider にセット & 返却]
    F --> G

    subgraph テストカバレッジ
        T1[デフォルト → VercelBlobProvider]
        T2[vercel-blob → VercelBlobProvider]
        T3[r2 → R2StorageProvider]
        T4[キャッシュ検証]
        T5[reset 後に新インスタンス]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/web-app-vercel/lib/storage/__tests__/index.test.ts`, line 9 ([link](https://github.com/hiroki-org/audicle/blob/fc3654c6486842ab92e0a3fe041aa02ed48e3f35/packages/web-app-vercel/lib/storage/__tests__/index.test.ts#L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **不要な `jest.clearAllMocks()` の呼び出し**

   `jest.mock` がすべて削除されたため、`jest.clearAllMocks()` はこのテストスイートでは何もしません。ノイズを避けるため削除を検討してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/storage/__tests__/index.test.ts
   Line: 9

   Comment:
   **不要な `jest.clearAllMocks()` の呼び出し**

   `jest.mock` がすべて削除されたため、`jest.clearAllMocks()` はこのテストスイートでは何もしません。ノイズを避けるため削除を検討してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/storage/__tests__/index.test.ts
Line: 1-2

Comment:
**未使用インポートの削除**

`R2StorageProvider` および `VercelBlobProvider` は、`jest.mock` 削除後どこでも使われていません。未使用のままにしておくと linter 警告が出るため、削除することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/web-app-vercel/lib/storage/__tests__/index.test.ts
Line: 9

Comment:
**不要な `jest.clearAllMocks()` の呼び出し**

`jest.mock` がすべて削除されたため、`jest.clearAllMocks()` はこのテストスイートでは何もしません。ノイズを避けるため削除を検討してください。

```suggestion
    jest.resetModules();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: improve getStorageProvider tests t..."](https://github.com/hiroki-org/audicle/commit/fc3654c6486842ab92e0a3fe041aa02ed48e3f35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29096877)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->