### PR TITLE
test: clear browser caches in e2e setup

### DIFF
--- a/packages/web-app-vercel/__tests__/testSetup.test.ts
+++ b/packages/web-app-vercel/__tests__/testSetup.test.ts
@@ -1,0 +1,102 @@
+import { clearLocalStorage, clearLocalStorageAndCookies } from '../tests/helpers/testSetup';
+
+function mockPage() {
+    const clearCookies = jest.fn().mockResolvedValue(undefined);
+
+    return {
+        clearCookies,
+        page: {
+            goto: jest.fn().mockResolvedValue(undefined),
+            waitForLoadState: jest.fn().mockResolvedValue(undefined),
+            evaluate: jest.fn((fn: (..._args: unknown[]) => unknown, ...args: unknown[]) => fn(...args)),
+            context: jest.fn(() => ({
+                clearCookies,
+            })),
+        },
+    };
+}
+
+function installBrowserStateMocks() {
+    const localStorageMock = { clear: jest.fn(), setItem: jest.fn() };
+    const sessionStorageMock = { clear: jest.fn() };
+    const cachesMock = {
+        delete: jest.fn().mockResolvedValue(true),
+        keys: jest.fn().mockResolvedValue(['audicle-app-cache', 'audicle-audio-cache']),
+    };
+    const deleteDatabase = jest.fn(() => {
+        const request: Partial<IDBOpenDBRequest> = {};
+        queueMicrotask(() => request.onsuccess?.({} as Event));
+        return request as IDBOpenDBRequest;
+    });
+    const indexedDBMock = {
+        databases: jest.fn().mockResolvedValue([
+            { name: 'audicle-audio-cache', version: 1 },
+            { name: undefined, version: undefined },
+        ]),
+        deleteDatabase,
+    };
+
+    Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: localStorageMock,
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: sessionStorageMock,
+    });
+    Object.defineProperty(globalThis, 'caches', {
+        configurable: true,
+        value: cachesMock,
+    });
+    Object.defineProperty(globalThis, 'indexedDB', {
+        configurable: true,
+        value: indexedDBMock,
+    });
+
+    return {
+        cachesMock,
+        deleteDatabase,
+        indexedDBMock,
+        localStorageMock,
+        sessionStorageMock,
+    };
+}
+
+describe('testSetup browser cleanup helpers', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('clears storage, Cache Storage, and IndexedDB without clearing auth cookies', async () => {
+        const state = installBrowserStateMocks();
+        const { clearCookies, page } = mockPage();
+
+        await clearLocalStorage(page as never);
+
+        expect(page.goto).toHaveBeenCalledWith('/');
+        expect(page.waitForLoadState).toHaveBeenCalledWith('load');
+        expect(state.localStorageMock.clear).toHaveBeenCalledTimes(1);
+        expect(state.sessionStorageMock.clear).toHaveBeenCalledTimes(1);
+        expect(state.cachesMock.keys).toHaveBeenCalledTimes(1);
+        expect(state.cachesMock.delete).toHaveBeenCalledWith('audicle-app-cache');
+        expect(state.cachesMock.delete).toHaveBeenCalledWith('audicle-audio-cache');
+        expect(state.indexedDBMock.databases).toHaveBeenCalledTimes(1);
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-cache');
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-audio-cache');
+        expect(clearCookies).not.toHaveBeenCalled();
+    });
+
+    it('also clears cookies for unauthenticated browser reset', async () => {
+        const state = installBrowserStateMocks();
+        const { clearCookies, page } = mockPage();
+
+        await clearLocalStorageAndCookies(page as never);
+
+        expect(clearCookies).toHaveBeenCalledTimes(1);
+        expect(state.localStorageMock.clear).toHaveBeenCalledTimes(1);
+        expect(state.sessionStorageMock.clear).toHaveBeenCalledTimes(1);
+        expect(state.cachesMock.delete).toHaveBeenCalledWith('audicle-app-cache');
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-cache');
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-audio-cache');
+    });
+});

--- a/packages/web-app-vercel/__tests__/testSetup.test.ts
+++ b/packages/web-app-vercel/__tests__/testSetup.test.ts
@@ -99,4 +99,15 @@ describe('testSetup browser cleanup helpers', () => {
         expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-cache');
         expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-audio-cache');
     });
