### PR TITLE
fix: trust workspace for Gemini workflows

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -47,6 +47,7 @@ jobs:
         id: "gemini_invoke"
         env:
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           ADDITIONAL_CONTEXT: "${{ inputs.additional_context }}"
         with:
           # Minimal config — using API key only

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -31,6 +31,7 @@ jobs:
         continue-on-error: true
         env:
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GITHUB_TOKEN: "${{ github.token }}"
           ISSUE_TITLE: "${{ github.event.pull_request.title }}"
           ISSUE_BODY: "${{ github.event.pull_request.body }}"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -41,6 +41,7 @@ jobs:
         id: "gemini_pr_review"
         env:
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           GITHUB_TOKEN: "${{ github.token }}"
           ISSUE_TITLE: "${{ github.event.pull_request.title || github.event.issue.title }}"
           ISSUE_BODY: "${{ github.event.pull_request.body || github.event.issue.body }}"

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -75,6 +75,7 @@ jobs:
                   REPOSITORY: "${{ github.repository }}"
                   AVAILABLE_LABELS: "${{ steps.get_labels.outputs.available_labels }}"
                   GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+                  GEMINI_CLI_TRUST_WORKSPACE: "true"
               with:
                   # No GCP fields - using API key only
                   gemini_api_key: "${{ secrets.GEMINI_API_KEY }}"

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -122,6 +122,7 @@ jobs:
         env:
           GITHUB_TOKEN: "" # Do NOT pass any auth tokens here since this runs on untrusted inputs
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
           ISSUE_TITLE: "${{ github.event.issue.title }}"
           ISSUE_BODY: "${{ github.event.issue.body }}"
           AVAILABLE_LABELS: "${{ steps.get_labels.outputs.available_labels }}"

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -117,11 +117,17 @@ jobs:
       - name: "Run Gemini issue analysis"
         id: "gemini_analysis"
         if: |-
-          ${{ steps.get_labels.outputs.available_labels != '' && (inputs.issues_to_triage == '' || inputs.issues_to_triage == null) }}
+          ${{
+            steps.get_labels.outputs.available_labels != '' &&
+            (inputs.issues_to_triage == '' || inputs.issues_to_triage == null) &&
+            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.issue.author_association || '')
+          }}
         uses: "google-github-actions/run-gemini-cli@v0" # ratchet:exclude
         env:
           GITHUB_TOKEN: "" # Do NOT pass any auth tokens here since this runs on untrusted inputs
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          # The CLI requires an explicit trust signal in headless Actions runs.
+          # This step is gated to repository-trusted actors above.
           GEMINI_CLI_TRUST_WORKSPACE: "true"
           ISSUE_TITLE: "${{ github.event.issue.title }}"
           ISSUE_BODY: "${{ github.event.issue.body }}"


### PR DESCRIPTION
Closes #742.

## Summary
- set GEMINI_CLI_TRUST_WORKSPACE=true for all run-gemini-cli workflow steps
- keep existing token handling and workflow permissions unchanged

## Verification
- git diff --check origin/main
- Ruby YAML parse for the touched workflow files

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

すべての `run-gemini-cli` ワークフローステップに `GEMINI_CLI_TRUST_WORKSPACE: \"true\"` 環境変数を追加することで、Gemini CLI がワークスペースを自動的に信頼できるようにした修正です。既存のトークン管理やワークフローのパーミッションは変更されていません。

- `gemini-invoke.yml`・`gemini-review.yml`・`gemini-pr-review.yml`・`gemini-triage-bulk.yml` の 4 ファイルにシンプルな 1 行追加。
- `gemini-triage.yml` にも同様の追加。ただしこのワークフローは外部ユーザーのイシュー入力を処理するため意図的に `GITHUB_TOKEN=\"\"` が設定されており、ワークスペース信頼の付与は既存のセキュリティ設計と若干矛盾する点に注意（現状は `checkout` ステップがないため実害なし）。
- `gemini-pr-review.yml` のファイル末尾の欠損改行も合わせて修正。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

全ワークフローへの変更は小さく、既存のトークン管理・パーミッション設定には一切手を加えていないため、概ねマージ安全。

