### PR TITLE
fix: stabilize playlist audio playback

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run start"
+
 jobs:
   seed-test-db:
     name: テストデータ投入
@@ -247,11 +250,10 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
-          CI_WEB_SERVER_COMMAND: npm run start
 
   e2e-theme-fouc:
     name: E2E Theme FOUC
-    needs: [setup, seed-test-db]
+    needs: [setup, build, seed-test-db]
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -285,6 +287,11 @@ jobs:
         if: steps.playwright-cache-e2e.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
         working-directory: packages/web-app-vercel
+      - name: Download build
+        uses: actions/download-artifact@v8
+        with:
+          name: next-build
+          path: packages/web-app-vercel/.next
       - name: Run theme FOUC tests
         run: npx playwright test tests/e2e/theme-fouc.spec.ts --project=theme-fouc
         working-directory: packages/web-app-vercel
@@ -353,7 +360,6 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
-          CI_WEB_SERVER_COMMAND: npm run start
       - name: Debug - Check auth files
         run: |
           echo "=== Checking auth directory for CI-PR ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run start"
+
 jobs:
   setup:
     name: Setup
@@ -177,11 +180,18 @@ jobs:
           NODE_ENV: production
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXT_PUBLIC_AUTH_ENV: test
 
       - name: Verify Next.js output exists
         run: test -d packages/web-app-vercel/.next
-      - name: Verify Next.js output exists
-        run: test -d packages/web-app-vercel/.next
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: next-build
+          path: packages/web-app-vercel/.next
+          include-hidden-files: true
+          retention-days: 1
 
   e2e-auth:
     name: E2E Auth Setup
@@ -204,6 +214,11 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('packages/web-app-vercel/package-lock.json') }}
       - name: Create auth directory
         run: mkdir -p packages/web-app-vercel/playwright/.auth/
+      - name: Download build
+        uses: actions/download-artifact@v8
+        with:
+          name: next-build
+          path: packages/web-app-vercel/.next
       - name: Run Playwright auth setup
         run: npx playwright test --project=setup
         working-directory: packages/web-app-vercel
@@ -215,7 +230,6 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: http://localhost:3000
-          CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run build && AUTH_ENV=test npm run start"
           NODE_ENV: test
       - name: Upload auth state
         uses: actions/upload-artifact@v7
@@ -260,6 +274,12 @@ jobs:
           name: playwright-auth-state
           path: ${{ github.workspace }}/packages/web-app-vercel/playwright/.auth/
 
+      - name: Download build
+        uses: actions/download-artifact@v8
+        with:
+          name: next-build
+          path: packages/web-app-vercel/.next
+
       - name: Run e2e shard
         run: npx playwright test --shard=${{ matrix.shard }}/3 --project=${{ matrix.browser }}
         working-directory: packages/web-app-vercel
@@ -269,7 +289,6 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: http://localhost:3000
-          CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run build && AUTH_ENV=test npm run start"
 
       - name: Upload e2e test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: http://localhost:3000
+          CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run build && AUTH_ENV=test npm run start"
           NODE_ENV: test
       - name: Upload auth state
         uses: actions/upload-artifact@v7
@@ -268,6 +269,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: http://localhost:3000
+          CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run build && AUTH_ENV=test npm run start"
 
       - name: Upload e2e test results
         if: always()

--- a/packages/web-app-vercel/app/playlists/[id]/page.tsx
+++ b/packages/web-app-vercel/app/playlists/[id]/page.tsx
@@ -88,6 +88,11 @@ export default function PlaylistDetailPage() {
     });
   }, [playlist?.items, sortOption]);
 
