### PR TITLE
Fix IndexedDB delete abort handling

### DIFF
--- a/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
@@ -2,20 +2,34 @@ import { generateKey } from '../indexedDB';
 
 type IndexedDBMock = {
     openRequest: Record<string, any>;
+    openRequests: Record<string, any>[];
     db: Record<string, any>;
     transaction: Record<string, any>;
     store: Record<string, jest.Mock>;
+    index: Record<string, jest.Mock>;
+    keyRange: Record<string, jest.Mock>;
     putRequest: Record<string, any>;
     clearRequest: Record<string, any>;
+    openCursorRequest: Record<string, any>;
+    cursor: Record<string, jest.Mock>;
 };
 
 function createIndexedDBMock(): IndexedDBMock {
-    const openRequest: Record<string, any> = {};
+    const openRequests: Record<string, any>[] = [];
     const putRequest: Record<string, any> = {};
     const clearRequest: Record<string, any> = {};
+    const openCursorRequest: Record<string, any> = {};
+    const cursor = {
+        delete: jest.fn(),
+        continue: jest.fn(),
+    };
+    const index = {
+        openCursor: jest.fn(() => openCursorRequest),
+    };
     const store = {
         put: jest.fn(() => putRequest),
         clear: jest.fn(() => clearRequest),
+        index: jest.fn(() => index),
     };
     const transaction: Record<string, any> = {
         objectStore: jest.fn(() => store),
@@ -29,16 +43,43 @@ function createIndexedDBMock(): IndexedDBMock {
     Object.defineProperty(global, 'indexedDB', {
         configurable: true,
         value: {
-            open: jest.fn(() => openRequest),
+            open: jest.fn(() => {
+                const openRequest: Record<string, any> = {};
+                openRequests.push(openRequest);
+                return openRequest;
+            }),
         },
     });
 
-    return { openRequest, db, transaction, store, putRequest, clearRequest };
+    const keyRange = {
+        only: jest.fn((value) => ({ value })),
+    };
+
+    Object.defineProperty(global, 'IDBKeyRange', {
+        configurable: true,
+        value: keyRange,
+    });
+
+    return {
+        get openRequest() {
+            return openRequests[0];
+        },
+        openRequests,
+        db,
+        transaction,
+        store,
+        index,
+        keyRange,
+        putRequest,
+        clearRequest,
+        openCursorRequest,
+        cursor,
+    };
 }
 
-async function openDatabase(mock: IndexedDBMock) {
-    mock.openRequest.result = mock.db;
-    mock.openRequest.onsuccess();
+async function openDatabase(mock: IndexedDBMock, requestIndex = 0, db = mock.db) {
+    mock.openRequests[requestIndex].result = db;
+    mock.openRequests[requestIndex].onsuccess();
     await Promise.resolve();
 }
 
@@ -88,6 +129,8 @@ describe('IndexedDB write transactions', () => {
         jest.resetModules();
         // @ts-ignore
         delete global.indexedDB;
+        // @ts-ignore
+        delete global.IDBKeyRange;
     });
 
     it('saveAudioChunk should resolve only after the write transaction completes', async () => {
@@ -162,6 +205,84 @@ describe('IndexedDB write transactions', () => {
         await expect(promise).rejects.toThrow('Save transaction aborted');
     });
 
+    it('saveAudioChunk should reject with the transaction abort error when present', async () => {
+        const mock = createIndexedDBMock();
+        const { saveAudioChunk } = await import('../indexedDB');
+        const error = new Error('quota exceeded');
+        const promise = saveAudioChunk({
+            audioData: new Blob(['audio'], { type: 'audio/wav' }),
+            timestamp: 123,
+            articleUrl: 'https://example.com/article',
+            chunkIndex: 0,
+            totalChunks: 1,
+            size: 5,
+        });
+
+        await openDatabase(mock);
+        mock.transaction.error = error;
+        mock.transaction.onabort();
+
+        await expect(promise).rejects.toBe(error);
+    });
+
+    it('deleteArticle should resolve only after deleting matching cursors and transaction completes', async () => {
+        const mock = createIndexedDBMock();
+        const { deleteArticle } = await import('../indexedDB');
+        const articleUrl = 'https://example.com/article';
+
+        let resolved = false;
+        const promise = deleteArticle(articleUrl).then(() => {
+            resolved = true;
+        });
+
+        await openDatabase(mock);
+
+        expect(mock.keyRange.only).toHaveBeenCalledWith(articleUrl);
+        expect(mock.index.openCursor).toHaveBeenCalledWith({ value: articleUrl });
+
+        mock.openCursorRequest.result = mock.cursor;
+        mock.openCursorRequest.onsuccess({ target: mock.openCursorRequest });
+
+        expect(mock.cursor.delete).toHaveBeenCalledTimes(1);
+        expect(mock.cursor.continue).toHaveBeenCalledTimes(1);
+        expect(resolved).toBe(false);
+
+        mock.openCursorRequest.result = null;
+        mock.openCursorRequest.onsuccess({ target: mock.openCursorRequest });
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        mock.transaction.oncomplete();
+
+        await expect(promise).resolves.toBeUndefined();
+        expect(resolved).toBe(true);
+    });
+
+    it('deleteArticle should reject when the cursor request fails', async () => {
+        const mock = createIndexedDBMock();
+        const { deleteArticle } = await import('../indexedDB');
+        const error = new Error('cursor failed');
+        const promise = deleteArticle('https://example.com/article');
+
+        await openDatabase(mock);
+        mock.openCursorRequest.error = error;
+        mock.openCursorRequest.onerror();
+
+        await expect(promise).rejects.toBe(error);
+    });
+
+    it('deleteArticle should reject with a fallback Error when the transaction abort has no error', async () => {
+        const mock = createIndexedDBMock();
+        const { deleteArticle } = await import('../indexedDB');
+        const promise = deleteArticle('https://example.com/article');
+
+        await openDatabase(mock);
+        mock.transaction.error = null;
+        mock.transaction.onabort();
+
+        await expect(promise).rejects.toThrow('Delete transaction aborted');
+    });
+
     it('clearAll should resolve only after the clear transaction completes', async () => {
         const mock = createIndexedDBMock();
         const { clearAll } = await import('../indexedDB');
@@ -206,5 +327,45 @@ describe('IndexedDB write transactions', () => {
         mock.transaction.onabort();
 
         await expect(promise).rejects.toThrow('Clear transaction aborted');
+    });
+});
+
+describe('IndexedDB connection lifecycle', () => {
+    afterEach(() => {
+        jest.resetModules();
+        // @ts-ignore
+        delete global.indexedDB;
+        // @ts-ignore
+        delete global.IDBKeyRange;
+    });
+
+    it('should close and discard the cached connection on version changes', async () => {
+        const mock = createIndexedDBMock();
+        const { saveAudioChunk } = await import('../indexedDB');
+        const entry = {
+            audioData: new Blob(['audio'], { type: 'audio/wav' }),
+            timestamp: 123,
+            articleUrl: 'https://example.com/article',
+            chunkIndex: 0,
+            totalChunks: 1,
+            size: 5,
+        };
+
+        const firstSave = saveAudioChunk(entry);
+        await openDatabase(mock);
+        mock.transaction.oncomplete();
+        await expect(firstSave).resolves.toBeUndefined();
+
+        mock.db.onversionchange();
+
+        expect(mock.db.close).toHaveBeenCalledTimes(1);
+
+        const secondSave = saveAudioChunk({ ...entry, chunkIndex: 1 });
+        expect(global.indexedDB.open).toHaveBeenCalledTimes(2);
+
+        await openDatabase(mock, 1);
+        mock.transaction.oncomplete();
+
+        await expect(secondSave).resolves.toBeUndefined();
     });
 });

--- a/packages/web-app-vercel/lib/indexedDB.ts
+++ b/packages/web-app-vercel/lib/indexedDB.ts
@@ -218,10 +218,22 @@ export async function deleteArticle(articleUrl: string): Promise<void> {
 
     return new Promise((resolve, reject) => {
         const transaction = db.transaction([STORE_NAME], 'readwrite');
+        let isSettled = false;
+
+        const rejectOnce = (message: string, error: unknown) => {
+            if (isSettled) return;
+            isSettled = true;
+            const finalError = error || new Error(message);
+            logger.error(message, finalError);
+            reject(finalError);
+        };
 
         transaction.onerror = () => {
-            logger.error('Delete transaction error', transaction.error);
-            reject(transaction.error);
+            rejectOnce('Delete transaction error', transaction.error);
+        };
+
+        transaction.onabort = () => {
+            rejectOnce('Delete transaction aborted', transaction.error);
         };
 
         const store = transaction.objectStore(STORE_NAME);
@@ -229,6 +241,7 @@ export async function deleteArticle(articleUrl: string): Promise<void> {
         const request = index.openCursor(IDBKeyRange.only(articleUrl));
 
         request.onsuccess = (event) => {
+            if (isSettled) return;
             const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
             if (cursor) {
                 cursor.delete();
@@ -237,11 +250,12 @@ export async function deleteArticle(articleUrl: string): Promise<void> {
         };
 
         request.onerror = () => {
-            logger.error('Delete error', request.error);
-            reject(request.error);
+            rejectOnce('Delete error', request.error);
         };
 
         transaction.oncomplete = () => {
+            if (isSettled) return;
+            isSettled = true;
             logger.info(`Deleted all chunks for ${articleUrl}`);
             resolve();
         };


### PR DESCRIPTION
## Summary
- add single-settle abort/error handling to deleteArticle
- cover deleteArticle cursor success, cursor failure, and transaction abort paths
- add coverage for saveAudioChunk abort errors and cached DB versionchange reset

## Verification
- npm run test:unit -- --watchman=false --coverage=false lib/__tests__/indexedDB.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
- npm run test:unit -- --watchman=false --coverage=false

Replaces empty draft PR #769.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `deleteArticle` 関数に対して、アボートハンドラ（`transaction.onabort`）と単一決着ガード（`isSettled` / `rejectOnce`）を追加し、カーソル反復中のトランザクションアボートで Promise が二重 reject されていたバグを修正します。合わせて、`saveAudioChunk` のアボートエラーテスト・`deleteArticle` の全パス（成功・カーソルエラー・アボート）・DB の `versionchange` ライフサイクルの各テストを追加します。

- `deleteArticle` の `transaction.onerror` / `transaction.onabort` / `request.onerror` がすべて `rejectOnce` に統一され、`saveAudioChunk` や `clearAll` と対称的なパターンになった。
- テストモックを `openRequests[]` 配列・`IDBKeyRange`・カーソルに対応させ、複数 `open` 呼び出しのシナリオもカバーするよう拡張した。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

本体のロジック修正は正確で、既存パターンと一貫している。マージをブロックするものではない。

`deleteArticle` の `onabort` 追加ロジックは正しく動作し、二重 reject のバグを防げる。テストは大部分のパスをカバーしているが、「アボート時に `transaction.error` が存在する場合」の分岐だけ `deleteArticle` 側に対応テストがなく、`saveAudioChunk` の対称テストと比べて欠落している。

`indexedDB.test.ts` の `deleteArticle` アボートエラーありケースに追加テストを検討してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/indexedDB.ts | `deleteArticle` に `onabort` ハンドラと `isSettled`/`rejectOnce` ガードを追加し、カーソル反復中のアボートによる二重 reject を防止。ロジックは正確で、`saveAudioChunk`/`clearAll` と対称的なパターンに統一されている。 |
| packages/web-app-vercel/lib/__tests__/indexedDB.test.ts | モックを `openRequests[]` 配列・`IDBKeyRange`・カーソル対応に拡充し、`deleteArticle` とライフサイクルのテストケースを追加。`deleteArticle` のアボートエラーあり分岐のテストが欠落している。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant DA as deleteArticle()
    participant TX as IDBTransaction
    participant IDX as IDBIndex
    participant CR as IDBCursor

    C->>DA: deleteArticle(articleUrl)
    DA->>TX: transaction('readwrite')
    DA->>IDX: index.openCursor(IDBKeyRange.only(url))
    loop カーソル反復
        IDX-->>DA: request.onsuccess (cursor)
        alt isSettled = true
            DA-->>DA: early return
        else cursor != null
            DA->>CR: cursor.delete()
            DA->>CR: cursor.continue()
        else cursor == null
            Note over DA: 反復終了
        end
    end
    alt カーソルエラー
        IDX-->>DA: request.onerror
        DA->>DA: rejectOnce('Delete error', request.error)
    end
    alt トランザクション完了
        TX-->>DA: oncomplete
        DA-->>C: resolve()
    else トランザクションエラー
        TX-->>DA: onerror
        DA->>DA: rejectOnce('Delete transaction error', tx.error)
    else トランザクションアボート
        TX-->>DA: onabort
        DA->>DA: rejectOnce('Delete transaction aborted', tx.error ?? new Error(...))
        DA-->>C: reject(error)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/web-app-vercel/lib/__tests__/indexedDB.test.ts`, line 274-284 ([link](https://github.com/hiroki-org/audicle/blob/27eea93d4e7dea27fa346c14e3b62f8a51d0b7cd/packages/web-app-vercel/lib/__tests__/indexedDB.test.ts#L274-L284)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `deleteArticle` のアボートエラーテストが非対称

   `saveAudioChunk` のテストには「アボート時にエラーが存在する場合はそのエラーで reject する」ケース（`saveAudioChunk should reject with the transaction abort error when present`）が新たに追加されています。しかし `deleteArticle` には対応するテスト（`mock.transaction.error = someError; mock.transaction.onabort()` → `rejects.toBe(error)`）が存在せず、フォールバック（`error = null`）のケースしかカバーされていません。`rejectOnce` 内の `error || new Error(message)` の両分岐を対称的に検証するため、同様のテストを追加することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/__tests__/indexedDB.test.ts
   Line: 274-284

   Comment:
   `deleteArticle` のアボートエラーテストが非対称

   `saveAudioChunk` のテストには「アボート時にエラーが存在する場合はそのエラーで reject する」ケース（`saveAudioChunk should reject with the transaction abort error when present`）が新たに追加されています。しかし `deleteArticle` には対応するテスト（`mock.transaction.error = someError; mock.transaction.onabort()` → `rejects.toBe(error)`）が存在せず、フォールバック（`error = null`）のケースしかカバーされていません。`rejectOnce` 内の `error || new Error(message)` の両分岐を対称的に検証するため、同様のテストを追加することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/lib/__tests__/indexedDB.test.ts:274-284
`deleteArticle` のアボートエラーテストが非対称

`saveAudioChunk` のテストには「アボート時にエラーが存在する場合はそのエラーで reject する」ケース（`saveAudioChunk should reject with the transaction abort error when present`）が新たに追加されています。しかし `deleteArticle` には対応するテスト（`mock.transaction.error = someError; mock.transaction.onabort()` → `rejects.toBe(error)`）が存在せず、フォールバック（`error = null`）のケースしかカバーされていません。`rejectOnce` 内の `error || new Error(message)` の両分岐を対称的に検証するため、同様のテストを追加することを推奨します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: handle indexeddb delete aborts"](https://github.com/hiroki-org/audicle/commit/27eea93d4e7dea27fa346c14e3b62f8a51d0b7cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31025012)</sub>

<!-- /greptile_comment -->