### PR TITLE
🧪 [testing improvement] Add tests for useUserSettings hook

### DIFF
--- a/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
@@ -1,0 +1,141 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUserSettings, useUpdateUserSettingsMutation } from "../useUserSettings";
+import React from "react";
+import { useSession } from "next-auth/react";
+import type { UserSettings } from "@/types/settings";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+const mockUseSession = useSession as jest.Mock;
+global.fetch = jest.fn();
+
+describe("useUserSettings hooks", () => {
+  let queryClient: QueryClient;
+  const mockSession = {
+    data: { user: { email: "test@example.com" } },
+    status: "authenticated",
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    jest.clearAllMocks();
+    mockUseSession.mockReturnValue(mockSession);
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  describe("useUserSettings", () => {
+    it("should fetch user settings successfully", async () => {
+      const mockSettings: Partial<UserSettings> = { speed: 1.2 };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSettings,
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockSettings);
+      expect(global.fetch).toHaveBeenCalledWith("/api/settings/get");
+    });
+
+    it("should not fetch when user email is not available", async () => {
+      mockUseSession.mockReturnValueOnce({ data: null, status: "unauthenticated" });
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when API returns ok: false with custom error", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Custom fetch error" }),
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe("Custom fetch error");
+    });
+
+    it("should throw error when API returns ok: false with default error", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe("設定の取得に失敗しました");
+    });
+  });
+
+  describe("useUpdateUserSettingsMutation", () => {
+    it("should call update API and invalidate queries", async () => {
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+      const mockResponse = { success: true };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      const newSettings: Partial<UserSettings> = { speed: 1.5 };
+      result.current.mutate(newSettings as UserSettings);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(global.fetch).toHaveBeenCalledWith("/api/settings/update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newSettings),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["user-settings", "test@example.com"],
+      });
+    });
+
+    it("should throw error when API returns ok: false with custom error", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Custom update error" }),
+      });
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      const newSettings: Partial<UserSettings> = { speed: 1.5 };
+      result.current.mutate(newSettings as UserSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe("Custom update error");
+    });
+
+    it("should throw error when API returns ok: false with default error", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      });
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      const newSettings: Partial<UserSettings> = { speed: 1.5 };
+      result.current.mutate(newSettings as UserSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe("設定の保存に失敗しました");
+    });
+  });
+});

--- a/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
@@ -3,21 +3,34 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useUserSettings, useUpdateUserSettingsMutation } from "../useUserSettings";
 import React from "react";
 import { useSession } from "next-auth/react";
-import type { UserSettings } from "@/types/settings";
+import type { UpdateSettingsRequest, UserSettings } from "@/types/settings";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),
 }));
 
 const mockUseSession = useSession as jest.Mock;
-global.fetch = jest.fn();
+const originalFetch = global.fetch;
+type MutableGlobal = typeof globalThis & { fetch?: typeof fetch };
+let fetchMock: jest.MockedFunction<typeof fetch>;
 
 describe("useUserSettings hooks", () => {
   let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: React.ReactNode }) => React.ReactElement;
   const mockSession = {
     data: { user: { email: "test@example.com" } },
     status: "authenticated",
   };
