### PR TITLE
fix: hide gemini dispatch on normal reviews

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -4,9 +4,6 @@ on:
   pull_request_review_comment:
     types:
       - "created"
-  pull_request_review:
-    types:
-      - "submitted"
   issues:
     types:
       - "opened"


### PR DESCRIPTION
## Summary
- stop triggering Gemini Dispatch on ordinary pull_request_review events
- keep issue, PR comment, and inline review comment command paths available for @gemini-cli

Closes #747

## Verification
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

通常の PR レビュー送信（`pull_request_review.submitted`）時に Gemini Dispatch が不要に起動していた問題を修正します。`pull_request_review` トリガーを削除することで、`@gemini-cli` コマンドが含まれないレビューによるワークフロー実行を防ぎます。

- `pull_request_review` トリガー（3行）を削除。インラインレビューコメント（`pull_request_review_comment`）、Issue/PRコメント（`issue_comment`）、Issue 開設（`issues`）の各パスは引き続き有効。
- `dispatch` ジョブの `if` 条件と `extract_command` ステップの `REQUEST` 環境変数には `github.event.review.body` / `github.event.review.author_association` への参照が残っているが、これらは常に空として評価されるため動作上の影響はなし（P2 コメント参照）。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は安全にマージ可能。トリガー1つを削除するだけで、既存の動作パスへの影響はない。

変更内容は `pull_request_review` トリガーの削除のみで、既存のコマンドパス（インラインコメント・Issue コメント・Issue 開設）はすべて維持されている。残存する `github.event.review.body` 参照はデッドコードとなるが動作を壊さない。

`dispatch` ジョブの `if` 条件（45〜46行目）と `REQUEST` 環境変数（67行目）に残る `review` 参照を将来のクリーンアップ候補として確認することを推奨。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/gemini-dispatch.yml | `pull_request_review` トリガー（`submitted`）を削除し、通常のレビュー送信時に Gemini Dispatch が起動しないよう修正。`dispatch` ジョブの `if` 条件と `extract_command` ステップに `github.event.review.body` / `github.event.review.author_association` への参照が残っているが動作上は無害。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pull_request_review_comment\n(created)"] -->|トリガー| W["gemini-dispatch workflow"]
    B["issues\n(opened / reopened)"] -->|トリガー| W
    C["issue_comment\n(created)"] -->|トリガー| W
    D["~~pull_request_review\n(submitted)~~"] -. 削除 .-> W

    W --> E{dispatch ジョブ\nif 条件チェック}
    E -->|"@gemini-cli で始まる &\nOWNER/MEMBER/COLLABORATOR"| F[コマンド抽出]
    E -->|"issues.opened / reopened"| F
    E -->|条件不一致| SKIP["スキップ (ジョブなし)"]

    F -->|"/review"| G[gemini-review.yml]
    F -->|"/triage"| H[gemini-triage.yml]
    F -->|"invoke (現在 false)"| I["gemini-invoke.yml\n(無効)"]
    F -->|"fallthrough (現在 false)"| J["fallthrough\n(無効)"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/gemini-dispatch.yml`, line 45-46 ([link](https://github.com/hiroki-org/audicle/blob/7b470100ee6985255540da1cf9a33f37a53b35b7/.github/workflows/gemini-dispatch.yml#L45-L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`review.body` / `review.author_association` への参照が残存**

   `pull_request_review` トリガーが削除されたため、`github.event.review.body` および `github.event.review.author_association` は今後どのトリガーでも値が設定されません。常に空文字列（falsy）として評価されるので動作は壊れませんが、将来のメンテナーが「`review` イベントも対応している」と誤解するリスクがあります。これらの参照を `dispatch` ジョブの `if` 条件と `extract_command` ステップの `REQUEST` 環境変数から取り除くと、意図がより明確になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/gemini-dispatch.yml
   Line: 45-46

   Comment:
   **`review.body` / `review.author_association` への参照が残存**

   `pull_request_review` トリガーが削除されたため、`github.event.review.body` および `github.event.review.author_association` は今後どのトリガーでも値が設定されません。常に空文字列（falsy）として評価されるので動作は壊れませんが、将来のメンテナーが「`review` イベントも対応している」と誤解するリスクがあります。これらの参照を `dispatch` ジョブの `if` 条件と `extract_command` ステップの `REQUEST` 環境変数から取り除くと、意図がより明確になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/gemini-dispatch.yml:45-46
**`review.body` / `review.author_association` への参照が残存**

`pull_request_review` トリガーが削除されたため、`github.event.review.body` および `github.event.review.author_association` は今後どのトリガーでも値が設定されません。常に空文字列（falsy）として評価されるので動作は壊れませんが、将来のメンテナーが「`review` イベントも対応している」と誤解するリスクがあります。これらの参照を `dispatch` ジョブの `if` 条件と `extract_command` ステップの `REQUEST` 環境変数から取り除くと、意図がより明確になります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide gemini dispatch on normal revi..."](https://github.com/hiroki-org/audicle/commit/7b470100ee6985255540da1cf9a33f37a53b35b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30981124)</sub>

<!-- /greptile_comment -->