### PR TITLE
🧪 Add tests for isCachedInIndex undefined chunks edge case

### DIFF
--- a/packages/web-app-vercel/lib/db/__tests__/cacheIndex.test.ts
+++ b/packages/web-app-vercel/lib/db/__tests__/cacheIndex.test.ts
@@ -41,4 +41,16 @@ describe('isCachedInIndex', () => {
         } as unknown as CacheIndex;
         expect(isCachedInIndex(mockIndex, 'hash1')).toBe(false);
     });
+
+    it('returns false if cached_chunks is undefined', () => {
+        const mockIndex = {
+            article_url: 'https://example.com',
+            voice: 'en-US-Standard-A',
+            cached_chunks: undefined,
+            completed_playback: false,
+            read_count: 0,
+            last_accessed: new Date().toISOString(),
+        } as unknown as CacheIndex;
+        expect(isCachedInIndex(mockIndex, 'hash1')).toBe(false);
+    });
 });


### PR DESCRIPTION
🎯 What: Added a missing test case for `cached_chunks` being `undefined` in `isCachedInIndex`.
📊 Coverage: Now explicitly covers the undefined array edge case handled by optional chaining.
✨ Result: Improved test coverage and reliability for cache index validation.

---
*PR created automatically by Jules for task [8411661270542563900](https://jules.google.com/task/8411661270542563900) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`isCachedInIndex` における `cached_chunks` が `undefined` の場合のエッジケーステストを追加する PR です。実装側の `?.` オプショナルチェーンが `null` と `undefined` の両方を正しく処理することを明示的にカバーしており、既存のテストパターンとも整合しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、安全にマージ可能です。

変更はテストファイルと自動生成メタデータのみ。追加されたテストケースのロジックは正確で、既存パターンと整合しています。残る指摘はファイル末尾改行欠落のみ（P2）です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/db/__tests__/cacheIndex.test.ts | `cached_chunks` が `undefined` の場合のエッジケーステストを追加。既存パターンと整合しており、ロジックは正確。ファイル末尾の改行欠落のみ軽微なスタイル問題あり。 |
| submission.txt | PR メタデータを含む自動生成ファイル。コードレビューの対象外。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isCachedInIndex(index, textHash)"] --> B{index が null?}
    B -- はい --> F["false を返す"]
    B -- いいえ --> C{cached_chunks が\nnull / undefined?}
    C -- はい --> F
    C -- いいえ --> D{cached_chunks に\ntextHash が含まれる?}
    D -- はい --> E["true を返す"]
    D -- いいえ --> F

    style F fill:#f96,color:#000
    style E fill:#6f6,color:#000
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/web-app-vercel/lib/db/__tests__/cacheIndex.test.ts
Line: 56

Comment:
**ファイル末尾の改行が欠落しています**

差分に `\ No newline at end of file` が表示されています。POSIX 標準およびほとんどのリンターは、テキストファイルの最終行に改行を要求します。

```suggestion
    });
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add undefined edge case to isCache..."](https://github.com/hiroki-org/audicle/commit/4c80a1ac58c7d9446c76f5e54fc854d240d5ea92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29098169)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->