+
+  beforeAll(() => {
+    if (!originalFetch) {
+      Object.defineProperty(global as MutableGlobal, "fetch", {
+        configurable: true,
+        writable: true,
+        value: jest.fn(),
+      });
+    }
+  });
 
   beforeEach(() => {
     queryClient = new QueryClient({
@@ -27,26 +40,44 @@ describe("useUserSettings hooks", () => {
       },
     });
     jest.clearAllMocks();
+    fetchMock = jest.spyOn(global, "fetch") as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockReset();
     mockUseSession.mockReturnValue(mockSession);
+    wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
   });
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  afterAll(() => {
+    if (originalFetch) {
+      (global as MutableGlobal).fetch = originalFetch;
+    } else {
+      delete (global as MutableGlobal).fetch;
+    }
+  });
 
   describe("useUserSettings", () => {
     it("should fetch user settings successfully", async () => {
-      const mockSettings: Partial<UserSettings> = { speed: 1.2 };
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      const mockSettings: UserSettings = {
+        playback_speed: 1.2,
+        voice_model: "ja-JP-Standard-B",
+        language: "ja-JP",
+        color_theme: "ocean",
+      };
+      fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => mockSettings,
-      });
+      } as Response);
 
       const { result } = renderHook(() => useUserSettings(), { wrapper });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(mockSettings);
-      expect(global.fetch).toHaveBeenCalledWith("/api/settings/get");
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/get");
     });
 
     it("should not fetch when user email is not available", async () => {
@@ -54,14 +85,14 @@ describe("useUserSettings hooks", () => {
       const { result } = renderHook(() => useUserSettings(), { wrapper });
 
       expect(result.current.fetchStatus).toBe("idle");
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it("should throw error when API returns ok: false with custom error", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      fetchMock.mockResolvedValueOnce({
         ok: false,
         json: async () => ({ error: "Custom fetch error" }),
-      });
+      } as Response);
 
       const { result } = renderHook(() => useUserSettings(), { wrapper });
 
@@ -70,10 +101,10 @@ describe("useUserSettings hooks", () => {
     });
 
     it("should throw error when API returns ok: false with default error", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      fetchMock.mockResolvedValueOnce({
         ok: false,
         json: async () => ({}),
-      });
+      } as Response);
 
       const { result } = renderHook(() => useUserSettings(), { wrapper });
 
@@ -86,19 +117,19 @@ describe("useUserSettings hooks", () => {
     it("should call update API and invalidate queries", async () => {
       const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
       const mockResponse = { success: true };
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => mockResponse,
-      });
+      } as Response);
 
       const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
 
-      const newSettings: Partial<UserSettings> = { speed: 1.5 };
-      result.current.mutate(newSettings as UserSettings);
+      const newSettings: UpdateSettingsRequest = { playback_speed: 1.5 };
+      result.current.mutate(newSettings);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(global.fetch).toHaveBeenCalledWith("/api/settings/update", {
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/update", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(newSettings),
@@ -108,31 +139,50 @@ describe("useUserSettings hooks", () => {
       });
     });
 
-    it("should throw error when API returns ok: false with custom error", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "Custom update error" }),
-      });
+    it("should invalidate unauthenticated query key when user email is not available", async () => {
+      mockUseSession.mockReturnValueOnce({ data: null, status: "unauthenticated" });
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
 
       const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
 
-      const newSettings: Partial<UserSettings> = { speed: 1.5 };
-      result.current.mutate(newSettings as UserSettings);
+      const newSettings: UpdateSettingsRequest = { playback_speed: 1.5 };
+      result.current.mutate(newSettings);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["user-settings", undefined],
+      });
+    });
+
+    it("should throw error when API returns ok: false with custom error", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Custom update error" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      const newSettings: UpdateSettingsRequest = { playback_speed: 1.5 };
+      result.current.mutate(newSettings);
 
       await waitFor(() => expect(result.current.isError).toBe(true));
       expect(result.current.error?.message).toBe("Custom update error");
     });
 
     it("should throw error when API returns ok: false with default error", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
+      fetchMock.mockResolvedValueOnce({
         ok: false,
         json: async () => ({}),
-      });
+      } as Response);
 
       const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
 
-      const newSettings: Partial<UserSettings> = { speed: 1.5 };
-      result.current.mutate(newSettings as UserSettings);
+      const newSettings: UpdateSettingsRequest = { playback_speed: 1.5 };
+      result.current.mutate(newSettings);
 
       await waitFor(() => expect(result.current.isError).toBe(true));
       expect(result.current.error?.message).toBe("設定の保存に失敗しました");

