### PR TITLE
ci: skip playwright setup during pr lint

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -71,30 +71,6 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: npm ci
         working-directory: packages/web-app-vercel
-      - name: Restore Playwright cache
-        id: playwright-cache-pr
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-pr-${{ runner.os }}-${{ hashFiles('packages/web-app-vercel/package-lock.json') }}
-      - name: Install Playwright browsers
-        if: steps.playwright-cache-pr.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-        working-directory: packages/web-app-vercel
-      - name: Restore Playwright cache
-        id: playwright-cache-lint
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/web-app-vercel/package-lock.json') }}
-      - name: Install Playwright browsers
-        if: steps.playwright-cache-lint.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-        working-directory: packages/web-app-vercel
-
-      - name: Create auth directory
-        run: mkdir -p playwright/.auth
-        working-directory: packages/web-app-vercel
       - name: Run lint
         run: npm run lint
         working-directory: packages/web-app-vercel


### PR DESCRIPTION
## Summary
- remove duplicate Playwright cache restore/install steps from the PR lint job
- remove auth directory creation from lint, since lint does not consume browser auth state
- keep Playwright setup in the E2E jobs where browser binaries are actually required

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-pr.yml"); puts "ci-pr.yml ok"'

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PR #765 のレビューを完了しました。`.github/workflows/ci-pr.yml` の `lint` ジョブから不要な Playwright セットアップステップを削除する変更を確認しました。変更自体は正しく、1件の P2 コメント（`needs: setup` の残存による不要な待機）を残しました。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CI ワークフローから不要なステップを取り除くだけの変更で、E2E や lint の実際の動作には影響なし。マージ自体は安全。

lint ジョブから Playwright 関連ステップを削除する変更は意図どおりで、E2E ジョブへの影響もない。削除後も `needs: setup` が残っていることで lint が不要な待機を引き起こす点は軽微な最適化余地だが、機能的な誤りではない。

.github/workflows/ci-pr.yml の `lint` ジョブの `needs: setup` 依存が残存しているため、そこだけ確認する価値がある。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci-pr.yml | lint ジョブから不要な Playwright インストール・キャッシュ復元ステップと auth ディレクトリ作成を削除。変更自体は正しいが、lint ジョブに残存する `needs: setup` 依存が無用な待機を発生させる可能性がある。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci-pr.yml`, line 55 ([link](https://github.com/hiroki-org/audicle/blob/10a099cd82547537bbf15ecca40523338866a709/.github/workflows/ci-pr.yml#L55)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **lint ジョブの `needs: setup` が不要な待機を引き起こしている可能性**

   `lint` ジョブは `needs: setup` を宣言していますが、`setup` ジョブ（44〜51行目）が生成するアーティファクトやキャッシュを `lint` は一切参照していません。`lint` は独自の npm キャッシュを復元・インストールしており、今回の PR で Playwright の依存も削除されたため、`setup` の完了を待つ理由がなくなっています。このままでは `setup` が完了するまで `lint` が開始できず、CI 全体のフィードバックが遅くなります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci-pr.yml
   Line: 55

   Comment:
   **lint ジョブの `needs: setup` が不要な待機を引き起こしている可能性**

   `lint` ジョブは `needs: setup` を宣言していますが、`setup` ジョブ（44〜51行目）が生成するアーティファクトやキャッシュを `lint` は一切参照していません。`lint` は独自の npm キャッシュを復元・インストールしており、今回の PR で Playwright の依存も削除されたため、`setup` の完了を待つ理由がなくなっています。このままでは `setup` が完了するまで `lint` が開始できず、CI 全体のフィードバックが遅くなります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/ci-pr.yml:55
**lint ジョブの `needs: setup` が不要な待機を引き起こしている可能性**

`lint` ジョブは `needs: setup` を宣言していますが、`setup` ジョブ（44〜51行目）が生成するアーティファクトやキャッシュを `lint` は一切参照していません。`lint` は独自の npm キャッシュを復元・インストールしており、今回の PR で Playwright の依存も削除されたため、`setup` の完了を待つ理由がなくなっています。このままでは `setup` が完了するまで `lint` が開始できず、CI 全体のフィードバックが遅くなります。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: skip playwright setup during pr lint"](https://github.com/hiroki-org/audicle/commit/10a099cd82547537bbf15ecca40523338866a709) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31021966)</sub>

<!-- /greptile_comment -->