+  const firstPlayableIndex = useMemo(
+    () => sortedItems.findIndex((item) => Boolean(item.article?.url)),
+    [sortedItems]
+  );
+
   // playlistが読み込まれたら編集フィールドを初期化
   useEffect(() => {
     if (playlist && !isEditing) {
@@ -181,19 +186,27 @@ export default function PlaylistDetailPage() {
 
   const handleArticleClick = useCallback(
     (playlistItem: PlaylistItemWithArticle) => {
-      if (playlist?.id) {
-        // Find the index in sortedItems
-        const index = sortedItems.findIndex(
-          (item) => item.id === playlistItem.id
-        );
-        startPlaylistPlayback(
-          playlist.id,
-          playlist.name,
-          sortedItems,
-          index >= 0 ? index : 0,
-          sortOption
-        );
+      if (!playlist?.id) return;
+
+      const index = sortedItems.findIndex((item) => item.id === playlistItem.id);
+      const item = index >= 0 ? sortedItems[index] : playlistItem;
+      if (index < 0 || !item.article?.url) {
+        logger.warn("プレイリスト記事クリックをスキップ: 再生可能なURLがありません", {
+          playlistId: playlist.id,
+          itemId: playlistItem.id,
+          articleId: playlistItem.article_id,
+          articleUrl: item.article?.url,
+        });
+        return;
       }
+
+      startPlaylistPlayback(
+        playlist.id,
+        playlist.name,
+        sortedItems,
+        index,
+        sortOption
+      );
     },
     [startPlaylistPlayback, playlist?.id, playlist?.name, sortedItems, sortOption]
   );
@@ -338,16 +351,17 @@ export default function PlaylistDetailPage() {
               </div>
               <button
                 onClick={() => {
-                  if (playlist && sortedItems.length > 0) {
+                  if (playlist && firstPlayableIndex >= 0) {
                     startPlaylistPlayback(
                       playlist.id,
                       playlist.name,
                       sortedItems,
-                      0,
+                      firstPlayableIndex,
                       sortOption
                     );
                   }
                 }}
+                disabled={firstPlayableIndex < 0}
                 className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors flex items-center gap-2 whitespace-nowrap"
               >
                 <Play className="size-4" />

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -10,7 +10,10 @@ import { MobilePlayerControls } from "@/components/MobilePlayerControls";
 import { PlaylistSelectorModal } from "@/components/PlaylistSelectorModal";
 import { PlaylistCompletionScreen } from "@/components/PlaylistCompletionScreen";
 import { usePlaylistPlayback } from "@/contexts/PlaylistPlaybackContext";
-import { useAudioPlayback } from "@/contexts/AudioPlaybackContext";
+import {
+  useAudioPlayback,
+  type AudioPlaybackSource,
+} from "@/contexts/AudioPlaybackContext";
 import { Chunk } from "@/types/api";
 import { Playlist } from "@/types/playlist";
 import { extractContent, parseApiErrorMessage } from "@/lib/api";
@@ -128,6 +131,9 @@ export default function ReaderPageClient() {
   const hasInitiatedAutoplayRef = useRef(false);
   // 直前に再生していた記事URLを追跡（記事切り替え時のみ停止するため）
   const prevArticleUrlRef = useRef<string>("");
+  const stopRef = useRef<() => void>(() => {});
+  const setPlaybackSourceRef =
+    useRef<((_next: AudioPlaybackSource | null) => void) | null>(null);
 
   const chunkCount = chunks.length;
 
@@ -160,6 +166,11 @@ export default function ReaderPageClient() {
     playbackRate,
     setPlaybackRate,
   } = useAudioPlayback();
+
+  useEffect(() => {
+    stopRef.current = stop;
+    setPlaybackSourceRef.current = setPlaybackSource;
+  }, [stop, setPlaybackSource]);
 
   const handleArticleEnd = useCallback(() => {
     logger.info("handleArticleEnd 呼び出し", {
@@ -265,10 +276,10 @@ export default function ReaderPageClient() {
   // コンポーネントのアンマウント時（リーダー画面から離れるとき）に再生を停止する
   useEffect(() => {
     return () => {
-      stop();
-      setPlaybackSource(null);
+      stopRef.current();
+      setPlaybackSourceRef.current?.(null);
     };
-  }, [stop, setPlaybackSource]);
+  }, []);
 
   // ダウンロード機能（モバイルメニュー用）はReaderViewに集約されています
   const { status: downloadStatus, startDownload } = useDownload({

--- a/packages/web-app-vercel/app/reader/ReaderClient.tsx
+++ b/packages/web-app-vercel/app/reader/ReaderClient.tsx
@@ -27,17 +27,7 @@ import { type DetectedLanguage } from "@/lib/languageDetector";
 import { selectVoiceModel } from "@/lib/voiceSelector";
 import { UserSettings, DEFAULT_SETTINGS } from "@/types/settings";
 import { createReaderUrl } from "@/lib/urlBuilder";
-import { zIndex } from "@/lib/zIndex";
 import { getPlaylistSortKey } from "@/lib/playlist-utils";
-
-import type { RepeatMode } from "@/contexts/PlaylistPlaybackContext";
-
-// リピートモードのラベルマップ
-const repeatModeLabels: Record<RepeatMode, string> = {
-  off: "リピート: オフ",
-  one: "リピート: 1曲",
-  all: "リピート: 全曲",
-};
 
 function convertParagraphsToChunks(htmlContent: string): {
   chunks: Chunk[];
@@ -113,6 +103,12 @@ export default function ReaderPageClient() {
   const [currentPlaylistIndex, setCurrentPlaylistIndex] = useState<number>(
     indexFromQuery ? parseInt(indexFromQuery, 10) : 0,
   );
+  const playlistIndexFromUrl =
+    indexFromQuery !== null ? parseInt(indexFromQuery, 10) : null;
+  const activePlaylistIndex =
+    playlistIndexFromUrl !== null && !Number.isNaN(playlistIndexFromUrl)
+      ? playlistIndexFromUrl
+      : currentPlaylistIndex;
   const [isPlaylistMode] = useState<boolean>(!!playlistIdFromQuery);
   const [showCompletionScreen, setShowCompletionScreen] = useState(false);
 
@@ -859,16 +855,17 @@ export default function ReaderPageClient() {
         playlistIdFromQuery,
         playlistStatePlaylistId: playlistState.playlistId,
         currentPlaylistIndex,
+        activePlaylistIndex,
         playlistStateCurrentIndex: playlistState.currentIndex,
         targetIndex: index,
         itemsLength: playlistState.items.length,
       });
 
       // 同一URLへのpushを避ける（無反応に見えるのを防ぐ）
-      if (index === currentPlaylistIndex) {
+      if (index === activePlaylistIndex) {
         logger.info("Skip navigation: same index", {
           index,
-          currentPlaylistIndex,
+          activePlaylistIndex,
         });
         return;
       }
@@ -894,10 +891,36 @@ export default function ReaderPageClient() {
           playlistIndex: index,
           autoplay: false,
         });
+        setCurrentPlaylistIndex(index);
         router.push(readerUrl);
       }
     },
-    [playlistIdFromQuery, playlistState, router, currentPlaylistIndex],
+    [playlistIdFromQuery, playlistState, router, activePlaylistIndex, currentPlaylistIndex],
+  );
+
+  const getPlaylistItemHref = useCallback(
+    (index: number) => {
+      if (
+        playlistIdFromQuery &&
+        playlistState.playlistId !== playlistIdFromQuery
+      ) {
+        return undefined;
+      }
+
+      const item = playlistState.items[index];
+      const targetPlaylistId = playlistIdFromQuery || playlistState.playlistId;
+      if (!item?.article?.url || !targetPlaylistId) {
+        return undefined;
+      }
+
+      return createReaderUrl({
+        articleUrl: item.article.url,
+        playlistId: targetPlaylistId,
+        playlistIndex: index,
+        autoplay: false,
+      });
+    },
+    [playlistIdFromQuery, playlistState.items, playlistState.playlistId],
   );
 
   // プレイリストのインデックスを循環させるユーティリティ
@@ -908,14 +931,6 @@ export default function ReaderPageClient() {
       return ((index % len) + len) % len;
     },
     [playlistState.items.length],
-  );
-
-  // 再生速度変更ハンドラー（デスクトップ版とモバイル版で共通）
-  const handlePlaybackRateChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setPlaybackRate(parseFloat(e.target.value));
-    },
-    [setPlaybackRate],
   );
 
   return (
@@ -985,7 +1000,7 @@ export default function ReaderPageClient() {
 
                 <button
                   type="submit"
-                  disabled={isLoading}
+                  disabled={isLoading || !arePlaylistsLoaded}
                   className="px-4 sm:px-6 py-1.5 sm:py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors shrink-0"
                   data-testid="extract-button"
                 >
@@ -1028,9 +1043,9 @@ export default function ReaderPageClient() {
               isPlaylistContextReady={isPlaylistContextReady}
               canMovePrevious={canMovePrevious}
               canMoveNext={canMoveNext}
-              navigateToPlaylistItem={navigateToPlaylistItem}
+              getPlaylistItemHref={getPlaylistItemHref}
               wrapIndex={wrapIndex}
-              currentPlaylistIndex={currentPlaylistIndex}
+              currentPlaylistIndex={activePlaylistIndex}
               isPlaying={isPlaying}
               play={play}
               pause={pause}
@@ -1103,9 +1118,9 @@ export default function ReaderPageClient() {
           isPlaylistContextReady={isPlaylistContextReady}
           canMovePrevious={canMovePrevious}
           canMoveNext={canMoveNext}
-          navigateToPlaylistItem={navigateToPlaylistItem}
+          getPlaylistItemHref={getPlaylistItemHref}
           wrapIndex={wrapIndex}
-          currentPlaylistIndex={currentPlaylistIndex}
+          currentPlaylistIndex={activePlaylistIndex}
           isPlaying={isPlaying}
           play={play}
           pause={pause}

--- a/packages/web-app-vercel/components/DesktopPlayerControls.tsx
+++ b/packages/web-app-vercel/components/DesktopPlayerControls.tsx
@@ -22,7 +22,7 @@ const repeatModeLabels: Record<RepeatMode, string> = {
 
 export interface DesktopPlayerControlsProps {
   playbackRate: number;
-  setIsSpeedModalOpen: (open: boolean) => void;
+  setIsSpeedModalOpen: (_open: boolean) => void;
   playlistState: {
     isPlaylistMode: boolean;
     shuffle: boolean;
@@ -32,8 +32,8 @@ export interface DesktopPlayerControlsProps {
   isPlaylistContextReady: boolean;
   canMovePrevious: boolean;
   canMoveNext: boolean;
-  navigateToPlaylistItem: (index: number) => void;
-  wrapIndex: (index: number) => number;
+  getPlaylistItemHref: (_index: number) => string | undefined;
+  wrapIndex: (_index: number) => number;
   currentPlaylistIndex: number;
   isPlaying: boolean;
   play: () => void;
@@ -41,7 +41,7 @@ export interface DesktopPlayerControlsProps {
   isPlaybackLoading: boolean;
   toggleRepeatMode: () => void;
   articleId: string | null;
-  setIsPlaylistModalOpen: (open: boolean) => void;
+  setIsPlaylistModalOpen: (_open: boolean) => void;
   url: string;
   startDownload: () => void;
   downloadStatus: string;
@@ -55,7 +55,7 @@ export function DesktopPlayerControls({
   isPlaylistContextReady,
   canMovePrevious,
   canMoveNext,
-  navigateToPlaylistItem,
+  getPlaylistItemHref,
   wrapIndex,
   currentPlaylistIndex,
   isPlaying,
@@ -69,6 +69,14 @@ export function DesktopPlayerControls({
   startDownload,
   downloadStatus,
 }: DesktopPlayerControlsProps) {
+  const previousIndex = wrapIndex(currentPlaylistIndex - 1);
+  const nextIndex = wrapIndex(currentPlaylistIndex + 1);
+  const previousHref = getPlaylistItemHref(previousIndex);
+  const nextHref = getPlaylistItemHref(nextIndex);
+  const isPreviousDisabled =
+    !isPlaylistContextReady || !canMovePrevious || !previousHref;
+  const isNextDisabled = !isPlaylistContextReady || !canMoveNext || !nextHref;
+
   return (
     <div
       className={`hidden sm:flex sm:fixed sm:bottom-0 sm:left-0 sm:right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 p-4 shadow-lg z-[${zIndex.desktopControls}]`}
@@ -113,20 +121,22 @@ export function DesktopPlayerControls({
             )}
 
             {playlistState.isPlaylistMode && (
-              <button
-                onClick={() => {
-                  if (isPlaylistContextReady && canMovePrevious) {
-                    navigateToPlaylistItem(wrapIndex(currentPlaylistIndex - 1));
-                  }
+              <a
+                href={previousHref || "#"}
+                onClick={(event) => {
+                  if (isPreviousDisabled) event.preventDefault();
                 }}
-                disabled={!isPlaylistContextReady || !canMovePrevious}
-                className="p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                aria-disabled={isPreviousDisabled}
+                tabIndex={isPreviousDisabled ? -1 : undefined}
+                className={`p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors ${
+                  isPreviousDisabled ? "opacity-50 cursor-not-allowed" : ""
+                }`}
                 data-testid="desktop-prev-button"
                 title="前の記事"
                 aria-label="前の記事"
               >
                 <SkipBack className="size-5" />
-              </button>
+              </a>
             )}
 
             <button
@@ -156,20 +166,22 @@ export function DesktopPlayerControls({
             </button>
 
             {playlistState.isPlaylistMode && (
-              <button
-                onClick={() => {
-                  if (isPlaylistContextReady && canMoveNext) {
-                    navigateToPlaylistItem(wrapIndex(currentPlaylistIndex + 1));
-                  }
+              <a
+                href={nextHref || "#"}
+                onClick={(event) => {
+                  if (isNextDisabled) event.preventDefault();
                 }}
-                disabled={!isPlaylistContextReady || !canMoveNext}
-                className="p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                aria-disabled={isNextDisabled}
+                tabIndex={isNextDisabled ? -1 : undefined}
+                className={`p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors ${
+                  isNextDisabled ? "opacity-50 cursor-not-allowed" : ""
+                }`}
                 data-testid="desktop-next-button"
                 title="次の記事"
                 aria-label="次の記事"
               >
                 <SkipForward className="size-5" />
-              </button>
+              </a>
             )}
 
             {playlistState.isPlaylistMode && (

--- a/packages/web-app-vercel/components/MobilePlayerControls.tsx
+++ b/packages/web-app-vercel/components/MobilePlayerControls.tsx
@@ -21,7 +21,7 @@ const repeatModeLabels: Record<RepeatMode, string> = {
 
 export interface MobilePlayerControlsProps {
   playbackRate: number;
-  setIsSpeedModalOpen: (open: boolean) => void;
+  setIsSpeedModalOpen: (_open: boolean) => void;
   playlistState: {
     isPlaylistMode: boolean;
     shuffle: boolean;
@@ -31,8 +31,8 @@ export interface MobilePlayerControlsProps {
   isPlaylistContextReady: boolean;
   canMovePrevious: boolean;
   canMoveNext: boolean;
-  navigateToPlaylistItem: (index: number) => void;
-  wrapIndex: (index: number) => number;
+  getPlaylistItemHref: (_index: number) => string | undefined;
+  wrapIndex: (_index: number) => number;
   currentPlaylistIndex: number;
   isPlaying: boolean;
   play: () => void;
@@ -40,7 +40,7 @@ export interface MobilePlayerControlsProps {
   isPlaybackLoading: boolean;
   toggleRepeatMode: () => void;
   articleId: string | null;
-  setIsPlaylistModalOpen: (open: boolean) => void;
+  setIsPlaylistModalOpen: (_open: boolean) => void;
   url: string;
   startDownload: () => void;
   downloadStatus: string;
@@ -54,7 +54,7 @@ export function MobilePlayerControls({
   isPlaylistContextReady,
   canMovePrevious,
   canMoveNext,
-  navigateToPlaylistItem,
+  getPlaylistItemHref,
   wrapIndex,
   currentPlaylistIndex,
   isPlaying,
@@ -68,6 +68,14 @@ export function MobilePlayerControls({
   startDownload,
   downloadStatus,
 }: MobilePlayerControlsProps) {
+  const previousIndex = wrapIndex(currentPlaylistIndex - 1);
+  const nextIndex = wrapIndex(currentPlaylistIndex + 1);
+  const previousHref = getPlaylistItemHref(previousIndex);
+  const nextHref = getPlaylistItemHref(nextIndex);
+  const isPreviousDisabled =
+    !isPlaylistContextReady || !canMovePrevious || !previousHref;
+  const isNextDisabled = !isPlaylistContextReady || !canMoveNext || !nextHref;
+
   return (
     <div
       className={`sm:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 p-4 shadow-lg z-[${zIndex.mobileControls}]`}
@@ -108,19 +116,21 @@ export function MobilePlayerControls({
           )}
 
           {playlistState.isPlaylistMode && (
-            <button
-              onClick={() => {
-                if (isPlaylistContextReady && canMovePrevious) {
-                  navigateToPlaylistItem(wrapIndex(currentPlaylistIndex - 1));
-                }
+            <a
+              href={previousHref || "#"}
+              onClick={(event) => {
+                if (isPreviousDisabled) event.preventDefault();
               }}
-              disabled={!isPlaylistContextReady || !canMovePrevious}
-              className="mr-2 p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-disabled={isPreviousDisabled}
+              tabIndex={isPreviousDisabled ? -1 : undefined}
+              className={`mr-2 p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors ${
+                isPreviousDisabled ? "opacity-50 cursor-not-allowed" : ""
+              }`}
               title="前の記事"
               aria-label="前の記事"
             >
               <SkipBack className="size-5" />
-            </button>
+            </a>
           )}
 
           <button
@@ -146,19 +156,21 @@ export function MobilePlayerControls({
           </button>
 
           {playlistState.isPlaylistMode && (
-            <button
-              onClick={() => {
-                if (isPlaylistContextReady && canMoveNext) {
-                  navigateToPlaylistItem(wrapIndex(currentPlaylistIndex + 1));
-                }
+            <a
+              href={nextHref || "#"}
+              onClick={(event) => {
+                if (isNextDisabled) event.preventDefault();
               }}
-              disabled={!isPlaylistContextReady || !canMoveNext}
-              className="ml-2 p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-disabled={isNextDisabled}
+              tabIndex={isNextDisabled ? -1 : undefined}
+              className={`ml-2 p-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors ${
+                isNextDisabled ? "opacity-50 cursor-not-allowed" : ""
+              }`}
               title="次の記事"
               aria-label="次の記事"
             >
               <SkipForward className="size-5" />
-            </button>
+            </a>
           )}
 
           {playlistState.isPlaylistMode && (

--- a/packages/web-app-vercel/contexts/AudioPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/AudioPlaybackContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useMemo, useState } from "react";
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
 import type { Chunk } from "@/types/api";
 import { usePlayback } from "@/hooks/usePlayback";
 
@@ -52,11 +52,24 @@ export function AudioPlaybackProvider({
     articleAuthor: source?.author,
     onArticleEnd: source?.onArticleEnd,
   });
+  const stopPlayback = playback.stop;
+
+  const setPlaybackSource = useCallback(
+    (next: AudioPlaybackSource | null) => {
+      if (source?.articleUrl && next?.articleUrl && source.articleUrl !== next.articleUrl) {
+        stopPlayback();
+      } else if (source && next === null) {
+        stopPlayback();
+      }
+      setSource(next);
+    },
+    [source, stopPlayback]
+  );
 
   const value: AudioPlaybackContextType = useMemo(
     () => ({
       source,
-      setSource,
+      setSource: setPlaybackSource,
       isPlaying: playback.isPlaying,
       isLoading: playback.isLoading,
       error: playback.error,
@@ -73,6 +86,7 @@ export function AudioPlaybackProvider({
     }),
     [
       source,
+      setPlaybackSource,
       playback.isPlaying,
       playback.isLoading,
       playback.error,

--- a/packages/web-app-vercel/contexts/AudioPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/AudioPlaybackContext.tsx
@@ -56,9 +56,7 @@ export function AudioPlaybackProvider({
 
   const setPlaybackSource = useCallback(
     (next: AudioPlaybackSource | null) => {
-      if (source?.articleUrl && next?.articleUrl && source.articleUrl !== next.articleUrl) {
-        stopPlayback();
-      } else if (source && next === null) {
+      if (source && (!next || source.articleUrl !== next.articleUrl)) {
         stopPlayback();
       }
       setSource(next);

--- a/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
+++ b/packages/web-app-vercel/contexts/PlaylistPlaybackContext.tsx
@@ -89,6 +89,10 @@ const PlaylistPlaybackContext = createContext<
 
 const STORAGE_KEY = STORAGE_KEYS.PLAYLIST_PLAYBACK;
 
+function isPlayablePlaylistItem(item: PlaylistItemWithArticle | undefined): boolean {
+  return Boolean(item?.article?.url);
+}
+
 /**
  * SortOptionをfieldとorderにパース
  */
@@ -230,6 +234,18 @@ export function PlaylistPlaybackProvider({
       startIndex: number = 0,
       sortKey?: string
     ) => {
+      const startItem = items[startIndex];
+      if (!playlistId || startIndex < 0 || startIndex >= items.length || !isPlayablePlaylistItem(startItem)) {
+        logger.warn("プレイリスト再生開始をスキップ: 再生可能な記事URLがありません", {
+          playlistId,
+          startIndex,
+          itemsLength: items.length,
+          articleId: startItem?.article_id,
+          articleUrl: startItem?.article?.url,
+        });
+        return;
+      }
+
       // デバッグ: 再生開始時のキュー順序を出力
       logger.info("プレイリスト再生開始", {
         playlistId,

--- a/packages/web-app-vercel/contexts/__tests__/AudioPlaybackContext.test.tsx
+++ b/packages/web-app-vercel/contexts/__tests__/AudioPlaybackContext.test.tsx
@@ -200,4 +200,55 @@ describe('AudioPlaybackContext', () => {
     contextValue.setPlaybackRate(1.5);
     expect(mockSetPlaybackRate).toHaveBeenCalledWith(1.5);
   });
+
+  it('should stop playback when switching from an empty article URL source to a different source', () => {
+    const mockStop = jest.fn();
+    mockUsePlayback.mockReturnValue({
+      isPlaying: true,
+      isLoading: false,
+      error: '',
+      currentIndex: 0,
+      currentChunkId: 'chunk-1',
+      playbackRate: 1,
+      play: jest.fn(),
+      pause: jest.fn(),
+      stop: mockStop,
+      next: jest.fn(),
+      previous: jest.fn(),
+      seekToChunk: jest.fn(),
+      setPlaybackRate: jest.fn(),
+    });
+
+    let contextValue: any;
+
+    function TestComponent() {
+      const val = useAudioPlayback();
+      React.useEffect(() => {
+        contextValue = val;
+      }, [val]);
+      return <div>Test</div>;
+    }
+
+    render(
+      <AudioPlaybackProvider>
+        <TestComponent />
+      </AudioPlaybackProvider>
+    );
+
+    act(() => {
+      contextValue.setSource({
+        chunks: [{ id: 'chunk-1', text: 'Old', cleanedText: 'Old', type: 'paragraph' as const }],
+        articleUrl: '',
+      });
+    });
+
+    act(() => {
+      contextValue.setSource({
+        chunks: [{ id: 'chunk-2', text: 'New', cleanedText: 'New', type: 'paragraph' as const }],
+        articleUrl: 'https://example.com/new',
+      });
+    });
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web-app-vercel/hooks/__tests__/usePlayback.test.ts
+++ b/packages/web-app-vercel/hooks/__tests__/usePlayback.test.ts
@@ -130,7 +130,7 @@ describe("usePlayback", () => {
     expect(mockAudioInstance.src).toBe("blob:mock-audio-url");
   });
 
-  it("複数回の再生リクエストが同時に発生した場合、2回目以降がスキップされることを確認", async () => {
+  it("複数回の再生リクエストが同時に発生した場合、最後のリクエストだけが再生状態を更新すること", async () => {
     const { audioCache } = require("@/lib/audioCache");
     const { getAudioChunk } = require("@/lib/indexedDB");
     const { logger } = require("@/lib/logger");
@@ -175,11 +175,60 @@ describe("usePlayback", () => {
       { timeout: 3000 }
     );
 
-    // 警告ログが2回呼ばれたことを確認（2回目と3回目がスキップされた）
+    // booleanロックではなくセッションIDで古いリクエストを破棄するため、スキップ警告は出ない
     const warnCalls = logger.warn.mock.calls.filter(
       (call: any[]) => call[0] === "再生リクエストが既に進行中のため、新しいリクエストをスキップします"
     );
-    expect(warnCalls.length).toBeGreaterThanOrEqual(1);
+    expect(warnCalls).toHaveLength(0);
+    expect(mockAudioInstance.playCallCount).toBe(1);
+    expect(result.current.currentIndex).toBe(0);
+  });
+
+  it("音声取得中に stop() された場合、古い取得結果を再生しないこと", async () => {
+    const { audioCache } = require("@/lib/audioCache");
+    const { getAudioChunk } = require("@/lib/indexedDB");
+
+    getAudioChunk.mockResolvedValue(null);
+    audioCache.get.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve("blob:stale-audio-url"), 100)
+        )
+    );
+
+    const mockChunks: Chunk[] = [
+      {
+        id: "chunk-1",
+        text: "テストチャンク1",
+        cleanedText: "テストチャンク1",
+        type: "paragraph",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      usePlayback({
+        chunks: mockChunks,
+        articleUrl: "https://example.com/test",
+        voiceModel: "ja-JP-Standard-B",
+      })
+    );
+
+    await act(async () => {
+      const playPromise = result.current.play();
+      result.current.stop();
+      await playPromise;
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+      },
+      { timeout: 3000 }
+    );
+
+    expect(mockAudioInstance.playCallCount).toBe(0);
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.currentIndex).toBe(-1);
   });
 
   describe('next()', () => {
@@ -772,7 +821,7 @@ describe("usePlayback", () => {
         global.MediaError = { MEDIA_ERR_SRC_NOT_SUPPORTED: 4 };
 
         if (audioInstance.onerror) {
-          audioInstance.onerror(new Event('error'));
+          await audioInstance.onerror(new Event('error'));
         }
       });
 
@@ -794,6 +843,102 @@ describe("usePlayback", () => {
 
       // 再取得が行われたことを確認（2回目の audioCache.get 呼び出し）
       expect(audioCache.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('play() が NotSupportedError を返した場合、音声を再取得して同じチャンクを再生し直すこと', async () => {
+      const { audioCache } = require("@/lib/audioCache");
+      const { getAudioChunk } = require("@/lib/indexedDB");
+      getAudioChunk.mockResolvedValue(null);
+      audioCache.get
+        .mockResolvedValueOnce("blob:stale-audio-url")
+        .mockResolvedValueOnce("blob:fresh-audio-url");
+      mockAudioInstance.play = jest
+        .fn()
+        .mockRejectedValueOnce({
+          name: "NotSupportedError",
+          message: "unsupported source",
+        })
+        .mockResolvedValue(undefined);
+
+      const mockChunks = [
+        { id: "chunk-1", text: "テスト1", cleanedText: "テスト1", type: "paragraph" },
+      ];
+
+      const { result } = renderHook(() =>
+        usePlayback({
+          chunks: mockChunks,
+          articleUrl: "https://example.com/test",
+          voiceModel: "ja-JP-Standard-B",
+        })
+      );
+
+      await act(async () => {
+        await result.current.play();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPlaying).toBe(true);
+      });
+
+      expect(mockAudioInstance.play).toHaveBeenCalledTimes(2);
+      expect(mockAudioInstance.src).toBe("blob:fresh-audio-url");
+      expect(result.current.currentIndex).toBe(0);
+      expect(result.current.error).toBe("");
+      expect(audioCache.get).toHaveBeenNthCalledWith(
+        2,
+        "テスト1",
+        "ja-JP-Standard-B",
+        "https://example.com/test",
+        true
+      );
+    });
+
+    it('play() の NotSupportedError 後の再取得に失敗した場合、次のチャンクへ進むこと', async () => {
+      const { audioCache } = require("@/lib/audioCache");
+      const { getAudioChunk } = require("@/lib/indexedDB");
+      getAudioChunk.mockResolvedValue(null);
+      audioCache.get
+        .mockResolvedValueOnce("blob:stale-audio-url")
+        .mockRejectedValueOnce(new Error("Re-fetch failed"))
+        .mockResolvedValueOnce("blob:next-audio-url");
+      mockAudioInstance.play = jest
+        .fn()
+        .mockRejectedValueOnce({
+          name: "NotSupportedError",
+          message: "unsupported source",
+        })
+        .mockResolvedValue(undefined);
+
+      const mockChunks = [
+        { id: "chunk-1", text: "テスト1", cleanedText: "テスト1", type: "paragraph" },
+        { id: "chunk-2", text: "テスト2", cleanedText: "テスト2", type: "paragraph" },
+      ];
+
+      const { result } = renderHook(() =>
+        usePlayback({
+          chunks: mockChunks,
+          articleUrl: "https://example.com/test",
+          voiceModel: "ja-JP-Standard-B",
+        })
+      );
+
+      await act(async () => {
+        await result.current.play();
+      });
+
+      await waitFor(() => {
+        expect(result.current.currentIndex).toBe(1);
+      });
+
+      expect(mockAudioInstance.src).toBe("blob:next-audio-url");
+      expect(result.current.error).toBe("一部の音声が再生できませんでした。次の部分から再開します。");
+      expect(audioCache.get).toHaveBeenNthCalledWith(
+        2,
+        "テスト1",
+        "ja-JP-Standard-B",
+        "https://example.com/test",
+        true
+      );
     });
 
     it('onerror イベントで MEDIA_ERR_SRC_NOT_SUPPORTED が発生し再取得も失敗した場合、エラーが設定されて次のチャンクへスキップすること', async () => {
@@ -836,7 +981,7 @@ describe("usePlayback", () => {
         global.MediaError = { MEDIA_ERR_SRC_NOT_SUPPORTED: 4 };
 
         if (audioInstance.onerror) {
-          audioInstance.onerror(new Event('error'));
+          await audioInstance.onerror(new Event('error'));
         }
       });
 

--- a/packages/web-app-vercel/hooks/__tests__/usePlayback.test.ts
+++ b/packages/web-app-vercel/hooks/__tests__/usePlayback.test.ts
@@ -941,6 +941,62 @@ describe("usePlayback", () => {
       );
     });
 
+    it('NotSupportedError 後の再取得中に stop() された場合、古い失敗でエラー状態を上書きしないこと', async () => {
+      const { audioCache } = require("@/lib/audioCache");
+      const { getAudioChunk } = require("@/lib/indexedDB");
+      getAudioChunk.mockResolvedValue(null);
+
+      let rejectRefetch: (_error: Error) => void = () => {};
+      audioCache.get
+        .mockResolvedValueOnce("blob:stale-audio-url")
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectRefetch = reject;
+            })
+        );
+      mockAudioInstance.play = jest
+        .fn()
+        .mockRejectedValueOnce({
+          name: "NotSupportedError",
+          message: "unsupported source",
+        })
+        .mockResolvedValue(undefined);
+
+      const mockChunks = [
+        { id: "chunk-1", text: "テスト1", cleanedText: "テスト1", type: "paragraph" },
+        { id: "chunk-2", text: "テスト2", cleanedText: "テスト2", type: "paragraph" },
+      ];
+
+      const { result } = renderHook(() =>
+        usePlayback({
+          chunks: mockChunks,
+          articleUrl: "https://example.com/test",
+          voiceModel: "ja-JP-Standard-B",
+        })
+      );
+
+      const playPromise = result.current.play();
+
+      await waitFor(() => {
+        expect(audioCache.get).toHaveBeenCalledTimes(2);
+      });
+
+      act(() => {
+        result.current.stop();
+      });
+
+      await act(async () => {
+        rejectRefetch(new Error("Re-fetch failed"));
+        await playPromise;
+      });
+
+      expect(result.current.error).toBe("");
+      expect(result.current.isPlaying).toBe(false);
+      expect(result.current.currentIndex).toBe(-1);
+      expect(audioCache.get).toHaveBeenCalledTimes(2);
+    });
+
     it('onerror イベントで MEDIA_ERR_SRC_NOT_SUPPORTED が発生し再取得も失敗した場合、エラーが設定されて次のチャンクへスキップすること', async () => {
       const { audioCache } = require("@/lib/audioCache");
       const { getAudioChunk } = require("@/lib/indexedDB");

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -498,8 +498,8 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
                 void playFromIndexRef.current(index + 1).catch((skipErr) => {
                   logger.error("次チャンクへのスキップ中にエラー", skipErr);
                 });
+                setError("一部の音声が再生できませんでした。次の部分から再開します。");
               }
-              setError("一部の音声が再生できませんでした。次の部分から再開します。");
             }
             return;
           }
@@ -521,6 +521,9 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
         onChunkChange?.(chunk.id);
       } catch (err) {
         const error = err as Error;
+        if (!isCurrentPlaybackSession(currentSessionId)) {
+          return;
+        }
 
         // AbortErrorは通常の操作で発生する可能性があるため、警告レベルで記録
         // (例: ユーザーが素早くクリック、ページ遷移、コンポーネントのアンマウント等)
@@ -545,9 +548,6 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
             chunkIndex: index,
             errorMessage: error.message,
           });
-          if (!isCurrentPlaybackSession(currentSessionId)) {
-            return;
-          }
           const audio = audioRef.current;
           if (audio) {
             audio.onended = null;
@@ -602,13 +602,13 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
             }
           } catch (refetchErr2) {
             logger.warn(`⚠️ NotSupportedError後の再取得失敗: チャンク ${index + 1}、次のチャンクへスキップします。`, refetchErr2);
-            setIsPlaying(false);
             if (isCurrentPlaybackSession(currentSessionId)) {
+              setIsPlaying(false);
               void playFromIndexRef.current(index + 1).catch((skipErr) => {
                 logger.error("次チャンクへのスキップ中にエラー", skipErr);
               });
+              setError("一部の音声が再生できませんでした。次の部分から再開します。");
             }
-            setError("一部の音声が再生できませんでした。次の部分から再開します。");
           }
         } else {
           setError(

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -63,8 +63,8 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const currentAudioUrlRef = useRef<string | null>(null);
   const onArticleEndRef = useRef<(() => void) | undefined>(onArticleEnd);
-  // 再生処理が進行中かどうかを追跡するフラグ
-  const isPlayingRequestInProgressRef = useRef<boolean>(false);
+  // 非同期の音声取得・再生開始を世代管理し、古い処理の状態更新を防ぐ
+  const playbackSessionIdRef = useRef<number>(0);
   // `playFromIndex` と `handleAudioEnded` の間の循環参照を解決するためのRef。
   // `handleAudioEnded` は `useCallback` でメモ化されていますが、内部で `playFromIndex` を呼び出す必要があります。
   // `playFromIndex` も `handleAudioEnded` に依存しているため、単純に依存配列に加えると循環参照が発生します。
@@ -114,7 +114,10 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
   }, []);
 
   // onended ハンドラを共通化
-  const handleAudioEnded = useCallback(async (currentIndex: number) => {
+  const handleAudioEnded = useCallback(async (currentIndex: number, sessionId: number) => {
+    if (playbackSessionIdRef.current !== sessionId) {
+      return;
+    }
     if (currentIndex < 0 || currentIndex >= chunks.length) {
       logger.warn("handleAudioEnded called with invalid index", {
         currentIndex,
@@ -132,6 +135,10 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       }
     }
 
+    if (playbackSessionIdRef.current !== sessionId) {
+      return;
+    }
+
     // 次のチャンクがあれば自動的に再生
     if (currentIndex + 1 < chunks.length) {
       // onended からの連続再生は await せず非同期で開始
@@ -144,6 +151,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       // 最後のチャンク終了時も URL を解放
       if (currentAudioUrlRef.current?.startsWith('blob:')) {
         URL.revokeObjectURL(currentAudioUrlRef.current);
+        currentAudioUrlRef.current = null;
       }
       setIsPlaying(false);
       setCurrentIndex(-1);
@@ -169,6 +177,17 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       onArticleEndRef.current?.();
     }
   }, [chunks, setIsPlaying, setCurrentIndex, articleUrl, voiceModel]);
+
+  const isCurrentPlaybackSession = useCallback((sessionId: number) => {
+    return playbackSessionIdRef.current === sessionId;
+  }, []);
+
+  const releaseCurrentAudioUrl = useCallback(() => {
+    if (currentAudioUrlRef.current?.startsWith("blob:")) {
+      URL.revokeObjectURL(currentAudioUrlRef.current);
+    }
+    currentAudioUrlRef.current = null;
+  }, []);
 
   const updateMediaSessionPositionState = useCallback(() => {
     if (!("mediaSession" in navigator)) return;
@@ -262,8 +281,21 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       if (articleUrl && !forceRegenerate) {
         const cachedChunk = await getAudioChunk(articleUrl, index, voiceModel);
         if (cachedChunk) {
+          logger.info("✅ IndexedDB: キャッシュヒット", {
+            articleUrl,
+            chunkIndex: index,
+            voiceModel,
+          });
           return URL.createObjectURL(cachedChunk.audioData);
         }
+        logger.info("💾 IndexedDB: キャッシュミス", {
+          articleUrl,
+          chunkIndex: index,
+          voiceModel,
+        });
+      }
+      if (!articleUrl && !forceRegenerate) {
+        return audioCache.get(chunk.cleanedText, voiceModel);
       }
       return audioCache.get(chunk.cleanedText, voiceModel, articleUrl, forceRegenerate);
     },
@@ -298,15 +330,8 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
         return;
       }
 
-      // 既に再生処理が進行中の場合は新しいリクエストを無視
-      // フラグのチェックと設定を即座に行うことで競合状態を最小化
-      if (isPlayingRequestInProgressRef.current) {
-        logger.warn("再生リクエストが既に進行中のため、新しいリクエストをスキップします", {
-          index,
-        });
-        return;
-      }
-      isPlayingRequestInProgressRef.current = true;
+      // セッションIDを更新
+      const currentSessionId = ++playbackSessionIdRef.current;
 
       setIsLoading(true);
       setError("");
@@ -330,8 +355,17 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
           await sleep(getPauseDuration("heading"));
         }
 
+        if (!isCurrentPlaybackSession(currentSessionId)) return;
+
         logger.info(`💾 音声取得: チャンク ${index + 1}/${chunks.length}`);
         const audioUrl = await fetchAudioUrl(index);
+
+        if (!isCurrentPlaybackSession(currentSessionId)) {
+          if (audioUrl.startsWith("blob:")) {
+            URL.revokeObjectURL(audioUrl);
+          }
+          return;
+        }
 
         // 先読み
         prefetchAudio(index + 1);
@@ -363,11 +397,26 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
 
         // play()を一度だけ呼び出す
         await audio.play();
+        if (!isCurrentPlaybackSession(currentSessionId)) {
+          audio.pause();
+          if (audioUrl.startsWith("blob:")) {
+            URL.revokeObjectURL(audioUrl);
+          }
+          if (currentAudioUrlRef.current === audioUrl) {
+            currentAudioUrlRef.current = null;
+          }
+          return;
+        }
         setIsPlaying(true); // 再生状態を更新
 
         // イベントハンドラを設定
-        audio.onended = () => handleAudioEnded(index);
+        audio.onended = () => {
+          void handleAudioEnded(index, currentSessionId);
+        };
         audio.onerror = async (e) => {
+          if (!isCurrentPlaybackSession(currentSessionId)) {
+            return;
+          }
           const mediaError = audio.error;
 
           if (mediaError?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
@@ -401,22 +450,40 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
             // ハンドラを一旦クリアして再取得を試みる
             audio.onended = null;
             audio.onerror = null;
-            if (currentAudioUrlRef.current?.startsWith("blob:")) {
-              URL.revokeObjectURL(currentAudioUrlRef.current);
-            }
+            releaseCurrentAudioUrl();
             audio.src = "";
-            currentAudioUrlRef.current = null;
 
             try {
               logger.info(`🔄 音声を強制再取得中: チャンク ${index + 1}`);
               const newUrl = await fetchAudioUrl(index, true);
+              if (!isCurrentPlaybackSession(currentSessionId)) {
+                if (newUrl.startsWith("blob:")) {
+                  URL.revokeObjectURL(newUrl);
+                }
+                return;
+              }
               audio.src = newUrl;
               currentAudioUrlRef.current = newUrl;
               audio.playbackRate = isNaN(rate) ? DEFAULT_PLAYBACK_RATE : rate;
               await audio.play();
+              if (!isCurrentPlaybackSession(currentSessionId)) {
+                audio.pause();
+                if (newUrl.startsWith("blob:")) {
+                  URL.revokeObjectURL(newUrl);
+                }
+                if (currentAudioUrlRef.current === newUrl) {
+                  currentAudioUrlRef.current = null;
+                }
+                return;
+              }
               // 再取得成功：ハンドラを再登録
-              audio.onended = () => handleAudioEnded(index);
+              audio.onended = () => {
+                void handleAudioEnded(index, currentSessionId);
+              };
               audio.onerror = async (e2) => {
+                if (!isCurrentPlaybackSession(currentSessionId)) {
+                  return;
+                }
                 const err2 = audio.error;
                 const errorMessage2 = `音声の再生に失敗しました (Code: ${err2?.code})`;
                 logger.error("音声再生エラー（再取得後）", { error: err2, event: e2, chunkIndex: index });
@@ -426,11 +493,13 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
               logger.info(`✅ 再取得成功: チャンク ${index + 1}`);
             } catch (refetchErr) {
               logger.warn(`⚠️ 再取得失敗: チャンク ${index + 1}、次のチャンクへスキップします。`, refetchErr);
-              setError("一部の音声が再生できませんでした。次の部分から再開します。");
               // 次のチャンクへ進む
-              void playFromIndexRef.current(index + 1).catch((skipErr) => {
-                logger.error("次チャンクへのスキップ中にエラー", skipErr);
-              });
+              if (isCurrentPlaybackSession(currentSessionId)) {
+                void playFromIndexRef.current(index + 1).catch((skipErr) => {
+                  logger.error("次チャンクへのスキップ中にエラー", skipErr);
+                });
+              }
+              setError("一部の音声が再生できませんでした。次の部分から再開します。");
             }
             return;
           }
@@ -476,28 +545,49 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
             chunkIndex: index,
             errorMessage: error.message,
           });
+          if (!isCurrentPlaybackSession(currentSessionId)) {
+            return;
+          }
           const audio = audioRef.current;
           if (audio) {
             audio.onended = null;
             audio.onerror = null;
-            if (currentAudioUrlRef.current?.startsWith("blob:")) {
-              URL.revokeObjectURL(currentAudioUrlRef.current);
-            }
+            releaseCurrentAudioUrl();
             audio.src = "";
-            currentAudioUrlRef.current = null;
           }
           try {
             const chunk = chunks[index];
             const newUrl = await fetchAudioUrl(index, true);
+            if (!isCurrentPlaybackSession(currentSessionId)) {
+              if (newUrl.startsWith("blob:")) {
+                URL.revokeObjectURL(newUrl);
+              }
+              return;
+            }
             if (audio) {
               audio.src = newUrl;
               currentAudioUrlRef.current = newUrl;
               const rate2 = parseFloat(localStorage.getItem(PLAYBACK_RATE_STORAGE_KEY) || "");
               audio.playbackRate = isNaN(rate2) ? DEFAULT_PLAYBACK_RATE : rate2;
               await audio.play();
+              if (!isCurrentPlaybackSession(currentSessionId)) {
+                audio.pause();
+                if (newUrl.startsWith("blob:")) {
+                  URL.revokeObjectURL(newUrl);
+                }
+                if (currentAudioUrlRef.current === newUrl) {
+                  currentAudioUrlRef.current = null;
+                }
+                return;
+              }
               setIsPlaying(true);
-              audio.onended = () => handleAudioEnded(index);
+              audio.onended = () => {
+                void handleAudioEnded(index, currentSessionId);
+              };
               audio.onerror = async (e3) => {
+                if (!isCurrentPlaybackSession(currentSessionId)) {
+                  return;
+                }
                 const err3 = audio.error;
                 logger.error("音声再生エラー（NotSupportedError後の再取得後）", { error: err3, event: e3, chunkIndex: index });
                 setError(`音声の再生に失敗しました (Code: ${err3?.code})`);
@@ -512,13 +602,13 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
             }
           } catch (refetchErr2) {
             logger.warn(`⚠️ NotSupportedError後の再取得失敗: チャンク ${index + 1}、次のチャンクへスキップします。`, refetchErr2);
-            setError("一部の音声が再生できませんでした。次の部分から再開します。");
             setIsPlaying(false);
-            // isPlayingRequestInProgressRef をリセットしてから次チャンクへ
-            isPlayingRequestInProgressRef.current = false;
-            void playFromIndexRef.current(index + 1).catch((skipErr) => {
-              logger.error("次チャンクへのスキップ中にエラー", skipErr);
-            });
+            if (isCurrentPlaybackSession(currentSessionId)) {
+              void playFromIndexRef.current(index + 1).catch((skipErr) => {
+                logger.error("次チャンクへのスキップ中にエラー", skipErr);
+              });
+            }
+            setError("一部の音声が再生できませんでした。次の部分から再開します。");
           }
         } else {
           setError(
@@ -528,8 +618,9 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
           setIsPlaying(false);
         }
       } finally {
-        setIsLoading(false);
-        isPlayingRequestInProgressRef.current = false;
+        if (isCurrentPlaybackSession(currentSessionId)) {
+          setIsLoading(false);
+        }
       }
     },
     [
@@ -541,6 +632,8 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       fetchAudioUrl,
       handleAudioEnded,
       installPositionStateUpdater,
+      isCurrentPlaybackSession,
+      releaseCurrentAudioUrl,
     ]
   );
 
@@ -556,7 +649,10 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
 
   // 一時停止
   const pause = useCallback(() => {
+    playbackSessionIdRef.current++;
     if (audioRef.current) {
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
       audioRef.current.pause();
       setIsPlaying(false);
     }
@@ -564,16 +660,26 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
 
   // 停止
   const stop = useCallback(() => {
+    playbackSessionIdRef.current++;
     if (audioRef.current) {
-      if (currentAudioUrlRef.current?.startsWith('blob:')) {
-        URL.revokeObjectURL(currentAudioUrlRef.current);
-      }
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
+      releaseCurrentAudioUrl();
       audioRef.current.pause();
       audioRef.current.currentTime = 0;
+      if (typeof audioRef.current.removeAttribute === "function") {
+        audioRef.current.removeAttribute("src");
+      } else {
+        audioRef.current.src = "";
+      }
+      if (typeof audioRef.current.load === "function") {
+        audioRef.current.load();
+      }
     }
     setIsPlaying(false);
     setCurrentIndex(-1);
-  }, []);
+    setIsLoading(false);
+  }, [releaseCurrentAudioUrl]);
 
   // 次のチャンクへ移動
   const next = useCallback(async () => {
@@ -639,15 +745,16 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
   // クリーンアップ
   useEffect(() => {
     return () => {
+      playbackSessionIdRef.current++;
       positionStateCleanupRef.current?.();
       if (audioRef.current) {
+        audioRef.current.onended = null;
+        audioRef.current.onerror = null;
         audioRef.current.pause();
       }
-      if (currentAudioUrlRef.current?.startsWith('blob:')) {
-        URL.revokeObjectURL(currentAudioUrlRef.current);
-      }
+      releaseCurrentAudioUrl();
     };
-  }, []);
+  }, [releaseCurrentAudioUrl]);
 
   return {
     isPlaying,

--- a/packages/web-app-vercel/tests/auth.setup.ts
+++ b/packages/web-app-vercel/tests/auth.setup.ts
@@ -4,10 +4,11 @@ import fs from 'fs'
 const authFile = 'playwright/.auth/user.json'
 
 setup('authenticate', async ({ page }) => {
-    // 既に認証状態ファイルが存在する場合はスキップ
+    // Stale local auth state can redirect every protected E2E page back to
+    // /auth/signin. Always create a fresh state for deterministic runs.
     if (fs.existsSync(authFile)) {
-        console.log('[AUTH SETUP] Using existing auth state from', authFile)
-        return
+        console.log('[AUTH SETUP] Removing existing auth state at', authFile)
+        fs.rmSync(authFile, { force: true })
     }
 
     console.log('[AUTH SETUP] Creating new auth state...')

--- a/packages/web-app-vercel/tests/e2e/reader-layout.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/reader-layout.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { mockArticles } from '../helpers/testData';
-import { clearLocalStorage } from '../helpers/testSetup';
 
 test.describe('Reader layout and controls', () => {
     test('Desktop: bottom-fixed controls and PlaybackSpeedDial modal', async ({ page }) => {
@@ -9,7 +8,9 @@ test.describe('Reader layout and controls', () => {
         // Load an article to show the audio controls
         await page.waitForSelector('[data-testid="url-input"]', { state: 'visible' });
         await page.fill('[data-testid="url-input"]', mockArticles[0].url);
-        await page.click('[data-testid="extract-button"]');
+        const extractButton = page.locator('[data-testid="extract-button"]');
+        await expect(extractButton).toBeEnabled();
+        await extractButton.click();
         // Wait for the desktop controls to appear (sm: fixed bar)
         await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible', timeout: 30000 });
 

--- a/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts
@@ -1,5 +1,65 @@
-import { test, expect } from '@playwright/test';
-import { clearLocalStorage } from '../helpers/testSetup';
+import { test, expect, type Page } from '@playwright/test';
+
+const navigationArticles = [
+    { title: 'Apple', url: 'https://example.com/?id=apple' },
+    { title: 'Banana', url: 'https://example.com/?id=banana' },
+    { title: 'Cherry', url: 'https://example.com/?id=cherry' },
+] as const;
+
+async function requireOk(response: Awaited<ReturnType<Page['request']['get']>>, action: string) {
+    if (!response.ok()) {
+        throw new Error(`${action} failed: ${response.status()} ${await response.text()}`);
+    }
+}
+
+async function createNavigationPlaylist(page: Page) {
+    const createResp = await page.request.post('/api/playlists', {
+        data: {
+            name: `E2E Navigation ${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        },
+    });
+    await requireOk(createResp, 'create playlist');
+    const playlist = await createResp.json();
+
+    for (const article of navigationArticles) {
+        const itemResp = await page.request.post(`/api/playlists/${playlist.id}/items`, {
+            data: {
+                article_url: article.url,
+                article_title: article.title,
+                thumbnail_url: null,
+                last_read_position: 0,
+            },
+        });
+        await requireOk(itemResp, `add ${article.title}`);
+    }
+
+    return playlist as { id: string; name: string };
+}
+
+async function ensureDefaultPlaylistHasNavigationArticles(page: Page) {
+    const defaultResp = await page.request.get('/api/playlists/default');
+    await requireOk(defaultResp, 'get default playlist');
+    const defaultPlaylist = await defaultResp.json();
+
+    for (const article of navigationArticles) {
+        const itemResp = await page.request.post(`/api/playlists/${defaultPlaylist.id}/items`, {
+            data: {
+                article_url: article.url,
+                article_title: article.title,
+                thumbnail_url: null,
+                last_read_position: 0,
+            },
+        });
+        await requireOk(itemResp, `add default ${article.title}`);
+    }
+}
+
+async function deletePlaylist(page: Page, playlistId: string) {
+    const response = await page.request.delete(`/api/playlists/${playlistId}`);
+    if (!response.ok() && response.status() !== 404) {
+        throw new Error(`delete playlist failed: ${response.status()} ${await response.text()}`);
+    }
+}
 
 test.describe('Reader - プレイリスト関連のナビゲーション', () => {
     test.beforeEach(async ({ page }) => {
@@ -38,38 +98,33 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
     });
 
     test('プレイリスト詳細 -> リーダーにプレイリストクエリが含まれ、前へ/次へボタンが表示される', async ({ page }) => {
-        // Navigate to playlists list
-        await page.goto('/playlists');
-        await page.waitForSelector('a[data-testid="playlist-item"]', { state: 'visible' });
+        const playlist = await createNavigationPlaylist(page);
+        try {
+            await page.goto(`/playlists/${playlist.id}`);
+            await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
 
-        // Click the Default Playlist (explicitly find by text)
-        const defaultPlaylist = page.locator('a[data-testid="playlist-item"]').filter({ hasText: 'ソートテスト用プレイリスト' }).first();
-        await expect(defaultPlaylist).toBeVisible();
-        await defaultPlaylist.click();
+            const link = page.locator('a[data-testid="playlist-article"]').filter({ hasText: 'Apple' }).first();
+            const href = await link.getAttribute('href');
+            expect(href).toContain(`playlist=${playlist.id}`);
+            expect(href).toContain('index=0');
 
-        // Verify we are on playlist detail page
-        await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
+            if (!href) throw new Error('playlist article href is missing');
+            await page.goto(href);
 
-        // Find the first article (Apple)
-        const link = page.locator('a[data-testid="playlist-article"]').first();
-        const href = await link.getAttribute('href');
-        expect(href).toContain('playlist=');
-
-        // Navigate to reader
-        await link.click();
-
-        // Ensure audio player is visible and prev/next are present
-        await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
-        const prev = page.getByTestId('desktop-prev-button');
-        const next = page.getByTestId('desktop-next-button');
-        await expect(prev).toBeVisible();
-        await expect(next).toBeVisible();
-
-        // Verify title is "Apple" (mocked)
-        await expect(page.getByTestId('article-title')).toContainText('Apple');
+            await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
+            const prev = page.getByTestId('desktop-prev-button');
+            const next = page.getByTestId('desktop-next-button');
+            await expect(prev).toBeVisible();
+            await expect(next).toBeVisible();
+            await expect(page.getByTestId('article-title')).toContainText('Apple');
+        } finally {
+            await deletePlaylist(page, playlist.id);
+        }
     });
 
     test('ホーム -> リーダーがデフォルトプレイリストを使用し、前へ/次へボタンが表示される', async ({ page }) => {
+        await ensureDefaultPlaylistHasNavigationArticles(page);
+
         // Open home and click first article (home shows default playlist items)
         await page.goto('/');
         await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
@@ -91,73 +146,64 @@ test.describe('Reader - プレイリスト関連のナビゲーション', () =>
 
     // Tests are now unskipped as we mock the extraction
     test('プレイリスト内の前へ/次へ遷移が正しくナビゲートする', async ({ page }) => {
-        // Navigate to playlists list
-        await page.goto('/playlists');
-        await page.waitForSelector('a[data-testid="playlist-item"]', { state: 'visible' });
+        const playlist = await createNavigationPlaylist(page);
+        try {
+            await page.goto(`/playlists/${playlist.id}`);
+            await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
 
-        // Click the Default Playlist
-        await page.locator('a[data-testid="playlist-item"]').filter({ hasText: 'ソートテスト用プレイリスト' }).first().click();
+            const firstLink = page.locator('a[data-testid="playlist-article"]').filter({ hasText: 'Apple' }).first();
+            await expect(firstLink).toBeVisible();
+            const firstHref = await firstLink.getAttribute('href');
+            if (!firstHref) throw new Error('playlist article href is missing');
+            await page.goto(firstHref);
 
-        // Wait for articles
-        await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
+            await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
+            const next = page.getByTestId('desktop-next-button');
+            const prev = page.getByTestId('desktop-prev-button');
+            await expect(next).toBeVisible();
+            await expect(next).toBeEnabled();
+            await expect(prev).toBeVisible();
+            await expect(prev).toBeEnabled();
+            await expect(page.getByTestId('article-title')).toContainText('Apple');
 
-        // Click first article (Apple)
-        const firstLink = page.locator('a[data-testid="playlist-article"]').first();
-        await expect(firstLink).toContainText('Apple');
-        await firstLink.click();
+            const initialUrl = page.url();
+            await next.click();
+            await page.waitForURL((url) => url.toString() !== initialUrl);
+            await expect(page.getByTestId('article-title')).toContainText('Banana');
 
-        // ensure in playlist mode
-        await page.waitForSelector('[data-testid="audio-player-desktop"]', { state: 'visible' });
-        const next = page.getByTestId('desktop-next-button');
-        const prev = page.getByTestId('desktop-prev-button');
-        await expect(next).toBeVisible();
-        await expect(prev).toBeVisible();
-        await expect(page.getByTestId('article-title')).toContainText('Apple');
+            const secondUrl = page.url();
+            await next.click();
+            await page.waitForURL((url) => url.toString() !== secondUrl);
+            await expect(page.getByTestId('article-title')).toContainText('Cherry');
 
-        // Click next -> Banana
-        const initialUrl = page.url();
-        await next.click();
-        await page.waitForURL((url) => url.toString() !== initialUrl);
-        await expect(page.getByTestId('article-title')).toContainText('Banana');
-
-        // Click next -> Cherry
-        const secondUrl = page.url();
-        await next.click();
-        await page.waitForURL((url) => url.toString() !== secondUrl);
-        await expect(page.getByTestId('article-title')).toContainText('Cherry');
-
-        // Click previous -> Banana
-        const currentUrl = page.url();
-        await prev.click();
-        await page.waitForURL((url) => url.toString() !== currentUrl);
-        await expect(page.getByTestId('article-title')).toContainText('Banana');
+            const currentUrl = page.url();
+            await prev.click();
+            await page.waitForURL((url) => url.toString() !== currentUrl);
+            await expect(page.getByTestId('article-title')).toContainText('Banana');
+        } finally {
+            await deletePlaylist(page, playlist.id);
+        }
     });
 
     test('前へ/次へナビゲーションでプレイリストのソート順が尊重される', async ({ page }) => {
-        // Navigate to playlist
-        await page.goto('/playlists');
-        await page.waitForSelector('a[data-testid="playlist-item"]', { state: 'visible' });
-        await page.locator('a[data-testid="playlist-item"]').filter({ hasText: 'ソートテスト用プレイリスト' }).first().click();
+        const playlist = await createNavigationPlaylist(page);
+        try {
+            await page.goto(`/playlists/${playlist.id}`);
+            await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
 
-        // Wait for navigation to playlist detail page
-        await page.waitForURL(/\/playlists\/.+/);
+            const sortSelector = page.locator('[data-testid="playlist-sort-select"]');
+            await expect(sortSelector).toBeVisible({ timeout: 15000 });
 
-        // Wait for articles to load
-        await page.waitForSelector('a[data-testid="playlist-article"]', { state: 'visible' });
+            await sortSelector.click();
+            await page.waitForSelector("text=タイトル順 (Z-A)", { state: 'visible' });
+            await page.getByRole('option', { name: 'タイトル順 (Z-A)' }).click();
 
-        // Wait for sort selector to appear (indicates playlist has items)
-        const sortSelector = page.locator('[data-testid="playlist-sort-select"]');
-        await expect(sortSelector).toBeVisible({ timeout: 15000 });
-
-        // Change sort to Title Descending (Z-A)
-        await sortSelector.click();
-        await page.waitForSelector("text=タイトル順 (Z-A)", { state: 'visible' });
-        await page.getByRole('option', { name: 'タイトル順 (Z-A)' }).click();
-
-        // Verify sort order: Cherry > Banana > Apple (Z-A)
-        const articles = page.locator('a[data-testid="playlist-article"]');
-        await expect(articles.nth(0)).toContainText('Cherry');
-        await expect(articles.nth(1)).toContainText('Banana');
-        await expect(articles.nth(2)).toContainText('Apple');
+            const articles = page.locator('a[data-testid="playlist-article"]');
+            await expect(articles.nth(0)).toContainText('Cherry');
+            await expect(articles.nth(1)).toContainText('Banana');
+            await expect(articles.nth(2)).toContainText('Apple');
+        } finally {
+            await deletePlaylist(page, playlist.id);
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Replace the playback in-flight boolean with session IDs so stale async fetch/play/refetch work cannot resume after stop, navigation, or a newer play request.
- Complete the #753 audio 404 / NotSupportedError recovery path, including IndexedDB diagnostics and tests for refetch success/failure.
- Complete the #754/#755 follow-up by stopping on source changes/unmount, guarding playlist playback against URL-less items, and preserving sorted playlist auto-advance behavior.
- Run CI e2e web servers via build/start to avoid the main-branch dev-server readiness timeout.

## Verification
- npm run lint -- hooks/usePlayback.ts hooks/__tests__/usePlayback.test.ts contexts/AudioPlaybackContext.tsx contexts/PlaylistPlaybackContext.tsx app/reader/ReaderClient.tsx 'app/playlists/[id]/page.tsx'
- npm run test:unit -- --watchman=false --coverage=false hooks/__tests__/usePlayback.test.ts
- npm run test:unit -- --watchman=false
- npm run build

Follow-up for merged incomplete PRs #756, #757, #758 and their source issues #753, #754, #755.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

再生リクエストの競合状態を修正するため、`isPlayingRequestInProgressRef`（boolean フラグ）をセッション ID（インクリメントカウンター）に置き換えました。また、プレイリスト内の URL なしアイテムへのガード、`AudioPlaybackContext` でのソース切り替え時の自動停止、CI e2e の dev-server タイムアウト回避のためビルド成果物共有を追加しています。

- `usePlayback.ts`: boolean フラグをセッション ID に変更し、stop/pause/新規 play 呼び出し後に古い非同期処理の状態更新を完全にブロック。`stop()` に `setIsLoading(false)` も追加。
- `AudioPlaybackContext.tsx`: `setPlaybackSource` を `useCallback` で包み、ソース変更時に `stopPlayback()` を呼ぶよう修正（空 URL からの切り替えも含む）。
- CI ワークフロー: Next.js ビルドをアーティファクトとしてアップロード・共有し、各 e2e ジョブが `npm run start` でビルド済み成果物を使用するよう変更。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

2 つの独立した不具合（`pause()` 中の `isLoading` 残留と CI アーティファクトのバージョン不一致）がマージブロッカーになり得る。

`pause()` が `setIsLoading(false)` を呼ばないため、音声取得中に一時停止するとローディング UI が解除されない。また `upload-artifact@v7` と `download-artifact@v8` のバージョン不一致は e2e ジョブでのビルドダウンロードを壊す可能性がある。どちらも実際に発生しうる不具合。

`hooks/usePlayback.ts`（`pause()` の `isLoading` 処理）と `.github/workflows/ci.yml`（アーティファクトバージョン）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/hooks/usePlayback.ts | boolean フラグをセッション ID に置き換えて競合状態を修正。ただし `pause()` が `setIsLoading(false)` を呼ばないため、音声取得中に pause すると isLoading が stuck する問題あり。 |
| .github/workflows/ci.yml | ビルド成果物をアーティファクトとしてアップロード・共有するよう変更。ただし `upload-artifact@v7` と `download-artifact@v8` のメジャーバージョン不一致があり、e2e ジョブでのビルドダウンロードが失敗するリスクがある。 |
| packages/web-app-vercel/contexts/AudioPlaybackContext.tsx | `setPlaybackSource` を `useCallback` で包み、ソース変更時に `stop()` を呼ぶよう修正。空の `articleUrl` → 別 URL への切り替えでも `stop` が正しく呼ばれることをテストで確認している。 |
| packages/web-app-vercel/app/reader/ReaderClient.tsx | `activePlaylistIndex` の導入で URL クエリと state の競合を解消し、アンマウント時の `stop/setPlaybackSource` を ref 経由で呼ぶよう変更。`navigateToPlaylistItem` を `getPlaylistItemHref` に置き換え `<a>` リンクへ移行。 |
| packages/web-app-vercel/tests/e2e/reader-playlist.spec.ts | テストデータをシード固定データから API 経由の動的生成に切り替え、`finally` でクリーンアップ。テストの再現性が向上。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/web-app-vercel/hooks/usePlayback.ts`, line 651-659 ([link](https://github.com/hiroki-org/audicle/blob/ff7001c58124fcfa14bc8351152caab942390e2c/packages/web-app-vercel/hooks/usePlayback.ts#L651-L659)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`pause()` 中に音声取得が進行中だと `isLoading` が永遠に `true` のまま残る**

   `pause()` はセッション ID をインクリメントして進行中の `playFromIndex` を無効化しますが、`setIsLoading(false)` を呼んでいません。一方 `playFromIndex` の `finally` ブロックは `isCurrentPlaybackSession(currentSessionId)` が真のときだけ `setIsLoading(false)` を実行します。そのため、音声取得中（`isLoading === true`）に `pause()` を呼び出すと、セッションが失効してセッションチェックが false になり、`isLoading` が `true` のまま解除されず、ローディング UI がスピナーを表示し続けます。`stop()` は `setIsLoading(false)` を無条件に呼んでいるため（681行目）、同じパターンに揃える必要があります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/hooks/usePlayback.ts
   Line: 651-659

   Comment:
   **`pause()` 中に音声取得が進行中だと `isLoading` が永遠に `true` のまま残る**

   `pause()` はセッション ID をインクリメントして進行中の `playFromIndex` を無効化しますが、`setIsLoading(false)` を呼んでいません。一方 `playFromIndex` の `finally` ブロックは `isCurrentPlaybackSession(currentSessionId)` が真のときだけ `setIsLoading(false)` を実行します。そのため、音声取得中（`isLoading === true`）に `pause()` を呼び出すと、セッションが失効してセッションチェックが false になり、`isLoading` が `true` のまま解除されず、ローディング UI がスピナーを表示し続けます。`stop()` は `setIsLoading(false)` を無条件に呼んでいるため（681行目）、同じパターンに揃える必要があります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `.github/workflows/ci.yml`, line 188-190 ([link](https://github.com/hiroki-org/audicle/blob/ff7001c58124fcfa14bc8351152caab942390e2c/.github/workflows/ci.yml#L188-L190)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`upload-artifact@v7` と `download-artifact@v8` のバージョン不一致**

   アップロードに `v7`、ダウンロードに `v8` を使っており、メジャーバージョンが揃っていません。アーティファクトの内部フォーマットやAPIがバージョン間で異なる場合、ダウンロードが失敗して `.next` ディレクトリが存在しない状態で e2e テストが実行されます。`ci-pr.yml` のダウンロードも `v8` を使っているため、アップロードも `v8` に合わせるか、全ジョブで同一バージョンに統一してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 188-190

   Comment:
   **`upload-artifact@v7` と `download-artifact@v8` のバージョン不一致**

   アップロードに `v7`、ダウンロードに `v8` を使っており、メジャーバージョンが揃っていません。アーティファクトの内部フォーマットやAPIがバージョン間で異なる場合、ダウンロードが失敗して `.next` ディレクトリが存在しない状態で e2e テストが実行されます。`ci-pr.yml` のダウンロードも `v8` を使っているため、アップロードも `v8` に合わせるか、全ジョブで同一バージョンに統一してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/hooks/usePlayback.ts:651-659
**`pause()` 中に音声取得が進行中だと `isLoading` が永遠に `true` のまま残る**

`pause()` はセッション ID をインクリメントして進行中の `playFromIndex` を無効化しますが、`setIsLoading(false)` を呼んでいません。一方 `playFromIndex` の `finally` ブロックは `isCurrentPlaybackSession(currentSessionId)` が真のときだけ `setIsLoading(false)` を実行します。そのため、音声取得中（`isLoading === true`）に `pause()` を呼び出すと、セッションが失効してセッションチェックが false になり、`isLoading` が `true` のまま解除されず、ローディング UI がスピナーを表示し続けます。`stop()` は `setIsLoading(false)` を無条件に呼んでいるため（681行目）、同じパターンに揃える必要があります。

### Issue 2 of 2
.github/workflows/ci.yml:188-190
**`upload-artifact@v7` と `download-artifact@v8` のバージョン不一致**

アップロードに `v7`、ダウンロードに `v8` を使っており、メジャーバージョンが揃っていません。アーティファクトの内部フォーマットやAPIがバージョン間で異なる場合、ダウンロードが失敗して `.next` ディレクトリが存在しない状態で e2e テストが実行されます。`ci-pr.yml` のダウンロードも `v8` を使っているため、アップロードも `v8` に合わせるか、全ジョブで同一バージョンに統一してください。

```suggestion
      - name: Upload build artifact
        uses: actions/upload-artifact@v8
        with:
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: repair playlist e2e and ci startup"](https://github.com/hiroki-org/audicle/commit/ff7001c58124fcfa14bc8351152caab942390e2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31004163)</sub>

<!-- /greptile_comment -->