### PR TITLE
fix: wait for indexeddb write transactions

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
@@ -143,6 +143,25 @@ describe('IndexedDB write transactions', () => {
         await expect(promise).rejects.toBe(error);
     });
 
+    it('saveAudioChunk should reject with a fallback Error when the transaction abort has no error', async () => {
+        const mock = createIndexedDBMock();
+        const { saveAudioChunk } = await import('../indexedDB');
+        const promise = saveAudioChunk({
+            audioData: new Blob(['audio'], { type: 'audio/wav' }),
+            timestamp: 123,
+            articleUrl: 'https://example.com/article',
+            chunkIndex: 0,
+            totalChunks: 1,
+            size: 5,
+        });
+
+        await openDatabase(mock);
+        mock.transaction.error = null;
+        mock.transaction.onabort();
+
+        await expect(promise).rejects.toThrow('Save transaction aborted');
+    });
+
     it('clearAll should resolve only after the clear transaction completes', async () => {
         const mock = createIndexedDBMock();
         const { clearAll } = await import('../indexedDB');
@@ -175,5 +194,17 @@ describe('IndexedDB write transactions', () => {
         mock.transaction.onabort();
 
         await expect(promise).rejects.toBe(error);
+    });
+
+    it('clearAll should reject with a fallback Error when the transaction abort has no error', async () => {
+        const mock = createIndexedDBMock();
+        const { clearAll } = await import('../indexedDB');
+        const promise = clearAll();
+
+        await openDatabase(mock);
+        mock.transaction.error = null;
+        mock.transaction.onabort();
+
+        await expect(promise).rejects.toThrow('Clear transaction aborted');
     });
 });

--- a/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
@@ -1,5 +1,47 @@
 import { generateKey } from '../indexedDB';
 