5 つのワークフローすべてで変更内容は同一の 1 行追加のみで、既存の設定や権限は維持されています。唯一気になる点は `gemini-triage.yml` の設計意図との不整合で、同ワークフローは外部ユーザーのイシュー入力を untrusted として扱い `GITHUB_TOKEN` を空にしているにもかかわらず、ワークスペース信頼が付与されています。`checkout` ステップが存在しないため現状は問題になりませんが、将来の変更でリスクが顕在化する可能性があります。

.github/workflows/gemini-triage.yml — 既存のセキュリティ設計（GITHUB_TOKEN="" / untrusted inputs）との整合性を確認してください。
</details>

<details open><summary><h3>Security Review</h3></summary>

- `gemini-triage.yml` の `Run Gemini issue analysis` ステップは外部ユーザーのイシュータイトル・本文（非信頼入力）を処理するよう設計されており、`GITHUB_TOKEN: \"\"` で意図的にトークンを除外しています。今回の `GEMINI_CLI_TRUST_WORKSPACE: \"true\"` 追加は、`checkout` ステップが存在しないため現時点での直接的リスクはありませんが、将来ワークスペースに実コードが含まれた場合、`run_shell_command` ツールと組み合わさることでプロンプトインジェクションの攻撃面が広がる可能性があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/gemini-invoke.yml | actions/checkout ステップあり。GEMINI_CLI_TRUST_WORKSPACE=true を追加。ワークスペースに実際のコードが存在するため、この設定は設計上適切。 |
| .github/workflows/gemini-pr-review.yml | 非フォーク PR のみ実行（fork == false）。GEMINI_CLI_TRUST_WORKSPACE=true 追加に加え、ファイル末尾の改行も修正。 |
| .github/workflows/gemini-review.yml | GEMINI_CLI_TRUST_WORKSPACE=true を env に追加。既存の GITHUB_TOKEN・パーミッション設定に変更なし。 |
| .github/workflows/gemini-triage-bulk.yml | バルクトリアージワークフロー。checkout ステップなし。GEMINI_CLI_TRUST_WORKSPACE=true を追加。GITHUB_TOKEN は維持されている。 |
| .github/workflows/gemini-triage.yml | GEMINI_CLI_TRUST_WORKSPACE=true を追加。GITHUB_TOKEN="" の意図的なセキュリティ設計と一部矛盾するが、checkout ステップがないため現状は実害なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant WF as Workflow Runner
    participant GCL as run-gemini-cli Action
    participant API as Gemini API

    GH->>WF: issue_opened / pull_request / workflow_call
    WF->>WF: env: GEMINI_API_KEY, env: GEMINI_CLI_TRUST_WORKSPACE=true
    WF->>GCL: uses: google-github-actions/run-gemini-cli@v0
    note over GCL: ワークスペースを信頼済みとして扱う
    GCL->>API: プロンプト送信 (Gemini CLI)
    API-->>GCL: レスポンス (ラベル選択 / レビューコメント等)
    GCL-->>WF: 結果を GITHUB_ENV / outputs に書き込み
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/gemini-triage.yml:122-125
**信頼されていない入力環境での GEMINI_CLI_TRUST_WORKSPACE 追加**

このステップには `GITHUB_TOKEN: ""` と「Do NOT pass any auth tokens here since this runs on untrusted inputs」という明示的なセキュリティコメントが存在します。今回 `GEMINI_CLI_TRUST_WORKSPACE: "true"` が追加されましたが、このワークフローには `actions/checkout` ステップがないためワークスペースは空で、現時点での実害はありません。ただし、この設定は既存のセキュリティ設計の意図（外部ユーザーのイシュー本文を untrusted input として扱う）と矛盾します。将来 `checkout` ステップが追加された場合、`run_shell_command` ツールが有効な状態でワークスペース信頼が自動的に有効になり、プロンプトインジェクションの攻撃面が広がるリスクがあります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/hiroki-org/audicle/commit/8d2a0e148181949dd9806318a0c7ad76fbf8ae74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30979001)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->