--- a/packages/web-app-vercel/lib/hooks/useUserSettings.ts
+++ b/packages/web-app-vercel/lib/hooks/useUserSettings.ts
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
-import type { UserSettings } from "@/types/settings";
+import type { UpdateSettingsRequest, UserSettings } from "@/types/settings";
 
 /**
  * ユーザー設定を取得
@@ -32,7 +32,7 @@ export function useUpdateUserSettingsMutation() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: async (settings: UserSettings) => {
+        mutationFn: async (settings: UpdateSettingsRequest) => {
             const response = await fetch("/api/settings/update", {
                 method: "PUT",
                 headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added unit tests for `useUserSettings` and `useUpdateUserSettingsMutation` hooks in `packages/web-app-vercel/lib/hooks/useUserSettings.ts`.
📊 **Coverage:** What scenarios are now tested: successful data fetching, error cases (custom and default error messages), not fetching when unauthenticated, mutation success including cache invalidation, and mutation error cases.
✨ **Result:** The improvement in test coverage: ensuring reliable configuration and state update for user settings.

---
*PR created automatically by Jules for task [772553438547116427](https://jules.google.com/task/772553438547116427) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`useUserSettings` および `useUpdateUserSettingsMutation` フックに対する新規ユニットテストを追加するPRです。成功ケース・エラーケース・未認証ケース・キャッシュ無効化など主要なシナリオはカバーされており、全体的な品質は良好です。指摘はすべてスタイルや軽微なカバレッジギャップに関するものであり、ブロッキングな問題はありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストファイルのみの変更であり、プロダクションコードへの影響はなく、マージしても安全です。

変更はテストファイル一本のみで、主要なユースケースはカバーされています。global.fetch のグローバル汚染や wrapper のスコープパターン、型キャストの粗さなど軽微な改善余地が残るものの、実際のテスト動作を壊すものではありません。

packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx — global.fetch のクリーンアップと wrapper の定義場所を見直すと将来的な保守性が上がります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx | useUserSettings / useUpdateUserSettingsMutation の新規テストファイル。主要なシナリオはカバーされているが、global.fetch のクリーンアップ不足・wrapper のスコープパターン・型キャストなど軽微な改善余地がある。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストコード
    participant RH as renderHook
    participant Hook as useUserSettings /<br/>useUpdateUserSettingsMutation
    participant QC as QueryClient
    participant Fetch as global.fetch (mock)

    Test->>RH: renderHook(() => useUserSettings(), { wrapper })
    RH->>Hook: フック初期化
    Hook->>Hook: useSession() → userEmail 取得
    alt userEmail あり
        Hook->>Fetch: fetch("/api/settings/get")
        Fetch-->>Hook: { ok: true, json: mockSettings }
        Hook-->>QC: キャッシュ保存
        QC-->>Test: isSuccess = true, data = mockSettings
    else userEmail なし
        Hook-->>Test: fetchStatus = idle (クエリ無効)
    end

    Test->>RH: renderHook(() => useUpdateUserSettingsMutation(), { wrapper })
    RH->>Hook: ミューテーション初期化
    Test->>Hook: mutate(newSettings)
    Hook->>Fetch: fetch("/api/settings/update", { method: PUT })
    alt ok: true
        Fetch-->>Hook: { ok: true, json: { success: true } }
        Hook->>QC: invalidateQueries([user-settings, userEmail])
        QC-->>Test: isSuccess = true
    else ok: false
        Fetch-->>Hook: { ok: false, json: { error: ... } }
        Hook-->>Test: isError = true, error.message
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:13
**`global.fetch` の未クリーンアップ**

`global.fetch = jest.fn()` をモジュールスコープで上書きしていますが、`afterAll` や `afterEach` でリストアしていません。Jest はテストファイルごとにモジュール環境を分離しますが、`--runInBand` 実行や将来的な設定変更でグローバル `fetch` が別のテストファイルにも影響する可能性があります。`beforeAll`/`afterAll` を使って安全に管理することを推奨します。

### Issue 2 of 4
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:32-34
**`wrapper` を `beforeEach` 外で定義している**

`wrapper` は `let queryClient` 変数をクロージャでキャプチャしており、JS の変数参照のため `beforeEach` で再代入された新しい `QueryClient` を正しく参照できます。ただし、このパターンは読み手が気づきにくく、将来的に `const queryClient = new QueryClient()` に変更されると壊れます。`wrapper` も `beforeEach` 内で毎回生成するか、`renderHook` の `wrapper` オプションにイン���インで渡すとより安全で明示的です。

### Issue 3 of 4
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:80-100
**未認証時の `invalidateQueries` キー検証テストが欠けている**

`useUpdateUserSettingsMutation` は `userEmail` をフック初期化時にキャプチャし、`onSuccess` で `invalidateQueries({ queryKey: ["user-settings", userEmail] })` を呼びます。未認証（`userEmail` が `undefined`）の状態でミューテーションが実行された場合、`["user-settings", undefined]` というキーで invalidate されるため、認証済みユーザーのキャッシュが無効化されません。`useUserSettings` 側に「未認証では fetch しない」テストがあるのと対称的に、`useUpdateUserSettingsMutation` でも未認証時のシナリオを検証するテストケースの追加を検討してください。

### Issue 4 of 4
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:101-120
**`Partial<UserSettings>` を `as UserSettings` でキャストしている**

テストデータが `Partial<UserSettings>` のため `mutate()` の引数型 `UserSettings` に合わせて型キャストしていますが、この方法では必須フィールドの欠落が TypeScript に検出されません。テスト用の完全な `UserSettings` モックオブジェクトを用意するか、実装側の `mutationFn` の引数型を `Partial<UserSettings>` に変更することを検討してください。

```suggestion
      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });

      const newSettings = { speed: 1.5 } as UserSettings;
      result.current.mutate(newSettings);

      await waitFor(() => expect(result.current.isError).toBe(true));
      expect(result.current.error?.message).toBe("Custom update error");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for useUserSettings and ..."](https://github.com/hiroki-org/audicle/commit/69fbb214cf7ff0b3d4de99d4f80cc5f505046f82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30792816)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->