+
+    it('clears known IndexedDB cache names when database enumeration is unavailable', async () => {
+        const state = installBrowserStateMocks();
+        const { page } = mockPage();
+        delete (state.indexedDBMock as { databases?: unknown }).databases;
+
+        await clearLocalStorage(page as never);
+
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-cache');
+        expect(state.deleteDatabase).toHaveBeenCalledWith('audicle-audio-cache');
+    });
 });

--- a/packages/web-app-vercel/tests/helpers/testSetup.ts
+++ b/packages/web-app-vercel/tests/helpers/testSetup.ts
@@ -1,30 +1,68 @@
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { STORAGE_KEYS } from '@/lib/constants';
 
+async function openAppOrigin(page: Page) {
+    try {
+        await page.goto('/');
+        await page.waitForLoadState('load');
+    } catch {
+        // If navigation fails for some reason, continue and try to clear state
+        // from the current origin.
+        /* noop */
+    }
+}
+
+async function clearBrowserState(page: Page) {
+    await page.evaluate(async () => {
+        try { localStorage.clear(); } catch { /* ignore */ }
+        try { sessionStorage.clear(); } catch { /* ignore */ }
+
+        try {
+            if ('caches' in window) {
+                const cacheNames = await caches.keys();
+                await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+            }
+        } catch {
+            /* ignore */
+        }
+
+        try {
+            if ('indexedDB' in window) {
+                const databaseNames = new Set(['audicle-cache']);
+
+                if (typeof indexedDB.databases === 'function') {
+                    const databases = await indexedDB.databases();
+                    databases.forEach((database) => {
+                        if (database.name) {
+                            databaseNames.add(database.name);
+                        }
+                    });
+                }
+
+                await Promise.all([...databaseNames].map((name) => new Promise<void>((resolve) => {
+                    const request = indexedDB.deleteDatabase(name);
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => resolve();
+                    request.onblocked = () => resolve();
+                })));
+            }
+        } catch {
+            /* ignore */
+        }
+    });
+}
+
 /**
- * localStorageのみをクリアする（認証状態を保持）
+ * ブラウザ内のテスト状態をクリアする（認証Cookieは保持）
  * ソート順などの設定をリセットしたい場合に使用
  */
 export async function clearLocalStorage(page: Page) {
     try {
-        // Ensure we are on the app origin so localStorage is accessible.
-        // Using '/' relies on Playwright config baseURL.
-        try {
-            await page.goto('/');
-            await page.waitForLoadState('load');
-        } catch (e) {
-            // If navigation fails for some reason (non-critical), continue and
-            // try to clear localStorage from the current context.
-            /* noop */
-        }
+        await openAppOrigin(page);
 
         // Note: We intentionally do NOT clear cookies here to preserve auth session.
         // Use clearLocalStorageAndCookies if you need to clear everything.
-
-        await page.evaluate(() => {
-            localStorage.clear();
-            try { sessionStorage.clear(); } catch (e) { /* ignore */ }
-        });
+        await clearBrowserState(page);
     } catch (error) {
         // localStorageアクセスできない場合は無視（デフォルト値が使われる）
         console.warn('localStorage clear failed:', error);
@@ -37,23 +75,15 @@ export async function clearLocalStorage(page: Page) {
  */
 export async function clearLocalStorageAndCookies(page: Page) {
     try {
-        try {
-            await page.goto('/');
-            await page.waitForLoadState('load');
-        } catch (e) {
-            /* noop */
-        }
+        await openAppOrigin(page);
 
         try {
             await page.context().clearCookies();
-        } catch (e) {
+        } catch {
             /* noop */
         }
 
-        await page.evaluate(() => {
-            localStorage.clear();
-            try { sessionStorage.clear(); } catch (e) { /* ignore */ }
-        });
+        await clearBrowserState(page);
     } catch (error) {
         console.warn('localStorage/cookies clear failed:', error);
     }

--- a/packages/web-app-vercel/tests/helpers/testSetup.ts
+++ b/packages/web-app-vercel/tests/helpers/testSetup.ts
@@ -28,7 +28,7 @@ async function clearBrowserState(page: Page) {
 
         try {
             if ('indexedDB' in window) {
-                const databaseNames = new Set(['audicle-cache']);
+                const databaseNames = new Set(['audicle-cache', 'audicle-audio-cache']);
 
                 if (typeof indexedDB.databases === 'function') {
                     const databases = await indexedDB.databases();


### PR DESCRIPTION
## Summary
- clear Cache Storage and IndexedDB from the shared Playwright browser-state reset helper
- preserve auth cookies in clearLocalStorage while still clearing browser caches
- add Jest coverage for cookie-preserving and full-reset cleanup paths

## Verification
- npm run test:unit -- --watchman=false --coverage=false tests/helpers/__tests__/testSetup.test.ts
- npm run lint
- npm run test:unit -- --watchman=false
- NEXT_PUBLIC_AUTH_ENV=test AUTH_ENV=test NEXTAUTH_SECRET=test-secret npm run build

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

E2E テストのブラウザ状態リセットヘルパーに Cache Storage と IndexedDB のクリーンアップを追加し、認証 Cookie は保持しつつブラウザキャッシュも確実に消去できるようにリファクタリングしています。

- `clearBrowserState` ヘルパーを新設し、`localStorage` / `sessionStorage` / Cache Storage / IndexedDB を一括クリア。`audicle-cache` をハードコードのフォールバックとして保持しつつ `indexedDB.databases()` で動的に DB 名を収集する設計。
- `clearLocalStorage` は認証 Cookie を保持したまま上記クリーンアップを実行し、`clearLocalStorageAndCookies` は Cookie も含めた完全リセットを行う。両関数の内部実装が `openAppOrigin` と `clearBrowserState` に集約されコードの重複が解消。
- Jest ユニットテストを新規追加し、Cookie 保持パスと完全リセットパスの両方を検証。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストヘルパーの変更でプロダクションコードへの影響はなく、全体的にマージして問題ありません。

`onblocked` でプロミスを即 resolve する点は、別コネクションが DB を保持している場合に削除が完了しないままクリーンアップが終わるリスクがあります。テストの teardown 漏れと合わせて、将来的なテスト追加時の落とし穴になる可能性があります。

`testSetup.ts` の IndexedDB 削除ロジック（`onblocked` ハンドラ）と `testSetup.test.ts` の teardown 処理を確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/tests/helpers/testSetup.ts | Cache Storage・IndexedDB のクリーンアップを追加し、`openAppOrigin` と `clearBrowserState` にリファクタリング。`onblocked` でプロミスを即座に resolve している点が軽微な懸念。 |
| packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts | Cookie 保持パスと完全リセットパスの Jest テストを新規追加。`clearLocalStorageAndCookies` のナビゲーション呼び出し検証が欠けているのと、`Object.defineProperty` モックの teardown がない点を確認。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as E2E Test
    participant CS as clearLocalStorage / clearLocalStorageAndCookies
    participant OA as openAppOrigin
    participant CB as clearBrowserState (page.evaluate)
    participant B as Browser Context

    Test->>CS: call with page
    CS->>OA: openAppOrigin(page)
    OA->>B: goto('/') + waitForLoadState('load')
    B-->>OA: loaded
    OA-->>CS: done

    alt clearLocalStorageAndCookies only
        CS->>B: page.context().clearCookies()
        B-->>CS: cookies cleared
    end

    CS->>CB: clearBrowserState(page)
    CB->>B: localStorage.clear()
    CB->>B: sessionStorage.clear()
    CB->>B: caches.keys() to caches.delete(each)
    CB->>B: indexedDB.databases() to indexedDB.deleteDatabase(each)
    B-->>CB: onsuccess / onerror
    CB-->>CS: done
    CS-->>Test: cleanup complete
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/web-app-vercel/tests/helpers/testSetup.ts`, line 42-47 ([link](https://github.com/hiroki-org/audicle/blob/e1fb6b5add6634fe05cce400cfeaa50a12f0ad6f/packages/web-app-vercel/tests/helpers/testSetup.ts#L42-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `onblocked` 発火時はデータベースがまだ削除されていない状態です。現在の実装では blocked イベントで即座に `resolve()` するため、別のコネクションがDBを保持している場合に削除が完了しないままクリーンアップが終了したように見えます。後続のテストが古い IndexedDB データを引き継ぐ可能性があります。`onblocked` の解決はスキップし `onsuccess`/`onerror` のみで resolve するか、`onblocked` では警告ログを出す対応が安全です。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/tests/helpers/testSetup.ts
   Line: 42-47

   Comment:
   `onblocked` 発火時はデータベースがまだ削除されていない状態です。現在の実装では blocked イベントで即座に `resolve()` するため、別のコネクションがDBを保持している場合に削除が完了しないままクリーンアップが終了したように見えます。後続のテストが古い IndexedDB データを引き継ぐ可能性があります。`onblocked` の解決はスキップし `onsuccess`/`onerror` のみで resolve するか、`onblocked` では警告ログを出す対応が安全です。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts`, line 95-96 ([link](https://github.com/hiroki-org/audicle/blob/e1fb6b5add6634fe05cce400cfeaa50a12f0ad6f/packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts#L95-L96)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `clearLocalStorageAndCookies` のテストでは `page.goto('/')` と `page.waitForLoadState('load')` の呼び出しが検証されていません。`clearLocalStorage` のテストでは同等の検証がある（76–77行目）ため、対称性と回帰検知のために追加することを推奨します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts
   Line: 95-96

   Comment:
   `clearLocalStorageAndCookies` のテストでは `page.goto('/')` と `page.waitForLoadState('load')` の呼び出しが検証されていません。`clearLocalStorage` のテストでは同等の検証がある（76–77行目）ため、対称性と回帰検知のために追加することを推奨します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts`, line 39-54 ([link](https://github.com/hiroki-org/audicle/blob/e1fb6b5add6634fe05cce400cfeaa50a12f0ad6f/packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts#L39-L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `installBrowserStateMocks` で設定した `Object.defineProperty` は `jest.restoreAllMocks()` でリセットされません。現在の2テストは両方とも `installBrowserStateMocks()` を呼んでいるため問題ありませんが、将来テストが追加された際に前のテストで設定されたモックが残り、予期しない挙動が生じる可能性があります。`afterEach` で各プロパティを `delete` もしくは元の値に戻す teardown を追加することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts
   Line: 39-54

   Comment:
   `installBrowserStateMocks` で設定した `Object.defineProperty` は `jest.restoreAllMocks()` でリセットされません。現在の2テストは両方とも `installBrowserStateMocks()` を呼んでいるため問題ありませんが、将来テストが追加された際に前のテストで設定されたモックが残り、予期しない挙動が生じる可能性があります。`afterEach` で各プロパティを `delete` もしくは元の値に戻す teardown を追加することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web-app-vercel/tests/helpers/testSetup.ts:42-47
`onblocked` 発火時はデータベースがまだ削除されていない状態です。現在の実装では blocked イベントで即座に `resolve()` するため、別のコネクションがDBを保持している場合に削除が完了しないままクリーンアップが終了したように見えます。後続のテストが古い IndexedDB データを引き継ぐ可能性があります。`onblocked` の解決はスキップし `onsuccess`/`onerror` のみで resolve するか、`onblocked` では警告ログを出す対応が安全です。

```suggestion
                await Promise.all([...databaseNames].map((name) => new Promise<void>((resolve) => {
                    const request = indexedDB.deleteDatabase(name);
                    request.onsuccess = () => resolve();
                    request.onerror = () => resolve();
                    // onblocked はDB削除がブロックされているだけで未完了のため resolve しない。
                    // ブロッキング接続が閉じられると onsuccess が呼ばれる。
                    request.onblocked = () => { /* waiting for onsuccess/onerror */ };
                })));
```

### Issue 2 of 3
packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts:95-96
`clearLocalStorageAndCookies` のテストでは `page.goto('/')` と `page.waitForLoadState('load')` の呼び出しが検証されていません。`clearLocalStorage` のテストでは同等の検証がある（76–77行目）ため、対称性と回帰検知のために追加することを推奨します。

```suggestion
        expect(page.goto).toHaveBeenCalledWith('/');
        expect(page.waitForLoadState).toHaveBeenCalledWith('load');
        expect(clearCookies).toHaveBeenCalledTimes(1);
        expect(state.localStorageMock.clear).toHaveBeenCalledTimes(1);
```

### Issue 3 of 3
packages/web-app-vercel/tests/helpers/__tests__/testSetup.test.ts:39-54
`installBrowserStateMocks` で設定した `Object.defineProperty` は `jest.restoreAllMocks()` でリセットされません。現在の2テストは両方とも `installBrowserStateMocks()` を呼んでいるため問題ありませんが、将来テストが追加された際に前のテストで設定されたモックが残り、予期しない挙動が生じる可能性があります。`afterEach` で各プロパティを `delete` もしくは元の値に戻す teardown を追加することを推奨します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: clear browser caches in e2e setup"](https://github.com/hiroki-org/audicle/commit/e1fb6b5add6634fe05cce400cfeaa50a12f0ad6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31021734)</sub>

<!-- /greptile_comment -->