### PR TITLE
fix: isolate shuffle randomness in e2e

### DIFF
--- a/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
@@ -1,6 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { clearLocalStorage } from '../helpers/testSetup';
-
 test.describe('Reader - プレイリスト関連のナビゲーション', () => {
     test.beforeEach(async ({ page }) => {
         // Mock /api/extract to return deterministic content based on URL query
@@ -173,10 +171,6 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
     });
 
     test('シャッフル中の次へボタンがシャッフルキュー順にナビゲートする', async ({ page }) => {
-        await page.addInitScript(() => {
-            Math.random = () => 0;
-        });
-
         await page.goto('/playlists');
         await page.waitForSelector('a[data-testid="playlist-item"]', { state: 'visible' });
         await page.locator('a[data-testid="playlist-item"]').filter({ hasText: 'ソートテスト用プレイリスト' }).first().click();
@@ -195,6 +189,9 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
         await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
         await expect(page.getByTestId('article-title')).toContainText('Cherry');
 
+        await page.evaluate(() => {
+            Math.random = () => 0;
+        });
         await page.getByTestId('desktop-shuffle-button').click();
         const currentUrl = page.url();
         await page.getByTestId('desktop-next-button').click();


### PR DESCRIPTION
Summary:
- avoid overriding Math.random before the playlist page and Radix select are initialized
- keep deterministic shuffle behavior by overriding Math.random immediately before clicking shuffle
- remove an unused test helper import

Verification:
- npm run lint -- tests/e2e/reader-playlist.spec.ts
- git diff --check
- npm run test:e2e -- tests/e2e/reader-playlist.spec.ts --project=chromium --grep "シャッフル中" (blocked locally: Playwright browser is not installed)

Closes #750

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

シャッフル E2E テストにおける `Math.random` オーバーライドのタイミングを修正し、Radix Select やプレイリストページの初期化に影響を与えないようにしました。

- `addInitScript`（ページロード前に全ナビゲーションに適用）を `page.evaluate`（シャッフルボタンクリック直前にのみ適用）に置き換え、初期化処理への副作用を排除しました。
- 未使用だった `clearLocalStorage` ヘルパーのインポートを削除しました。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストファイルのみへの変更で、プロダクションコードへの影響はありません。修正内容は明確でリスクはありません。

`Math.random` のオーバーライドをシャッフルボタンクリック直前に移動する変更は意図通りに機能します。シャッフルキューはボタンクリック時に同期的に計算されるため、`page.evaluate` で設定したオーバーライドは確実に有効です。未使用インポートの削除も正確です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts | シャッフルテストの `Math.random` オーバーライドを `addInitScript` から `page.evaluate` に変更し、ページ初期化前にランダム処理が汚染されないよう修正。未使用の `clearLocalStorage` インポートも削除。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: isolate shuffle randomness in e2e"](https://github.com/hiroki-org/audicle/commit/2d026864635ae74864a9663c7d80dcaa563c8f15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30983998)</sub>

<!-- /greptile_comment -->