### PR TITLE
fix: clear corrupt article cache entries

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
@@ -245,5 +245,158 @@ describe("local-cache", () => {
             );
             expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
+
+        describe("safeRemoveCache swallows removeItem errors", () => {
+            beforeEach(() => {
+                (global.localStorage.removeItem as jest.Mock).mockImplementation(() => {
+                    throw new Error("Storage removeItem failed");
+                });
+            });
+
+            it("should not throw when removeItem fails on invalid cache structure", () => {
+                global.localStorage.setItem(mockKey, JSON.stringify({ invalid: "data" }));
+
+                expect(() => getArticlesCache(mockUserId)).not.toThrow();
+                const result = getArticlesCache(mockUserId);
+                expect(result).toBeNull();
+            });
+
+            it("should not throw when removeItem fails on version mismatch", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({ version: 999, timestamp: Date.now(), payload: mockData })
+                );
+
+                expect(() => getArticlesCache(mockUserId)).not.toThrow();
+                const result = getArticlesCache(mockUserId);
+                expect(result).toBeNull();
+            });
+
+            it("should not throw when removeItem fails on expired cache", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({
+                        version: 1,
+                        timestamp: Date.now() - (1000 * 60 * 60 * 25),
+                        payload: mockData,
+                    })
+                );
+
+                expect(() => getArticlesCache(mockUserId)).not.toThrow();
+                const result = getArticlesCache(mockUserId);
+                expect(result).toBeNull();
+            });
+
+            it("should not throw when removeItem fails on invalid payload structure", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({ version: 1, timestamp: Date.now(), payload: { invalid: "payload" } })
+                );
+
+                expect(() => getArticlesCache(mockUserId)).not.toThrow();
+                const result = getArticlesCache(mockUserId);
+                expect(result).toBeNull();
+            });
+
+            it("should not throw when removeItem fails on JSON parse error", () => {
+                global.localStorage.setItem(mockKey, "not-valid-json");
+
+                expect(() => getArticlesCache(mockUserId)).not.toThrow();
+                const result = getArticlesCache(mockUserId);
+                expect(result).toBeNull();
+            });
+        });
+
+        describe("safeRemoveCache called exactly once per error path", () => {
+            it("should call removeItem exactly once on invalid cache structure", () => {
+                global.localStorage.setItem(mockKey, JSON.stringify({ invalid: "data" }));
+
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).toHaveBeenCalledTimes(1);
+                expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+            });
+
+            it("should call removeItem exactly once on version mismatch", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({ version: 999, timestamp: Date.now(), payload: mockData })
+                );
+
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).toHaveBeenCalledTimes(1);
+                expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+            });
+
+            it("should call removeItem exactly once on expired cache", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({
+                        version: 1,
+                        timestamp: Date.now() - (1000 * 60 * 60 * 25),
+                        payload: mockData,
+                    })
+                );
+
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).toHaveBeenCalledTimes(1);
+                expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+            });
+
+            it("should call removeItem exactly once on invalid payload structure", () => {
+                global.localStorage.setItem(
+                    mockKey,
+                    JSON.stringify({ version: 1, timestamp: Date.now(), payload: { invalid: "payload" } })
+                );
+
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).toHaveBeenCalledTimes(1);
+                expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+            });
+
+            it("should call removeItem exactly once on JSON parse error", () => {
+                global.localStorage.setItem(mockKey, "not-valid-json");
+
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).toHaveBeenCalledTimes(1);
+                expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+            });
+
+            it("should not call removeItem on a cache miss (null stored value)", () => {
+                // Nothing in cache — no cleanup should occur
+                getArticlesCache(mockUserId);
+
+                expect(global.localStorage.removeItem).not.toHaveBeenCalled();
+            });
+        });
+
+        it("should call removeItem with correct key when localStorage.getItem itself throws", () => {
+            // Key is computed before the try block, so even when getItem throws,
+            // safeRemoveCache receives the correct key in the catch handler.
+            (global.localStorage.getItem as jest.Mock).mockImplementation(() => {
+                throw new Error("getItem failed");
+            });
+
+            const result = getArticlesCache(mockUserId);
+
+            expect(result).toBeNull();
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
+        });
+
+        it("should not throw when both getItem and removeItem throw", () => {
+            (global.localStorage.getItem as jest.Mock).mockImplementation(() => {
+                throw new Error("getItem failed");
+            });
+            (global.localStorage.removeItem as jest.Mock).mockImplementation(() => {
+                throw new Error("removeItem failed");
+            });
+
+            expect(() => getArticlesCache(mockUserId)).not.toThrow();
+            expect(getArticlesCache(mockUserId)).toBeNull();
+        });
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
@@ -398,5 +398,13 @@ describe("local-cache", () => {
             expect(() => getArticlesCache(mockUserId)).not.toThrow();
             expect(getArticlesCache(mockUserId)).toBeNull();
         });