+type IndexedDBMock = {
+    openRequest: Record<string, any>;
+    db: Record<string, any>;
+    transaction: Record<string, any>;
+    store: Record<string, jest.Mock>;
+    putRequest: Record<string, any>;
+    clearRequest: Record<string, any>;
+};
+
+function createIndexedDBMock(): IndexedDBMock {
+    const openRequest: Record<string, any> = {};
+    const putRequest: Record<string, any> = {};
+    const clearRequest: Record<string, any> = {};
+    const store = {
+        put: jest.fn(() => putRequest),
+        clear: jest.fn(() => clearRequest),
+    };
+    const transaction: Record<string, any> = {
+        objectStore: jest.fn(() => store),
+        error: null,
+    };
+    const db: Record<string, any> = {
+        transaction: jest.fn(() => transaction),
+        close: jest.fn(),
+    };
+
+    Object.defineProperty(global, 'indexedDB', {
+        configurable: true,
+        value: {
+            open: jest.fn(() => openRequest),
+        },
+    });
+
+    return { openRequest, db, transaction, store, putRequest, clearRequest };
+}
+
+async function openDatabase(mock: IndexedDBMock) {
+    mock.openRequest.result = mock.db;
+    mock.openRequest.onsuccess();
+    await Promise.resolve();
+}
+
 describe('generateKey', () => {
     it('should generate a key with all arguments provided', () => {
         const articleUrl = 'https://example.com/article';
@@ -38,5 +80,100 @@ describe('generateKey', () => {
         const result = generateKey(articleUrl, chunkIndex, voiceModel);
 
         expect(result).toBe(`${encodeURIComponent('https://example.com/path/to/article?param1=value1&param2=value2#hash')}:999:${encodeURIComponent('ja-JP-Standard-A')}`);
+    });
+});
+
+describe('IndexedDB write transactions', () => {
+    afterEach(() => {
+        jest.resetModules();
+        // @ts-ignore
+        delete global.indexedDB;
+    });
+
+    it('saveAudioChunk should resolve only after the write transaction completes', async () => {
+        const mock = createIndexedDBMock();
+        const { saveAudioChunk } = await import('../indexedDB');
+        const entry = {
+            audioData: new Blob(['audio'], { type: 'audio/wav' }),
+            timestamp: 123,
+            articleUrl: 'https://example.com/article',
+            chunkIndex: 0,
+            totalChunks: 2,
+            voiceModel: 'ja-JP-Test',
+            size: 5,
+        };
+
+        let resolved = false;
+        const promise = saveAudioChunk(entry).then(() => {
+            resolved = true;
+        });
+
+        await openDatabase(mock);
+
+        expect(mock.store.put).toHaveBeenCalledWith(expect.objectContaining({
+            key: generateKey(entry.articleUrl, entry.chunkIndex, entry.voiceModel),
+            articleUrl: entry.articleUrl,
+        }));
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        mock.transaction.oncomplete();
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(resolved).toBe(true);
+    });
+
+    it('saveAudioChunk should reject when the put request fails', async () => {
+        const mock = createIndexedDBMock();
+        const { saveAudioChunk } = await import('../indexedDB');
+        const error = new Error('put failed');
+        const promise = saveAudioChunk({
+            audioData: new Blob(['audio'], { type: 'audio/wav' }),
+            timestamp: 123,
+            articleUrl: 'https://example.com/article',
+            chunkIndex: 0,
+            totalChunks: 1,
+            size: 5,
+        });
+
+        await openDatabase(mock);
+        mock.putRequest.error = error;
+        mock.putRequest.onerror();
+
+        await expect(promise).rejects.toBe(error);
+    });
+
+    it('clearAll should resolve only after the clear transaction completes', async () => {
+        const mock = createIndexedDBMock();
+        const { clearAll } = await import('../indexedDB');
+
+        let resolved = false;
+        const promise = clearAll().then(() => {
+            resolved = true;
+        });
+
+        await openDatabase(mock);
+
+        expect(mock.store.clear).toHaveBeenCalledTimes(1);
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        mock.transaction.oncomplete();
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(resolved).toBe(true);
+    });
+
+    it('clearAll should reject when the clear transaction aborts', async () => {
+        const mock = createIndexedDBMock();
+        const { clearAll } = await import('../indexedDB');
+        const error = new Error('transaction aborted');
+        const promise = clearAll();
+
+        await openDatabase(mock);
+        mock.transaction.error = error;
+        mock.transaction.onabort();
+
+        await expect(promise).rejects.toBe(error);
     });
 });

--- a/packages/web-app-vercel/lib/indexedDB.ts
+++ b/packages/web-app-vercel/lib/indexedDB.ts
@@ -73,6 +73,11 @@ function openDB(): Promise<IDBDatabase> {
                 logger.warn('IndexedDB connection closed unexpectedly.');
                 dbPromise = null;
             };
+            db.onversionchange = () => {
+                logger.warn('IndexedDB version changed; closing cached connection.');
+                db.close();
+                dbPromise = null;
+            };
             resolve(db);
         };
 
@@ -109,23 +114,35 @@ export async function saveAudioChunk(entry: Omit<AudioCacheEntry, 'key'>): Promi
 
     return new Promise((resolve, reject) => {
         const transaction = db.transaction([STORE_NAME], 'readwrite');
+        let isSettled = false;
+
+        const rejectOnce = (message: string, error: unknown) => {
+            if (isSettled) return;
+            isSettled = true;
+            logger.error(message, error);
+            reject(error);
+        };
 
         transaction.onerror = () => {
-            logger.error('Save transaction error', transaction.error);
-            reject(transaction.error);
+            rejectOnce('Save transaction error', transaction.error);
+        };
+
+        transaction.onabort = () => {
+            rejectOnce('Save transaction aborted', transaction.error);
+        };
+
+        transaction.oncomplete = () => {
+            if (isSettled) return;
+            isSettled = true;
+            logger.info(`Saved chunk ${entry.chunkIndex + 1}/${entry.totalChunks} for ${entry.articleUrl}`);
+            resolve();
         };
 
         const store = transaction.objectStore(STORE_NAME);
         const request = store.put(cacheEntry);
 
-        request.onsuccess = () => {
-            logger.info(`Saved chunk ${entry.chunkIndex + 1}/${entry.totalChunks} for ${entry.articleUrl}`);
-            resolve();
-        };
-
         request.onerror = () => {
-            logger.error('Save error', request.error);
-            reject(request.error);
+            rejectOnce('Save error', request.error);
         };
     });
 }
@@ -238,23 +255,35 @@ export async function clearAll(): Promise<void> {
 
     return new Promise((resolve, reject) => {
         const transaction = db.transaction([STORE_NAME], 'readwrite');
+        let isSettled = false;
+
+        const rejectOnce = (message: string, error: unknown) => {
+            if (isSettled) return;
+            isSettled = true;
+            logger.error(message, error);
+            reject(error);
+        };
 
         transaction.onerror = () => {
-            logger.error('Clear transaction error', transaction.error);
-            reject(transaction.error);
+            rejectOnce('Clear transaction error', transaction.error);
+        };
+
+        transaction.onabort = () => {
+            rejectOnce('Clear transaction aborted', transaction.error);
+        };
+
+        transaction.oncomplete = () => {
+            if (isSettled) return;
+            isSettled = true;
+            logger.info('Cleared all cache');
+            resolve();
         };
 
         const store = transaction.objectStore(STORE_NAME);
         const request = store.clear();
 
-        request.onsuccess = () => {
-            logger.info('Cleared all cache');
-            resolve();
-        };
-
         request.onerror = () => {
-            logger.error('Clear error', request.error);
-            reject(request.error);
+            rejectOnce('Clear error', request.error);
         };
     });
 }

