### PR TITLE
fix: dedupe in-flight audio cache requests

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/audioCache.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/audioCache.test.ts
@@ -1,4 +1,5 @@
 import { AudioCache } from '../audioCache';
+import { synthesizeSpeech } from '../api';
 
 // Mock synthesizeSpeech
 jest.mock('../api', () => ({
@@ -10,6 +11,8 @@ describe('AudioCache', () => {
 
     beforeEach(() => {
         cache = new AudioCache();
+        (synthesizeSpeech as jest.Mock).mockReset();
+        (synthesizeSpeech as jest.Mock).mockResolvedValue(new Blob(['test'], { type: 'audio/wav' }));
         // Clear cache before each test
         cache.clear();
     });
@@ -104,12 +107,68 @@ describe('AudioCache', () => {
         });
 
         it('should not call synthesizeSpeech on cache hit', async () => {
-            const { synthesizeSpeech } = require('../api');
             // Clear mocks to have a clean slate for this test
             (synthesizeSpeech as jest.Mock).mockClear();
 
             await cache.get('test text', 'voice1', 'url1'); // First call, miss
             await cache.get('test text', 'voice1', 'url1'); // Second call, hit
+            expect(synthesizeSpeech).toHaveBeenCalledTimes(1);
+        });
+
+        it('should share one in-flight synthesis for concurrent requests with the same key', async () => {
+            let resolveSpeech!: (_blob: Blob) => void;
+            (synthesizeSpeech as jest.Mock).mockReturnValueOnce(
+                new Promise<Blob>((resolve) => {
+                    resolveSpeech = resolve;
+                })
+            );
+
+            const first = cache.get('same text', 'voice1', 'url1');
+            const second = cache.get('same text', 'voice1', 'url1');
+
+            expect(synthesizeSpeech).toHaveBeenCalledTimes(1);
+
+            resolveSpeech(new Blob(['deduped'], { type: 'audio/wav' }));
+
+            await expect(Promise.all([first, second])).resolves.toEqual([
+                expect.stringMatching(/^blob:/),
+                expect.stringMatching(/^blob:/),
+            ]);
+            expect(synthesizeSpeech).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove a failed in-flight request so a later call can retry', async () => {
+            const error = new Error('synthesis failed');
+            (synthesizeSpeech as jest.Mock)
+                .mockRejectedValueOnce(error)
+                .mockResolvedValueOnce(new Blob(['retry'], { type: 'audio/wav' }));
+
+            await expect(cache.get('retry text', 'voice1', 'url1')).rejects.toThrow('synthesis failed');
+
+            const retryUrl = await cache.get('retry text', 'voice1', 'url1');
+
+            expect(retryUrl).toMatch(/^blob:/);
+            expect(synthesizeSpeech).toHaveBeenCalledTimes(2);
+        });
+
+        it('should track an in-flight result that finishes after clear so it remains revocable', async () => {
+            let resolveSpeech!: (_blob: Blob) => void;
+            (synthesizeSpeech as jest.Mock)
+                .mockReturnValueOnce(
+                    new Promise<Blob>((resolve) => {
+                        resolveSpeech = resolve;
+                    })
+                )
+                .mockResolvedValueOnce(new Blob(['unexpected-resynthesis'], { type: 'audio/wav' }));
+
+            const pending = cache.get('clear text', 'voice1', 'url1');
+
+            cache.clear();
+            resolveSpeech(new Blob(['stale'], { type: 'audio/wav' }));
+
+            await expect(pending).resolves.toMatch(/^blob:/);
+            await expect(cache.get('clear text', 'voice1', 'url1')).resolves.toMatch(/^blob:/);
+
             expect(synthesizeSpeech).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/web-app-vercel/lib/audioCache.ts
+++ b/packages/web-app-vercel/lib/audioCache.ts
@@ -16,6 +16,7 @@ const MAX_CACHE_SIZE = 50; // キャッシュする最大アイテム数
 
 export class AudioCache {
   private cache = new Map<string, CacheEntry>();
+  private inFlightRequests = new Map<string, Promise<string>>();
 
   // キャッシュキーを生成（音声モデルと再生速度を含む）
   private getCacheKey(
@@ -49,6 +50,12 @@ export class AudioCache {
 
     // forceRegenerate フラグがある場合はキャッシュをスキップ
     if (!forceRegenerate) {
+      const inFlight = this.inFlightRequests.get(key);
+      if (inFlight) {
+        logger.cache("WAIT", `${text.substring(0, 30)}...`);
+        return inFlight;
+      }
+
       // キャッシュチェック
       const cached = this.cache.get(key);
       if (cached) {
@@ -80,6 +87,31 @@ export class AudioCache {
     }
 
     // キャッシュミス - 新規合成
+    const request = this.synthesizeAndStore(
+      key,
+      text,
+      voiceModel,
+      articleUrl,
+    );
+    if (!forceRegenerate) {
+      this.inFlightRequests.set(key, request);
+    }
+
+    try {
+      return await request;
+    } finally {
+      if (this.inFlightRequests.get(key) === request) {
+        this.inFlightRequests.delete(key);
+      }
+    }
+  }
+
+  private async synthesizeAndStore(
+    key: string,
+    text: string,
+    voiceModel: string,
+    articleUrl?: string,
+  ): Promise<string> {
     logger.cache("MISS", `${text.substring(0, 30)}...`);
     const blob = await synthesizeSpeech(
       text,
@@ -164,6 +196,7 @@ export class AudioCache {
       URL.revokeObjectURL(entry.url);
     });
     this.cache.clear();
+    this.inFlightRequests.clear();
     logger.cache("CLEAR", "all");
   }
 }


### PR DESCRIPTION
## Summary
- share a single in-flight synthesis promise for identical audio cache keys
- prevent pending synthesis from repopulating the cache after clear()
- add unit coverage for concurrency, retry-after-failure, and clear races

## Verification
- npm run test:unit -- --watchman=false --coverage=false lib/__tests__/audioCache.test.ts
- npm run lint -- lib/audioCache.ts lib/__tests__/audioCache.test.ts

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

同一キャッシュキーへの並行リクエストを単一のインフライト Promise に束ねることで重複合成を防ぎ、`cacheGeneration` カウンターで `clear()` 後にインフライト結果がキャッシュへ書き戻されないよう保護する変更です。

- `inFlightRequests` マップを追加し、同一キーへの 2 回目以降の `get()` は既存の Promise をそのまま返す（`synthesizeSpeech` の呼び出しを 1 回に抑制）。
- `cacheGeneration` を `clear()` 時にインクリメントし、世代が変わっていれば `synthesizeAndStore` 内でキャッシュへの書き込みをスキップ。
- 並行重複・失敗後リトライ・clear() レース条件の 3 シナリオをカバーするユニットテストを追加。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

コアロジックは正しく動作し、並行リクエストの重複排除・失敗後リトライ・clear() レース条件いずれも適切に処理される。

`clear()` 後にインフライトが完了した場合に生成される Blob URL がキャッシュに登録されず `URL.revokeObjectURL()` が呼ばれないまま残る点が懸念。頻度が高い用途では未解放 URL が蓄積する可能性がある。

`lib/audioCache.ts` の `synthesizeAndStore` 内、世代不一致時の URL 解放フローを確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/audioCache.ts | インフライトリクエストの重複排除と `cacheGeneration` によるクリア後の再格納防止を実装。`cacheGeneration` 不一致時に返す Blob URL が未解放になる可能性あり。 |
| packages/web-app-vercel/lib/__tests__/audioCache.test.ts | 並行リクエスト、失敗後のリトライ、clear() レース条件の3テストを追加。`beforeEach` でモックのリセットが正しく行われるよう改善。1テストにのみ残る `require('../api')` が冗長。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/web-app-vercel/lib/audioCache.ts`, line 125-130 ([link](https://github.com/hiroki-org/audicle/blob/f754b554f81fc1e927ad2913baaa937010e4aa14/packages/web-app-vercel/lib/audioCache.ts#L125-L130)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **生成世代不一致時の Blob URL がリークする**

   `cacheGeneration` が一致しない場合（`clear()` 後にインフライトが完了したとき）、`URL.createObjectURL(blob)` で生成された URL が返されますが、キャッシュには格納されません。そのため、この URL は `clear()` や LRU エビクションの対象外となり、`URL.revokeObjectURL()` が一度も呼ばれないまま残ります。ページ滞在中に `clear()` とインフライトリクエストが繰り返されると、解放されない Blob URL が蓄積します。`URL.revokeObjectURL(url)` を呼ぶタイミングを明示的に設けるか、"orphan URL" を別リストで追跡して次回の `clear()` 時にまとめて解放する設計を検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/audioCache.ts
   Line: 125-130

   Comment:
   **生成世代不一致時の Blob URL がリークする**

   `cacheGeneration` が一致しない場合（`clear()` 後にインフライトが完了したとき）、`URL.createObjectURL(blob)` で生成された URL が返されますが、キャッシュには格納されません。そのため、この URL は `clear()` や LRU エビクションの対象外となり、`URL.revokeObjectURL()` が一度も呼ばれないまま残ります。ページ滞在中に `clear()` とインフライトリクエストが繰り返されると、解放されない Blob URL が蓄積します。`URL.revokeObjectURL(url)` を呼ぶタイミングを明示的に設けるか、"orphan URL" を別リストで追跡して次回の `clear()` 時にまとめて解放する設計を検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/web-app-vercel/lib/__tests__/audioCache.test.ts`, line 101-103 ([link](https://github.com/hiroki-org/audicle/blob/f754b554f81fc1e927ad2913baaa937010e4aa14/packages/web-app-vercel/lib/__tests__/audioCache.test.ts#L101-L103)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> このテストだけ `require('../api')` でローカルに取得していますが、ファイル冒頭で `import { synthesizeSpeech } from '../api'` が追加されたので、他のテストと同様にそちらを直接使えます。`require` を残すと jest の Module registry を二重に参照するリスクがあり、他テストとの整合性も崩れます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/__tests__/audioCache.test.ts
   Line: 101-103

   Comment:
   このテストだけ `require('../api')` でローカルに取得していますが、ファイル冒頭で `import { synthesizeSpeech } from '../api'` が追加されたので、他のテストと同様にそちらを直接使えます。`require` を残すと jest の Module registry を二重に参照するリスクがあり、他テストとの整合性も崩れます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/lib/audioCache.ts:125-130
**生成世代不一致時の Blob URL がリークする**

`cacheGeneration` が一致しない場合（`clear()` 後にインフライトが完了したとき）、`URL.createObjectURL(blob)` で生成された URL が返されますが、キャッシュには格納されません。そのため、この URL は `clear()` や LRU エビクションの対象外となり、`URL.revokeObjectURL()` が一度も呼ばれないまま残ります。ページ滞在中に `clear()` とインフライトリクエストが繰り返されると、解放されない Blob URL が蓄積します。`URL.revokeObjectURL(url)` を呼ぶタイミングを明示的に設けるか、"orphan URL" を別リストで追跡して次回の `clear()` 時にまとめて解放する設計を検討してください。

### Issue 2 of 2
packages/web-app-vercel/lib/__tests__/audioCache.test.ts:101-103
このテストだけ `require('../api')` でローカルに取得していますが、ファイル冒頭で `import { synthesizeSpeech } from '../api'` が追加されたので、他のテストと同様にそちらを直接使えます。`require` を残すと jest の Module registry を二重に参照するリスクがあり、他テストとの整合性も崩れます。

```suggestion
        it('should call synthesizeSpeech on cache miss and return a blob URL', async () => {
            const url = await cache.get('test text', 'voice1', 'url1');
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dedupe in-flight audio cache reques..."](https://github.com/hiroki-org/audicle/commit/f754b554f81fc1e927ad2913baaa937010e4aa14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31013197)</sub>

<!-- /greptile_comment -->