### PR TITLE
fix: clear corrupt browser storage

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/articleStorage.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/articleStorage.test.ts
@@ -63,16 +63,79 @@ describe('articleStorage', () => {
             consoleSpy.mockRestore();
         });
 
-        it('should clear invalid article arrays', () => {
+        it('should filter invalid article entries', () => {
             const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-            localStorageMock.getItem.mockReturnValueOnce(JSON.stringify([{ id: 'missing-fields' }]));
+            const validArticle: Article = {
+                id: '1',
+                url: 'https://example.com',
+                title: 'Test Article',
+                chunks: [],
+                createdAt: '2024-01-01T00:00:00Z',
+            };
+            localStorageMock.getItem.mockReturnValueOnce(JSON.stringify([
+                validArticle,
+                { id: 'missing-fields' },
+            ]));
+
+            expect(articleStorage.getAll()).toEqual([validArticle]);
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Some articles in localStorage were invalid; filtering invalid entries'
+            );
+            expect(localStorageMock.setItem).toHaveBeenCalledWith(
+                'audicle_articles',
+                JSON.stringify([validArticle])
+            );
+            consoleSpy.mockRestore();
+        });
+
+        it('should reject articles with malformed chunks', () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+            localStorageMock.getItem.mockReturnValueOnce(JSON.stringify([
+                {
+                    id: '1',
+                    url: 'https://example.com',
+                    title: 'Test Article',
+                    chunks: [{ id: 'chunk-1', text: 'text' }],
+                    createdAt: '2024-01-01T00:00:00Z',
+                },
+            ]));
 
             expect(articleStorage.getAll()).toEqual([]);
 
             expect(consoleSpy).toHaveBeenCalledWith(
-                'Invalid articles in localStorage; clearing stored articles'
+                'Some articles in localStorage were invalid; filtering invalid entries'
+            );
+            expect(localStorageMock.setItem).toHaveBeenCalledWith('audicle_articles', '[]');
+            consoleSpy.mockRestore();
+        });
+
+        it('should clear storage when article storage is not an array', () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+            localStorageMock.getItem.mockReturnValueOnce(JSON.stringify({ invalid: 'shape' }));
+
+            expect(articleStorage.getAll()).toEqual([]);
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Invalid articles structure in localStorage; clearing stored articles'
             );
             expect(localStorageMock.removeItem).toHaveBeenCalledWith('audicle_articles');
+            consoleSpy.mockRestore();
+        });
+
+        it('should return empty array when localStorage getItem throws', () => {
+            const storageError = new Error('storage unavailable');
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+            localStorageMock.getItem.mockImplementationOnce(() => {
+                throw storageError;
+            });
+
+            expect(articleStorage.getAll()).toEqual([]);
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Failed to parse articles from localStorage',
+                storageError
+            );
             consoleSpy.mockRestore();
         });
     });

--- a/packages/web-app-vercel/lib/__tests__/articleStorage.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/articleStorage.test.ts
@@ -59,6 +59,20 @@ describe('articleStorage', () => {
             localStorageMock.getItem.mockReturnValueOnce('invalid json');
             expect(articleStorage.getAll()).toEqual([]);
             expect(consoleSpy).toHaveBeenCalled();
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('audicle_articles');
+            consoleSpy.mockRestore();
+        });
+
+        it('should clear invalid article arrays', () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+            localStorageMock.getItem.mockReturnValueOnce(JSON.stringify([{ id: 'missing-fields' }]));
+
+            expect(articleStorage.getAll()).toEqual([]);
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Invalid articles in localStorage; clearing stored articles'
+            );
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('audicle_articles');
             consoleSpy.mockRestore();
         });
     });

--- a/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
@@ -157,13 +157,14 @@ describe("local-cache", () => {
             expect(result).toBeNull();
         });
 