--- a/packages/web-app-vercel/lib/indexedDB.ts
+++ b/packages/web-app-vercel/lib/indexedDB.ts
@@ -119,8 +119,9 @@ export async function saveAudioChunk(entry: Omit<AudioCacheEntry, 'key'>): Promi
         const rejectOnce = (message: string, error: unknown) => {
             if (isSettled) return;
             isSettled = true;
-            logger.error(message, error);
-            reject(error);
+            const finalError = error || new Error(message);
+            logger.error(message, finalError);
+            reject(finalError);
         };
 
         transaction.onerror = () => {
@@ -260,8 +261,9 @@ export async function clearAll(): Promise<void> {
         const rejectOnce = (message: string, error: unknown) => {
             if (isSettled) return;
             isSettled = true;
-            logger.error(message, error);
-            reject(error);
+            const finalError = error || new Error(message);
+            logger.error(message, finalError);
+            reject(finalError);
         };
 
         transaction.onerror = () => {


### PR DESCRIPTION
## Summary
- resolve saveAudioChunk and clearAll only after the IndexedDB transaction completes
- reject write operations on transaction abort/error without double-settling
- close/reset the cached IndexedDB connection on version changes
- add unit coverage for write completion and failure paths

## Verification
- npm run test:unit -- --watchman=false --coverage=false lib/__tests__/indexedDB.test.ts
- npm run lint -- lib/indexedDB.ts lib/__tests__/indexedDB.test.ts
- NEXT_PUBLIC_AUTH_ENV=test AUTH_ENV=test NEXTAUTH_SECRET=test-secret npm run build

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

IndexedDB の書き込みトランザクションで `request.onsuccess` 時点で resolve していた問題を修正し、`transaction.oncomplete` まで待つように変更しています。加えて、トランザクション中断や二重 settle を防ぐ `rejectOnce` パターンと `onversionchange` による接続リセットも導入しています。

- `saveAudioChunk` / `clearAll` の resolve タイミングを `transaction.oncomplete` に統一し、`onabort` ハンドラと `rejectOnce` ガードを追加。
- `db.onversionchange` ハンドラを追加し、他タブ等がバージョンアップした際にキャッシュ済み接続を閉じてリセットするように対応。
- 書き込み完了・失敗パスを検証するユニットテストを新規追加したが、`deleteArticle`（同じく書き込みトランザクション）への同等修正が欠落しており、`onabort` 時に Promise がハングする可能性が残る。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

`saveAudioChunk` と `clearAll` の修正自体は正確だが、`deleteArticle` に同等の防御処理が施されていないためマージ前に確認が必要。

`deleteArticle` は書き込みトランザクションを使いながら `onabort` ハンドラを持たず、トランザクションが中断された場合に呼び出し元の Promise が永遠に settled にならないリスクが現行コードに残っている。

`lib/indexedDB.ts` の `deleteArticle` 関数（`onabort` ハンドラと `rejectOnce` パターンの欠落）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/indexedDB.ts | `saveAudioChunk` と `clearAll` の resolve タイミングを `request.onsuccess` から `transaction.oncomplete` に修正し、`rejectOnce` パターンと `onabort` ハンドラを追加。ただし同じ書き込みトランザクションを使う `deleteArticle` には同等の修正が適用されておらず、`onabort` ハンドラ欠落による Promise ハングのリスクが残る。 |
| packages/web-app-vercel/lib/__tests__/indexedDB.test.ts | 書き込みトランザクションの完了待ちと失敗パスをカバーする新規テストを追加。`jest.resetModules()` を使ったモジュール分離も適切。ただし `onversionchange` ハンドラのテストと `saveAudioChunk` の `transaction.onabort` パスのテストが欠落している。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/web-app-vercel/lib/indexedDB.ts`, line 215-248 ([link](https://github.com/hiroki-org/audicle/blob/46d8f75b4c8b4d566bb844b5fe036490a7ad8681/packages/web-app-vercel/lib/indexedDB.ts#L215-L248)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`deleteArticle` に `onabort` ハンドラが欠落しています**

   このPRは `saveAudioChunk` と `clearAll` に `transaction.onabort` ハンドラを追加して書き込みトランザクションの未処理中断を修正しましたが、同じく書き込みトランザクションを使う `deleteArticle` には対応が施されていません。IDBの仕様上、`transaction.abort()` が明示的に呼ばれた場合は `transaction.onerror` がスキップされ `transaction.onabort` だけが発火するため、このケースで返却された Promise が永遠に settled にならず呼び出し元がハングします。同じ `rejectOnce` パターンと `transaction.onabort` ハンドラを追加することで一貫した防御的実装になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/indexedDB.ts
   Line: 215-248

   Comment:
   **`deleteArticle` に `onabort` ハンドラが欠落しています**

   このPRは `saveAudioChunk` と `clearAll` に `transaction.onabort` ハンドラを追加して書き込みトランザクションの未処理中断を修正しましたが、同じく書き込みトランザクションを使う `deleteArticle` には対応が施されていません。IDBの仕様上、`transaction.abort()` が明示的に呼ばれた場合は `transaction.onerror` がスキップされ `transaction.onabort` だけが発火するため、このケースで返却された Promise が永遠に settled にならず呼び出し元がハングします。同じ `rejectOnce` パターンと `transaction.onabort` ハンドラを追加することで一貫した防御的実装になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/web-app-vercel/lib/__tests__/indexedDB.test.ts`, line 86-91 ([link](https://github.com/hiroki-org/audicle/blob/46d8f75b4c8b4d566bb844b5fe036490a7ad8681/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts#L86-L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`onversionchange` ハンドラのテストが存在しない**

   このPRで新たに追加された `db.onversionchange` ハンドラ（`db.close()` と `dbPromise = null` を実行する）に対応するユニットテストがありません。モックの `db.onversionchange()` を呼び出して `db.close` が呼ばれること、および次回の `openDB()` 呼び出しで新しい接続が開かれることを検証するテストを追加することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
   Line: 86-91

   Comment:
   **`onversionchange` ハンドラのテストが存在しない**

   このPRで新たに追加された `db.onversionchange` ハンドラ（`db.close()` と `dbPromise = null` を実行する）に対応するユニットテストがありません。モックの `db.onversionchange()` を呼び出して `db.close` が呼ばれること、および次回の `openDB()` 呼び出しで新しい接続が開かれることを検証するテストを追加することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `packages/web-app-vercel/lib/__tests__/indexedDB.test.ts`, line 126-144 ([link](https://github.com/hiroki-org/audicle/blob/46d8f75b4c8b4d566bb844b5fe036490a7ad8681/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts#L126-L144)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`saveAudioChunk` の `transaction.onabort` 失敗パスがテストされていない**

   `clearAll` には `transaction.onabort` で reject するテストがありますが、同じハンドラが追加された `saveAudioChunk` に対応するテストケースがありません。`request.onerror` の後にブラウザが自動的に `transaction.onabort` を発火させる実際の挙動を考えると、両方の関数に対称的なテストを用意することで `rejectOnce` の二重reject防止ガードが正しく機能することも検証できます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
   Line: 126-144

   Comment:
   **`saveAudioChunk` の `transaction.onabort` 失敗パスがテストされていない**

   `clearAll` には `transaction.onabort` で reject するテストがありますが、同じハンドラが追加された `saveAudioChunk` に対応するテストケースがありません。`request.onerror` の後にブラウザが自動的に `transaction.onabort` を発火させる実際の挙動を考えると、両方の関数に対称的なテストを用意することで `rejectOnce` の二重reject防止ガードが正しく機能することも検証できます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web-app-vercel/lib/indexedDB.ts:215-248
**`deleteArticle` に `onabort` ハンドラが欠落しています**

このPRは `saveAudioChunk` と `clearAll` に `transaction.onabort` ハンドラを追加して書き込みトランザクションの未処理中断を修正しましたが、同じく書き込みトランザクションを使う `deleteArticle` には対応が施されていません。IDBの仕様上、`transaction.abort()` が明示的に呼ばれた場合は `transaction.onerror` がスキップされ `transaction.onabort` だけが発火するため、このケースで返却された Promise が永遠に settled にならず呼び出し元がハングします。同じ `rejectOnce` パターンと `transaction.onabort` ハンドラを追加することで一貫した防御的実装になります。

### Issue 2 of 3
packages/web-app-vercel/lib/__tests__/indexedDB.test.ts:86-91
**`onversionchange` ハンドラのテストが存在しない**

このPRで新たに追加された `db.onversionchange` ハンドラ（`db.close()` と `dbPromise = null` を実行する）に対応するユニットテストがありません。モックの `db.onversionchange()` を呼び出して `db.close` が呼ばれること、および次回の `openDB()` 呼び出しで新しい接続が開かれることを検証するテストを追加することを推奨します。

### Issue 3 of 3
packages/web-app-vercel/lib/__tests__/indexedDB.test.ts:126-144
**`saveAudioChunk` の `transaction.onabort` 失敗パスがテストされていない**

`clearAll` には `transaction.onabort` で reject するテストがありますが、同じハンドラが追加された `saveAudioChunk` に対応するテストケースがありません。`request.onerror` の後にブラウザが自動的に `transaction.onabort` を発火させる実際の挙動を考えると、両方の関数に対称的なテストを用意することで `rejectOnce` の二重reject防止ガードが正しく機能することも検証できます。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use fallback errors for indexeddb a..."](https://github.com/hiroki-org/audicle/commit/46d8f75b4c8b4d566bb844b5fe036490a7ad8681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31019039)</sub>

<!-- /greptile_comment -->