### PR TITLE
🧹 Use logger instead of console.error in MobileArticleMenu

### DIFF
--- a/packages/web-app-vercel/components/MobileArticleMenu.tsx
+++ b/packages/web-app-vercel/components/MobileArticleMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
+import { logger } from "@/lib/logger";
 import {
   MoreVertical,
   ExternalLink,
@@ -80,7 +81,7 @@ export function MobileArticleMenu({
         setShowCopiedNotification(false);
       }, 2000);
     } catch (error) {
-      console.error("URLのコピーに失敗しました:", error);
+      logger.error("URLのコピーに失敗しました:", error);
     }
   };
 


### PR DESCRIPTION
🎯 **What:** The `console.error` statement in `MobileArticleMenu` has been replaced with the dedicated `logger.error` from `@/lib/logger`.
💡 **Why:** This improves the maintainability and readability of the codebase by keeping log styles and formats consistent across the application.
✅ **Verification:** Ran `npm run lint` and `npm run test` to verify changes are safe and correctly implemented.
✨ **Result:** Improved code health in `MobileArticleMenu` by standardizing error logging without changing functionality.

---
*PR created automatically by Jules for task [5083322209640900541](https://jules.google.com/task/5083322209640900541) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`MobileArticleMenu` コンポーネント内の `console.error` を、アプリ共通の `logger.error`（`@/lib/logger`）に置き換えたシンプルなクリーンアップPRです。変更は1行のみで、ロガーの型シグネチャ（`message: string, ...args: unknown[]`）とも適合しており、機能への影響はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は1行のみで、エラーハンドリングの挙動は変わらず、マージしても安全です。

置き換え先の `logger.error` は内部で同じく `console.error` を呼び出しており、動作は実質同一です。コンポーネントは `"use client"` 宣言済みでブラウザ環境前提のため、CSSスタイル付きログも問題なく機能します。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/MobileArticleMenu.tsx | `console.error` を `logger.error` に置き換えただけのシンプルな変更。ロガーの型シグネチャとも適合しており、問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザーがURLをコピーボタンをクリック] --> B[handleCopyUrl 実行]
    B --> C{navigator.clipboard.writeText}
    C -- 成功 --> D[showCopiedNotification = true]
    D --> E[2秒後に通知を非表示]
    C -- 失敗 --> F[logger.error でエラーを出力]
    F --> G[コンソールにスタイル付きエラーを表示]
```

<sub>Reviews (1): Last reviewed commit: ["Refactor MobileArticleMenu to use logger..."](https://github.com/hiroki-org/audicle/commit/9a76c0da2ab46802b13cac3a791de59077582d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30793049)</sub>

<!-- /greptile_comment -->