-        it("should return null and warn if cache structure is invalid", () => {
+        it("should clear cache and return null if cache structure is invalid", () => {
             global.localStorage.setItem(mockKey, JSON.stringify({ invalid: "data" }));
 
             const result = getArticlesCache(mockUserId);
 
             expect(result).toBeNull();
-            expect(console.warn).toHaveBeenCalledWith("Invalid cache structure detected");
+            expect(console.warn).toHaveBeenCalledWith("Invalid cache structure detected; clearing cache");
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
 
         it("should clear cache and return null if version mismatch", () => {
@@ -200,7 +201,7 @@ describe("local-cache", () => {
             expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
 
-        it("should return null and warn if payload is invalid", () => {
+        it("should clear cache and return null if payload is invalid", () => {
             global.localStorage.setItem(
                 mockKey,
                 JSON.stringify({
@@ -213,7 +214,8 @@ describe("local-cache", () => {
             const result = getArticlesCache(mockUserId);
 
             expect(result).toBeNull();
-            expect(console.warn).toHaveBeenCalledWith("Invalid cached payload structure");
+            expect(console.warn).toHaveBeenCalledWith("Invalid cached payload structure; clearing cache");
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
 
         it("should return parsed payload successfully", () => {
@@ -241,6 +243,7 @@ describe("local-cache", () => {
                 "Failed to read articles cache:",
                 expect.any(SyntaxError)
             );
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
     });
 });

--- a/packages/web-app-vercel/lib/articleStorage.ts
+++ b/packages/web-app-vercel/lib/articleStorage.ts
@@ -13,11 +13,23 @@ export interface Article {
 const STORAGE_KEY = "audicle_articles";
 
 const _clearCorruptStorage = (): void => {
+    if (typeof window === "undefined") return;
     try {
         localStorage.removeItem(STORAGE_KEY);
     } catch {
         // Ignore cleanup failures; callers can continue with an empty list.
     }
+};
+
+const _isStoredChunk = (value: unknown): value is Chunk => {
+    if (typeof value !== "object" || value === null) return false;
+    const chunk = value as Partial<Chunk>;
+    return (
+        typeof chunk.id === "string" &&
+        typeof chunk.text === "string" &&
+        typeof chunk.cleanedText === "string" &&
+        typeof chunk.type === "string"
+    );
 };
 
 const _isStoredArticle = (value: unknown): value is Article => {
@@ -28,20 +40,26 @@ const _isStoredArticle = (value: unknown): value is Article => {
         typeof article.url === "string" &&
         typeof article.title === "string" &&
         typeof article.createdAt === "string" &&
-        Array.isArray(article.chunks)
+        Array.isArray(article.chunks) &&
+        article.chunks.every(_isStoredChunk)
     );
 };
 
 const _readArticles = (): Article[] => {
     if (typeof window === "undefined") return [];
-    const data = localStorage.getItem(STORAGE_KEY);
     try {
+        const data = localStorage.getItem(STORAGE_KEY);
         if (!data) return [];
         const parsed = JSON.parse(data);
-        if (Array.isArray(parsed) && parsed.every(_isStoredArticle)) {
-            return parsed;
+        if (Array.isArray(parsed)) {
+            const validArticles = parsed.filter(_isStoredArticle);
+            if (validArticles.length !== parsed.length) {
+                console.warn("Some articles in localStorage were invalid; filtering invalid entries");
+                _writeArticles(validArticles);
+            }
+            return validArticles;
         }
-        console.warn("Invalid articles in localStorage; clearing stored articles");
+        console.warn("Invalid articles structure in localStorage; clearing stored articles");
         _clearCorruptStorage();
         return [];
     } catch (e) {

--- a/packages/web-app-vercel/lib/articleStorage.ts
+++ b/packages/web-app-vercel/lib/articleStorage.ts
@@ -12,13 +12,41 @@ export interface Article {
 
 const STORAGE_KEY = "audicle_articles";
 
+const _clearCorruptStorage = (): void => {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Ignore cleanup failures; callers can continue with an empty list.
+    }
+};
+
+const _isStoredArticle = (value: unknown): value is Article => {
+    if (typeof value !== "object" || value === null) return false;
+    const article = value as Partial<Article>;
+    return (
+        typeof article.id === "string" &&
+        typeof article.url === "string" &&
+        typeof article.title === "string" &&
+        typeof article.createdAt === "string" &&
+        Array.isArray(article.chunks)
+    );
+};
+
 const _readArticles = (): Article[] => {
     if (typeof window === "undefined") return [];
     const data = localStorage.getItem(STORAGE_KEY);
     try {
-        return data ? JSON.parse(data) : [];
+        if (!data) return [];
+        const parsed = JSON.parse(data);
+        if (Array.isArray(parsed) && parsed.every(_isStoredArticle)) {
+            return parsed;
+        }
+        console.warn("Invalid articles in localStorage; clearing stored articles");
+        _clearCorruptStorage();
+        return [];
     } catch (e) {
         console.error("Failed to parse articles from localStorage", e);
+        _clearCorruptStorage();
         return [];
     }
 };

--- a/packages/web-app-vercel/lib/local-cache.ts
+++ b/packages/web-app-vercel/lib/local-cache.ts
@@ -17,29 +17,38 @@ const CACHE_VERSION = 1;
 // Default TTL: 24 hours
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
 
+function removeCacheItem(key: string): void {
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // Ignore cleanup failures; callers already fall back to fresh data.
+    }
+}
+
 export function getArticlesCache(userId: string): CachedPlaylistData | null {
     if (typeof window === "undefined" || !userId) return null;
+    const key = `${STORAGE_KEYS.ARTICLES_CACHE}-${userId}`;
     try {
-        const key = `${STORAGE_KEYS.ARTICLES_CACHE}-${userId}`;
         const cached = localStorage.getItem(key);
         if (!cached) return null;
 
         const parsed = JSON.parse(cached);
 
         if (!isValidEnvelope(parsed)) {
-            console.warn("Invalid cache structure detected");
+            console.warn("Invalid cache structure detected; clearing cache");
+            removeCacheItem(key);
             return null;
         }
 
         if (parsed.version !== CACHE_VERSION) {
             console.warn("Cache version mismatch; clearing cache");
-            try { localStorage.removeItem(key); } catch { }
+            removeCacheItem(key);
             return null;
         }
 
         if (Date.now() - parsed.timestamp > CACHE_TTL_MS) {
             console.info("Articles cache expired; removing");
-            try { localStorage.removeItem(key); } catch { }
+            removeCacheItem(key);
             return null;
         }
 
@@ -47,10 +56,12 @@ export function getArticlesCache(userId: string): CachedPlaylistData | null {
             return parsed.payload;
         }
 
-        console.warn("Invalid cached payload structure");
+        console.warn("Invalid cached payload structure; clearing cache");
+        removeCacheItem(key);
         return null;
     } catch (error) {
         console.error("Failed to read articles cache:", error);
+        removeCacheItem(key);
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- clear malformed article list data instead of repeatedly reading broken localStorage
- clear invalid or unparsable home article cache entries so the app can refetch fresh data
- add regression coverage for corrupted article/cache storage

Closes #746

## Verification
- npm run lint -- lib/local-cache.ts lib/articleStorage.ts lib/__tests__/local-cache.test.ts lib/__tests__/articleStorage.test.ts
- npm run test -- --watchman=false --coverage=false lib/__tests__/local-cache.test.ts lib/__tests__/articleStorage.test.ts

Note: the same focused Jest run without --coverage=false passed all tests but exited non-zero because repository-wide coverage thresholds are applied to focused test runs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

壊れた localStorage データを無視して再読み込みし続ける問題を修正し、不正なデータを検出した際に該当エントリをクリアして次回起動時にフレッシュなデータを取得できるようにします。

- **`articleStorage.ts`**: `_isStoredArticle` 型ガードで記事の必須フィールドを検証し、不正データを検出したら `_clearCorruptStorage` でストレージをクリアするよう `_readArticles` を更新。
- **`local-cache.ts`**: `removeCacheItem` ヘルパーを導入し、不正構造・バージョン不一致・ペイロード不正・JSON パース失敗のすべてのエラーパスでキャッシュをクリアするよう統一。
- **テスト**: 両ファイルに `removeItem` 呼び出しを検証する新しいアサーション・ケースを追加し、リグレッションカバレッジを強化。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は概ね安全で、壊れたキャッシュデータのクリア処理を正しく実装しています。

`_isStoredArticle` が `chunks` 配列の要素型を検証しないため、`chunks` 内に不正なオブジェクトが混入していても記事がロードされてしまいます。壊れたデータをすべてのパスでクリアするメインのロジックは正確であり、テストも適切に追加されています。

`packages/web-app-vercel/lib/articleStorage.ts` の `_isStoredArticle` バリデーションロジックに注目してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/articleStorage.ts | `_isStoredArticle` と `_clearCorruptStorage` を追加し、壊れた記事データをクリアするロジックを実装。`chunks` 内部要素の型検証が省略されている点と SSR ガードの欠如が軽微な懸念点。 |
| packages/web-app-vercel/lib/local-cache.ts | `removeCacheItem` ヘルパーを導入し、すべてのエラーパスでキャッシュをクリアするよう統一。ロジックは正確で問題なし。 |
| packages/web-app-vercel/lib/__tests__/articleStorage.test.ts | 不正 JSON のケースに `removeItem` アサーションを追加し、不正配列クリアの新テストを追加。カバレッジは適切。 |
| packages/web-app-vercel/lib/__tests__/local-cache.test.ts | 不正構造・不正ペイロード・パース失敗の各ケースで `removeItem` が呼ばれることを検証する新アサーションを追加。テスト記述名も実際の振る舞いを反映するよう更新済み。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_readArticles / getArticlesCache 呼び出し] --> B{window undefined?}
    B -- Yes --> C[return empty / null]
    B -- No --> D[localStorage.getItem]
    D --> E{データが存在?}
    E -- No --> C
    E -- Yes --> F[JSON.parse]
    F --> G{SyntaxError?}
    G -- Yes --> H[console.error + removeItem
return empty/null]
    G -- No --> I{構造バリデーション
isValidEnvelope / isArray+isStoredArticle}
    I -- NG --> J[console.warn + removeItem
return empty/null]
    I -- OK --> K{バージョン / TTL / ペイロード検証}
    K -- NG --> L[console.warn/info + removeItem
return empty/null]
    K -- OK --> M[データを返す]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/lib/articleStorage.ts:23-33
`_isStoredArticle` は `chunks` がただの配列であることしか確認しておらず、各 `Chunk` 要素の型は検証していません。`chunks: [null, "bad", {}]` のような壊れたデータを持つ記事も通過してしまい、ダウンストリームのコード（音声合成や描画処理など）が予期しないデータを受け取る恐れがあります。

```suggestion
const _isStoredChunk = (value: unknown): boolean => {
    if (typeof value !== "object" || value === null) return false;
    const chunk = value as Record<string, unknown>;
    return typeof chunk.index === "number" && typeof chunk.text === "string";
};

const _isStoredArticle = (value: unknown): value is Article => {
    if (typeof value !== "object" || value === null) return false;
    const article = value as Partial<Article>;
    return (
        typeof article.id === "string" &&
        typeof article.url === "string" &&
        typeof article.title === "string" &&
        typeof article.createdAt === "string" &&
        Array.isArray(article.chunks) &&
        article.chunks.every(_isStoredChunk)
    );
};
```

### Issue 2 of 2
packages/web-app-vercel/lib/articleStorage.ts:15-21
`_clearCorruptStorage` は `typeof window === "undefined"` ガードを持っていません。`_readArticles` の最初でガードしているため現状は問題ありませんが、将来この関数を別の場所から呼び出した際に SSR 環境で `ReferenceError` が発生するリスクがあります（`try/catch` がそれを捕捉しますが、意図が不明確になります）。

```suggestion
const _clearCorruptStorage = (): void => {
    if (typeof window === "undefined") return;
    try {
        localStorage.removeItem(STORAGE_KEY);
    } catch {
        // Ignore cleanup failures; callers can continue with an empty list.
    }
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/hiroki-org/audicle/commit/f29fa79edebd0a3035d813e0d0fff776b5fd2890) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30981394)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->