### PR TITLE
fix: preserve playlist order during playback

### DIFF
--- a/packages/web-app-vercel/app/playlists/[id]/page.tsx
+++ b/packages/web-app-vercel/app/playlists/[id]/page.tsx
@@ -173,21 +173,19 @@ export default function PlaylistDetailPage() {
   const handleArticleClick = useCallback(
     (playlistItem: PlaylistItemWithArticle) => {
       if (playlistItem.article?.url && playlist?.id) {
-        // Find the index in sortedItems
         const index = sortedItems.findIndex(
           (item) => item.id === playlistItem.id
         );
-        router.push(
-          createReaderUrl({
-            articleUrl: playlistItem.article.url,
-            playlistId: playlist.id,
-            playlistIndex: index >= 0 ? index : 0,
-            autoplay: true,
-          })
+        startPlaylistPlayback(
+          playlist.id,
+          playlist.name,
+          sortedItems,
+          index >= 0 ? index : 0,
+          sortOption
         );
       }
     },
-    [router, playlist?.id, sortedItems]
+    [playlist, sortedItems, sortOption, startPlaylistPlayback]
   );
 
   if (isLoading) {
@@ -330,18 +328,12 @@ export default function PlaylistDetailPage() {
               </div>
               <button
                 onClick={() => {
-                  const firstArticleUrl =
-                    sortedItems && sortedItems.length > 0
-                      ? sortedItems[0].article?.url
-                      : undefined;
-
-                  router.push(
-                    createReaderUrl({
-                      articleUrl: firstArticleUrl,
-                      playlistId: playlist.id,
-                      playlistIndex: 0,
-                      autoplay: true,
-                    })
+                  startPlaylistPlayback(
+                    playlist.id,
+                    playlist.name,
+                    sortedItems,
+                    0,
+                    sortOption
                   );
                 }}
                 className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors flex items-center gap-2 whitespace-nowrap"

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -876,9 +876,25 @@ export default function ReaderPageClient() {
     (index: number) => {
       const len = playlistState.items.length;
       if (len === 0) return 0;
+      if (playlistState.shuffle && playlistState.shuffledIndices.length > 0) {
+        const currentShufflePos =
+          playlistState.shuffledIndices.indexOf(currentPlaylistIndex);
+        if (currentShufflePos !== -1 && index !== currentPlaylistIndex) {
+          const direction = index > currentPlaylistIndex ? 1 : -1;
+          const nextShufflePos =
+            (currentShufflePos + direction + playlistState.shuffledIndices.length) %
+            playlistState.shuffledIndices.length;
+          return playlistState.shuffledIndices[nextShufflePos];
+        }
+      }
       return ((index % len) + len) % len;
     },
-    [playlistState.items.length],
+    [
+      currentPlaylistIndex,
+      playlistState.items.length,
+      playlistState.shuffle,
+      playlistState.shuffledIndices,
+    ],
   );
 
   // 再生速度変更ハンドラー（デスクトップ版とモバイル版で共通）

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -871,23 +871,25 @@ export default function ReaderPageClient() {
     [playlistIdFromQuery, playlistState, router, currentPlaylistIndex],
   );
 
-  // プレイリストのインデックスを循環させるユーティリティ
-  const wrapIndex = useCallback(
-    (index: number) => {
+  const getAdjacentPlaylistIndex = useCallback(
+    (direction: -1 | 1) => {
       const len = playlistState.items.length;
       if (len === 0) return 0;
       if (playlistState.shuffle && playlistState.shuffledIndices.length > 0) {
         const currentShufflePos =
           playlistState.shuffledIndices.indexOf(currentPlaylistIndex);
-        if (currentShufflePos !== -1 && index !== currentPlaylistIndex) {
-          const direction = index > currentPlaylistIndex ? 1 : -1;
+        if (currentShufflePos !== -1) {
           const nextShufflePos =
             (currentShufflePos + direction + playlistState.shuffledIndices.length) %
             playlistState.shuffledIndices.length;
           return playlistState.shuffledIndices[nextShufflePos];
         }
+        logger.warn("Shuffle queue does not contain current playlist index", {
+          currentPlaylistIndex,
+          shuffledIndices: playlistState.shuffledIndices,
+        });
       }
-      return ((index % len) + len) % len;
+      return ((currentPlaylistIndex + direction) % len + len) % len;
     },
     [
       currentPlaylistIndex,
@@ -1016,8 +1018,7 @@ export default function ReaderPageClient() {
               canMovePrevious={canMovePrevious}
               canMoveNext={canMoveNext}
               navigateToPlaylistItem={navigateToPlaylistItem}
-              wrapIndex={wrapIndex}
-              currentPlaylistIndex={currentPlaylistIndex}
+              getAdjacentPlaylistIndex={getAdjacentPlaylistIndex}
               isPlaying={isPlaying}
               play={play}
               pause={pause}
@@ -1091,8 +1092,7 @@ export default function ReaderPageClient() {
           canMovePrevious={canMovePrevious}
           canMoveNext={canMoveNext}
           navigateToPlaylistItem={navigateToPlaylistItem}
-          wrapIndex={wrapIndex}
-          currentPlaylistIndex={currentPlaylistIndex}
+          getAdjacentPlaylistIndex={getAdjacentPlaylistIndex}
           isPlaying={isPlaying}
           play={play}
           pause={pause}

--- a/packages/web-app-vercel/components/DesktopPlayerControls.tsx
+++ b/packages/web-app-vercel/components/DesktopPlayerControls.tsx
@@ -22,7 +22,7 @@ const repeatModeLabels: Record<RepeatMode, string> = {
 
 export interface DesktopPlayerControlsProps {
   playbackRate: number;
-  setIsSpeedModalOpen: (open: boolean) => void;
+  setIsSpeedModalOpen: (_open: boolean) => void;
   playlistState: {
     isPlaylistMode: boolean;
     shuffle: boolean;
@@ -32,16 +32,15 @@ export interface DesktopPlayerControlsProps {
   isPlaylistContextReady: boolean;
   canMovePrevious: boolean;
   canMoveNext: boolean;
-  navigateToPlaylistItem: (index: number) => void;
-  wrapIndex: (index: number) => number;
-  currentPlaylistIndex: number;
+  navigateToPlaylistItem: (_index: number) => void;
+  getAdjacentPlaylistIndex: (_direction: -1 | 1) => number;
   isPlaying: boolean;
   play: () => void;
   pause: () => void;
   isPlaybackLoading: boolean;
   toggleRepeatMode: () => void;
   articleId: string | null;
-  setIsPlaylistModalOpen: (open: boolean) => void;
+  setIsPlaylistModalOpen: (_open: boolean) => void;
   url: string;
   startDownload: () => void;
   downloadStatus: string;
@@ -56,8 +55,7 @@ export function DesktopPlayerControls({
   canMovePrevious,
   canMoveNext,
   navigateToPlaylistItem,
-  wrapIndex,
-  currentPlaylistIndex,
+  getAdjacentPlaylistIndex,
   isPlaying,
   play,
   pause,
@@ -116,7 +114,7 @@ export function DesktopPlayerControls({
               <button
                 onClick={() => {
                   if (isPlaylistContextReady && canMovePrevious) {
-                    navigateToPlaylistItem(wrapIndex(currentPlaylistIndex - 1));
+                    navigateToPlaylistItem(getAdjacentPlaylistIndex(-1));
                   }
                 }}
                 disabled={!isPlaylistContextReady || !canMovePrevious}
@@ -159,7 +157,7 @@ export function DesktopPlayerControls({
               <button
                 onClick={() => {
                   if (isPlaylistContextReady && canMoveNext) {
-                    navigateToPlaylistItem(wrapIndex(currentPlaylistIndex + 1));
+                    navigateToPlaylistItem(getAdjacentPlaylistIndex(1));
                   }
                 }}
                 disabled={!isPlaylistContextReady || !canMoveNext}

--- a/packages/web-app-vercel/components/MobilePlayerControls.tsx
+++ b/packages/web-app-vercel/components/MobilePlayerControls.tsx
@@ -21,7 +21,7 @@ const repeatModeLabels: Record<RepeatMode, string> = {
 
 export interface MobilePlayerControlsProps {
   playbackRate: number;
-  setIsSpeedModalOpen: (open: boolean) => void;
+  setIsSpeedModalOpen: (_open: boolean) => void;
   playlistState: {
     isPlaylistMode: boolean;
     shuffle: boolean;
@@ -31,16 +31,15 @@ export interface MobilePlayerControlsProps {
   isPlaylistContextReady: boolean;
   canMovePrevious: boolean;
   canMoveNext: boolean;
-  navigateToPlaylistItem: (index: number) => void;
-  wrapIndex: (index: number) => number;
-  currentPlaylistIndex: number;
+  navigateToPlaylistItem: (_index: number) => void;
+  getAdjacentPlaylistIndex: (_direction: -1 | 1) => number;
   isPlaying: boolean;
   play: () => void;
   pause: () => void;
   isPlaybackLoading: boolean;
   toggleRepeatMode: () => void;
   articleId: string | null;
-  setIsPlaylistModalOpen: (open: boolean) => void;
+  setIsPlaylistModalOpen: (_open: boolean) => void;
   url: string;
   startDownload: () => void;
   downloadStatus: string;
@@ -55,8 +54,7 @@ export function MobilePlayerControls({
   canMovePrevious,
   canMoveNext,
   navigateToPlaylistItem,
-  wrapIndex,
-  currentPlaylistIndex,
+  getAdjacentPlaylistIndex,
   isPlaying,
   play,
   pause,
@@ -111,7 +109,7 @@ export function MobilePlayerControls({
             <button
               onClick={() => {
                 if (isPlaylistContextReady && canMovePrevious) {
-                  navigateToPlaylistItem(wrapIndex(currentPlaylistIndex - 1));
+                  navigateToPlaylistItem(getAdjacentPlaylistIndex(-1));
                 }
               }}
               disabled={!isPlaylistContextReady || !canMovePrevious}
@@ -149,7 +147,7 @@ export function MobilePlayerControls({
             <button
               onClick={() => {
                 if (isPlaylistContextReady && canMoveNext) {
-                  navigateToPlaylistItem(wrapIndex(currentPlaylistIndex + 1));
+                  navigateToPlaylistItem(getAdjacentPlaylistIndex(1));
                 }
               }}
               disabled={!isPlaylistContextReady || !canMoveNext}

--- a/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
@@ -159,5 +159,16 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
         await expect(articles.nth(0)).toContainText('Cherry');
         await expect(articles.nth(1)).toContainText('Banana');
         await expect(articles.nth(2)).toContainText('Apple');
+
+        await articles.nth(0).click();
+        await page.waitForURL(/\/reader\?/);
+        await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
+        await expect(page.getByTestId('article-title')).toContainText('Cherry');
+
+        const next = page.getByTestId('desktop-next-button');
+        const currentUrl = page.url();
+        await next.click();
+        await page.waitForURL((url) => url.toString() !== currentUrl);
+        await expect(page.getByTestId('article-title')).toContainText('Banana');
     });
 });

--- a/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
@@ -171,4 +171,34 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
         await page.waitForURL((url) => url.toString() !== currentUrl);
         await expect(page.getByTestId('article-title')).toContainText('Banana');
     });
+
+    test('シャッフル中の次へボタンがシャッフルキュー順にナビゲートする', async ({ page }) => {
+        await page.addInitScript(() => {
+            Math.random = () => 0;
+        });
+
+        await page.goto('/playlists');
+        await page.waitForSelector('a[data-testid="playlist-item"]', { state: 'visible' });
+        await page.locator('a[data-testid="playlist-item"]').filter({ hasText: 'ソートテスト用プレイリスト' }).first().click();
+        await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
+
+        const sortSelector = page.locator('[data-testid="playlist-sort-select"]');
+        await expect(sortSelector).toBeVisible({ timeout: 15000 });
+        await sortSelector.click();
+        await page.waitForSelector("text=タイトル順 (Z-A)", { state: 'visible' });
+        await page.getByRole('option', { name: 'タイトル順 (Z-A)' }).click();
+
+        const articles = page.locator('a[data-testid="playlist-article"]');
+        await expect(articles.nth(0)).toContainText('Cherry');
+        await articles.nth(0).click();
+        await page.waitForURL(/\/reader\?/);
+        await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
+        await expect(page.getByTestId('article-title')).toContainText('Cherry');
+
+        await page.getByTestId('desktop-shuffle-button').click();
+        const currentUrl = page.url();
+        await page.getByTestId('desktop-next-button').click();
+        await page.waitForURL((url) => url.toString() !== currentUrl);
+        await expect(page.getByTestId('article-title')).toContainText('Apple');
+    });
 });


### PR DESCRIPTION
Closes #741.

## Summary
- start playlist playback with the sorted items currently shown on the playlist detail page
- preserve shuffle queue navigation for prev/next controls instead of falling back to plain index +/- 1
- extend the reader playlist E2E scenario to enter the reader from a sorted playlist and move to the next item

## Verification
- git diff --check
- npm run lint -- "app/playlists/[id]/page.tsx" app/reader/ReaderClient.tsx tests/e2e/reader-playlist.spec.ts
- npm run test:e2e -- tests/e2e/reader-playlist.spec.ts --project=chromium (blocked locally: sandbox denied listening on 0.0.0.0:3000 with EPERM)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

プレイリスト詳細ページでの再生開始時に、`router.push` による直接遷移を `startPlaylistPlayback` に置き換え、現在表示中のソート済みアイテム順をコンテキストに渡すよう修正。また `wrapIndex` にシャッフルモード対応を追加し、prev/next ナビゲーションがシャッフルキューの順序に従うようになった。

- `PlaylistDetailPage` の「記事クリック」と「▶ 再生ボタン」が `sortedItems` + `sortOption` を `startPlaylistPlayback` へ渡し、プレイリストコンテキストが正しいキュー順序を保持するようになった。
- `ReaderClient` の `wrapIndex` に `shuffledIndices` を参照したシャッフルナビゲーションロジックを追加（非シャッフル時は従来通り線形ラップ）。
- E2E テストにソート済みプレイリストから Reader へ遷移し次の記事に移動するシナリオを追加した。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

コアの修正（sortedItems をコンテキストに渡す変更）は安全で、シャッフルロジックも現在のコールサイトでは正しく動作する。

`wrapIndex` のシャッフルナビゲーションは「呼び出し元が必ず `currentPlaylistIndex ± 1` を渡す」という暗黙的な契約に依存しており、この契約が破られるとシャッフルキューの位置が誤判定される。また `shuffledIndices` に現在インデックスが存在しない場合のサイレントフォールバックが、アイテム変更時などに気づかずに発生し得る。新規E2Eテストがシャッフルモードをカバーしておらず、今回の修正の重要な部分が自動保護されていない。

packages/web-app-vercel/app/reader/ReaderClient.tsx の `wrapIndex` 周辺とE2Eテストのシャッフルカバレッジを重点的に確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/playlists/[id]/page.tsx | router.push + createReaderUrl による直接遷移を startPlaylistPlayback に置き換え、ソート済みアイテムとソートキーをコンテキストに渡すよう変更。依存配列も適切に更新されており、問題なし。 |
| packages/web-app-vercel/app/reader/ReaderClient.tsx | wrapIndex にシャッフルナビゲーションロジックを追加。方向判定がコールサイトの暗黙的契約（±1）に依存しており、shuffledIndices ミス時のサイレントフォールバックも存在する。 |
| packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts | ソート済みプレイリストから Reader に入り次の記事へ移動するシナリオを追加。シャッフルモード時のナビゲーション順は未カバー。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PlaylistPage as PlaylistDetailPage
    participant Context as PlaylistPlaybackContext
    participant ReaderClient
    participant wrapIndex

    User->>PlaylistPage: ソート済みリストの記事をクリック
    PlaylistPage->>Context: startPlaylistPlayback(id, name, sortedItems, index, sortOption)
    Context->>Context: setState (items=sortedItems, shuffledIndices生成)
    Context->>ReaderClient: router.push(readerUrl)

    User->>ReaderClient: 次へボタンをクリック
    ReaderClient->>wrapIndex: wrapIndex(currentPlaylistIndex + 1)
    alt シャッフルON
        wrapIndex->>wrapIndex: shuffledIndices.indexOf(currentPlaylistIndex) で現在位置を取得
        wrapIndex->>wrapIndex: direction = index > currentPlaylistIndex ? 1 : -1
        wrapIndex-->>ReaderClient: shuffledIndices[nextShufflePos]
    else シャッフルOFF
        wrapIndex-->>ReaderClient: ((index % len) + len) % len
    end
    ReaderClient->>ReaderClient: navigateToPlaylistItem(wrappedIndex)
    ReaderClient->>ReaderClient: router.push(readerUrl with new index)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web-app-vercel/app/reader/ReaderClient.tsx:879-888
**シャッフルナビゲーションの方向判定がコールサイトの暗黙的契約に依存**

`index > currentPlaylistIndex ? 1 : -1` による方向判定は、呼び出し元が常に `currentPlaylistIndex ± 1` を渡すことを前提としています。現在のコールサイト（`wrapIndex(currentPlaylistIndex - 1)` / `wrapIndex(currentPlaylistIndex + 1)`）ではこの前提が成立しますが、将来的に異なる値が渡されると方向が誤判定されてシャッフルキューの位置が壊れます。明示的な `direction: 1 | -1` 引数を受け取るシグネチャへの変更、またはインラインコメントでの契約の明示を検討してください。

### Issue 2 of 3
packages/web-app-vercel/app/reader/ReaderClient.tsx:882-889
**シャッフルモード中に `currentPlaylistIndex` がキューに存在しない場合のサイレントフォールバック**

`shuffledIndices.indexOf(currentPlaylistIndex) === -1` の場合、シャッフルブロックが丸ごとスキップされ線形インデックス計算にフォールバックします。プレイリストアイテムが再生中に追加・削除されたり URL で直接ナビゲートされた場合に発生し得ます。`logger.warn` などで不整合を記録するか、フォールバック前に状態を再正規化することを検討してください。

### Issue 3 of 3
packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts:163-172
**シャッフルモードでのナビゲーション順が未テスト**

このPRの説明には「シャッフルキューの prev/next ナビゲーションを保持する」とありますが、新しいE2Eシナリオはシャッフルがオフの状態での線形順（Cherry→Banana）のみを検証しています。シャッフルがオンの場合に `wrapIndex` が `shuffledIndices` の順序に従って正しく動作することをカバーするシナリオが欠けており、今回の修正の核心部分が自動テストで保護されていません。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve playlist playback order"](https://github.com/hiroki-org/audicle/commit/7acc97638fc8f94924f773cfde48cfe746fa3276) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30979744)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->