+
+        it("should return null without throwing when localStorage is unavailable after window exists", () => {
+            // @ts-ignore
+            delete global.localStorage;
+
+            expect(() => getArticlesCache(mockUserId)).not.toThrow();
+            expect(getArticlesCache(mockUserId)).toBeNull();
+        });
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/local-cache.test.ts
@@ -164,6 +164,7 @@ describe("local-cache", () => {
 
             expect(result).toBeNull();
             expect(console.warn).toHaveBeenCalledWith("Invalid cache structure detected");
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
 
         it("should clear cache and return null if version mismatch", () => {
@@ -214,6 +215,7 @@ describe("local-cache", () => {
 
             expect(result).toBeNull();
             expect(console.warn).toHaveBeenCalledWith("Invalid cached payload structure");
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
 
         it("should return parsed payload successfully", () => {
@@ -241,6 +243,7 @@ describe("local-cache", () => {
                 "Failed to read articles cache:",
                 expect.any(SyntaxError)
             );
+            expect(global.localStorage.removeItem).toHaveBeenCalledWith(mockKey);
         });
     });
 });

--- a/packages/web-app-vercel/lib/local-cache.ts
+++ b/packages/web-app-vercel/lib/local-cache.ts
@@ -19,8 +19,9 @@ const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
 
 export function getArticlesCache(userId: string): CachedPlaylistData | null {
     if (typeof window === "undefined" || !userId) return null;
+    const key = getArticlesCacheKey(userId);
+
     try {
-        const key = `${STORAGE_KEYS.ARTICLES_CACHE}-${userId}`;
         const cached = localStorage.getItem(key);
         if (!cached) return null;
 
@@ -28,18 +29,19 @@ export function getArticlesCache(userId: string): CachedPlaylistData | null {
 
         if (!isValidEnvelope(parsed)) {
             console.warn("Invalid cache structure detected");
+            safeRemoveCache(key);
             return null;
         }
 
         if (parsed.version !== CACHE_VERSION) {
             console.warn("Cache version mismatch; clearing cache");
-            try { localStorage.removeItem(key); } catch { }
+            safeRemoveCache(key);
             return null;
         }
 
         if (Date.now() - parsed.timestamp > CACHE_TTL_MS) {
             console.info("Articles cache expired; removing");
-            try { localStorage.removeItem(key); } catch { }
+            safeRemoveCache(key);
             return null;
         }
 
@@ -48,10 +50,24 @@ export function getArticlesCache(userId: string): CachedPlaylistData | null {
         }
 
         console.warn("Invalid cached payload structure");
+        safeRemoveCache(key);
         return null;
     } catch (error) {
         console.error("Failed to read articles cache:", error);
+        safeRemoveCache(key);
         return null;
+    }
+}
+
+function getArticlesCacheKey(userId: string): string {
+    return `${STORAGE_KEYS.ARTICLES_CACHE}-${userId}`;
+}
+
+function safeRemoveCache(key: string): void {
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // Ignore cleanup failures; callers already fall back to a cache miss.
     }
 }
 
@@ -79,7 +95,7 @@ function isValidCachedData(data: any): data is CachedPlaylistData {
 export function setArticlesCache(userId: string, data: CachedPlaylistData): void {
     if (typeof window === "undefined" || !userId) return;
     try {
-        const key = `${STORAGE_KEYS.ARTICLES_CACHE}-${userId}`;
+        const key = getArticlesCacheKey(userId);
         const envelope: CacheEnvelope = { version: CACHE_VERSION, timestamp: Date.now(), payload: data };
         localStorage.setItem(key, JSON.stringify(envelope));
     } catch (error) {

--- a/packages/web-app-vercel/lib/local-cache.ts
+++ b/packages/web-app-vercel/lib/local-cache.ts
@@ -64,6 +64,8 @@ function getArticlesCacheKey(userId: string): string {
 }
 
 function safeRemoveCache(key: string): void {
+    if (typeof localStorage === "undefined" || localStorage === null) return;
+
     try {
         localStorage.removeItem(key);
     } catch {


### PR DESCRIPTION
## Summary
- remove malformed local article cache envelopes instead of leaving repeated read failures
- clear invalid payload and invalid JSON entries for the affected user cache key
- add unit coverage for cleanup on corrupt cache states

## Verification
- npm run test:unit -- --watchman=false --coverage=false lib/__tests__/local-cache.test.ts
- npm run lint -- lib/local-cache.ts lib/__tests__/local-cache.test.ts
- NEXT_PUBLIC_AUTH_ENV=test AUTH_ENV=test NEXTAUTH_SECRET=test-secret npm run build

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `getArticlesCache` 関数において、キャッシュが壊れている・バージョン不一致・JSONパース失敗などの失敗ケースで該当エントリを `localStorage` から削除するように修正します。合わせて、キー生成と削除処理を専用ヘルパー関数 (`getArticlesCacheKey`、`safeRemoveCache`) に切り出してコードの重複を解消しています。

- 無効エンベロープ・無効ペイロード・JSONパースエラーのすべての失敗パスで `safeRemoveCache(key)` が呼ばれるようになり、再読み込み時の連続失敗を防止。
- `safeRemoveCache` 内部に try-catch を持つことで、`localStorage.removeItem` 自体が失敗した場合もエラーが上位に伝播しない設計になっている。
- 3つのエラーケースに `removeItem` 呼び出しを検証するアサーションを追加し、テストカバレッジを補完。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

破損キャッシュの自動削除という限定的な修正で、既存の正常系には影響しない。マージして問題ない。

変更範囲は `getArticlesCache` の失敗パスのみで、正常に値が返るパスは一切変更されていない。`safeRemoveCache` は自身の try-catch で削除失敗を吸収するため、呼び出し元に例外が伝播しない。新規追加の3テストすべてが既存のモック構成と整合しており、回帰リスクは極めて低い。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/local-cache.ts | 破損キャッシュエントリの自動削除ロジックを追加。キー生成とキャッシュ削除の共通ヘルパー関数を抽出し、DRY性を向上。変更は小規模で論理的に正しい。 |
| packages/web-app-vercel/lib/__tests__/local-cache.test.ts | 破損キャッシュ時に `removeItem` が呼ばれることを検証するアサーションを3ケースに追加。既存テストと一貫したスタイルで実装されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getArticlesCache呼び出し] --> B{window未定義 or userId空?}
    B -- Yes --> C[nullを返す]
    B -- No --> D[cacheKeyを生成]
    D --> E[localStorage.getItem]
    E -- null --> C
    E -- 値あり --> F[JSON.parse]
    F -- 失敗 --> G[console.error\nsafeRemoveCache]
    G --> C
    F -- 成功 --> H{isValidEnvelope?}
    H -- No --> I[console.warn\nsafeRemoveCache]
    I --> C
    H -- Yes --> J{バージョン一致?}
    J -- No --> K[console.warn\nsafeRemoveCache]
    K --> C
    J -- Yes --> L{TTL内?}
    L -- No --> M[console.info\nsafeRemoveCache]
    M --> C
    L -- Yes --> N{isValidCachedData?}
    N -- No --> O[console.warn\nsafeRemoveCache]
    O --> C
    N -- Yes --> P[payloadを返す]
```

<sub>Reviews (1): Last reviewed commit: ["📝 CodeRabbit Chat: Add unit tests"](https://github.com/hiroki-org/audicle/commit/8e23a2c5df1a259fdb34dc3de66bd02b3aaf9eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31016299)</sub>

<!-- /greptile_comment -->