### PR TITLE
fix: prevent Gemini CLI parsing error in triage workflow

### DIFF
--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -87,11 +87,6 @@ jobs:
                         },
                         "telemetry": {
                           "enabled": false
-                        },
-                        "tools": {
-                          "core": [
-                            "run_shell_command"
-                          ]
                         }
                       }
                   prompt: |-
@@ -124,36 +119,36 @@ jobs:
                       ]
 
                       ## Strict Output Rules
-                      1. You MUST NOT output the JSON content in your text response.
-                      2. You MUST use the Python script below to write the file to avoid quoting issues.
-
-                      Execute exactly this format:
-                      run_shell_command(python3 -c "import json; f=open('/tmp/triaged_issues.json', 'w'); json.dump(YOUR_ANALYSIS_RESULT_LIST, f, ensure_ascii=False); f.close()")
-
-                      Warning: Do not use example data. Output the actual analysis results for the issues provided above.
-                      Execute the Python script now.
+                      Output the JSON array directly in your response. Ensure the output is strictly valid JSON format, without markdown formatting if possible. Warning: Do not use example data. Output the actual analysis results for the issues provided above.
 
             - name: "Collect outputs"
               id: "collect_outputs"
               uses: "actions/github-script@v9"
+              env:
+                  GEMINI_RESPONSE: "${{ steps.gemini_issue_analysis.outputs.gemini_response }}"
               with:
                   script: |-
-                      const fs = require('fs');
-                      const path = '/tmp/triaged_issues.json';
                       let triagedIssues = '[]';
+                      const response = process.env.GEMINI_RESPONSE || '';
                       
                       try {
-                        if (fs.existsSync(path)) {
-                          const content = fs.readFileSync(path, 'utf8');
-                          console.log('File content preview:', content.substring(0, 100)); // プレビューも出す
-                          // Validate JSON
-                          JSON.parse(content);
-                          triagedIssues = content;
+                        let jsonStr = response.trim();
+                        const jsonMatch = response.match(/```json\n([\s\S]*?)\n```/);
+                        if (jsonMatch) {
+                          jsonStr = jsonMatch[1];
                         } else {
-                          core.warning('⚠️ Output file /tmp/triaged_issues.json was NOT found. Gemini likely failed to execute the write command.');
+                          const anyMatch = response.match(/```\n([\s\S]*?)\n```/);
+                          if (anyMatch) {
+                            jsonStr = anyMatch[1];
+                          }
                         }
+
+                        console.log('Extracted content preview:', jsonStr.substring(0, 100));
+                        JSON.parse(jsonStr);
+                        triagedIssues = jsonStr;
                       } catch (error) {
-                        core.warning(`Error reading or parsing triaged issues file: ${error.message}`);
+                        core.warning(`Error parsing triaged issues from Gemini response: ${error.message}`);
+                        core.info(`Raw response: ${response}`);
                       }
                       
                       core.setOutput('triaged_issues', triagedIssues);

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -107,6 +107,8 @@ jobs:
                       ## Primary Directive
                       Analyze the issues above and generate a JSON array containing your triage decisions.
 
+                      Target File Path: /tmp/triaged_issues.json
+
                       Output Format (JSON Array):
                       [
                         {
@@ -139,9 +141,10 @@ jobs:
                           if (anyMatch) {
                             jsonStr = anyMatch[1];
                           } else {
-                            const arrayMatch = response.match(/(\[[\s\S]*\])/);
+                            // Extract JSON array literal with a fallback regex
+                            const arrayMatch = response.match(/\[[\s\S]*\]/);
                             if (arrayMatch) {
-                              jsonStr = arrayMatch[1];
+                              jsonStr = arrayMatch[0];
                             }
                           }
                         }
@@ -149,7 +152,7 @@ jobs:
                         console.log('Extracted content preview:', jsonStr.substring(0, 100));
                         const parsed = JSON.parse(jsonStr);
                         if (!Array.isArray(parsed)) {
-                          throw new Error('Gemini response must be a JSON array');
+                              throw new Error("Parsed JSON is not an array");
                         }
                         triagedIssues = jsonStr;
                       } catch (error) {

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -119,7 +119,7 @@ jobs:
                       ]
 
                       ## Strict Output Rules
-                      Output the JSON array directly in your response. Ensure the output is strictly valid JSON format, without markdown formatting if possible. Warning: Do not use example data. Output the actual analysis results for the issues provided above.
+                      Output the JSON array directly as the entire response body. The response MUST be strictly valid JSON only: no markdown fences, no prose, no preamble, and no trailing text. Warning: Do not use example data. Output the actual analysis results for the issues provided above.
 
             - name: "Collect outputs"
               id: "collect_outputs"

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -133,11 +133,11 @@ jobs:
                       
                       try {
                         let jsonStr = response.trim();
-                        const jsonMatch = response.match(/```json\n([\s\S]*?)\n```/);
+                        const jsonMatch = response.match(/```json\s*([\s\S]*?)\s*```/);
                         if (jsonMatch) {
                           jsonStr = jsonMatch[1];
                         } else {
-                          const anyMatch = response.match(/```\n([\s\S]*?)\n```/);
+                          const anyMatch = response.match(/```\s*([\s\S]*?)\s*```/);
                           if (anyMatch) {
                             jsonStr = anyMatch[1];
                           } else {
@@ -152,12 +152,17 @@ jobs:
                         console.log('Extracted content preview:', jsonStr.substring(0, 100));
                         const parsed = JSON.parse(jsonStr);
                         if (!Array.isArray(parsed)) {
-                              throw new Error("Parsed JSON is not an array");
+                          throw new Error("Parsed JSON is not an array");
                         }
                         triagedIssues = jsonStr;
                       } catch (error) {
                         core.warning(`Error parsing triaged issues from Gemini response: ${error.message}`);
-                        core.info(`Raw response: ${response}`);
+                        const trimmedResponse = response.trim();
+                        const previewLength = 500;
+                        const responsePreview = trimmedResponse.slice(0, previewLength);
+                        const isTruncated = trimmedResponse.length > previewLength;
+                        core.info(`Gemini response parse failure metadata: length=${response.length}, trimmedLength=${trimmedResponse.length}, previewLength=${responsePreview.length}, truncated=${isTruncated}`);
+                        core.info(`Gemini response preview (first ${previewLength} chars): ${responsePreview}`);
                       }
                       
                       core.setOutput('triaged_issues', triagedIssues);

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -152,17 +152,17 @@ jobs:
                         console.log('Extracted content preview:', jsonStr.substring(0, 100));
                         const parsed = JSON.parse(jsonStr);
                         if (!Array.isArray(parsed)) {
-                          throw new Error("Parsed JSON is not an array");
+                              throw new Error("Parsed JSON is not an array");
                         }
                         triagedIssues = jsonStr;
                       } catch (error) {
                         core.warning(`Error parsing triaged issues from Gemini response: ${error.message}`);
-                        const trimmedResponse = response.trim();
-                        const previewLength = 500;
-                        const responsePreview = trimmedResponse.slice(0, previewLength);
-                        const isTruncated = trimmedResponse.length > previewLength;
-                        core.info(`Gemini response parse failure metadata: length=${response.length}, trimmedLength=${trimmedResponse.length}, previewLength=${responsePreview.length}, truncated=${isTruncated}`);
-                        core.info(`Gemini response preview (first ${previewLength} chars): ${responsePreview}`);
+                        const len = response.length;
+                        const trimmedLen = response.trim().length;
+                        const previewStr = response.substring(0, 500);
+                        const isTruncated = len > 500;
+                        core.info(`Response Length: ${len}, Trimmed Length: ${trimmedLen}, Truncated: ${isTruncated}`);
+                        core.info(`Raw response preview: ${previewStr}`);
                       }
                       
                       core.setOutput('triaged_issues', triagedIssues);

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -107,8 +107,6 @@ jobs:
                       ## Primary Directive
                       Analyze the issues above and generate a JSON array containing your triage decisions.
 
-                      Target File Path: /tmp/triaged_issues.json
-
                       Output Format (JSON Array):
                       [
                         {
@@ -125,7 +123,7 @@ jobs:
               id: "collect_outputs"
               uses: "actions/github-script@v9"
               env:
-                  GEMINI_RESPONSE: "${{ steps.gemini_issue_analysis.outputs.gemini_response }}"
+                  GEMINI_RESPONSE: "${{ steps.gemini_issue_analysis.outputs.summary }}"
               with:
                   script: |-
                       let triagedIssues = '[]';
@@ -140,11 +138,19 @@ jobs:
                           const anyMatch = response.match(/```\n([\s\S]*?)\n```/);
                           if (anyMatch) {
                             jsonStr = anyMatch[1];
+                          } else {
+                            const arrayMatch = response.match(/(\[[\s\S]*\])/);
+                            if (arrayMatch) {
+                              jsonStr = arrayMatch[1];
+                            }
                           }
                         }
 
                         console.log('Extracted content preview:', jsonStr.substring(0, 100));
-                        JSON.parse(jsonStr);
+                        const parsed = JSON.parse(jsonStr);
+                        if (!Array.isArray(parsed)) {
+                          throw new Error('Gemini response must be a JSON array');
+                        }
                         triagedIssues = jsonStr;
                       } catch (error) {
                         core.warning(`Error parsing triaged issues from Gemini response: ${error.message}`);

--- a/.github/workflows/gemini-triage-bulk.yml
+++ b/.github/workflows/gemini-triage-bulk.yml
@@ -107,8 +107,6 @@ jobs:
                       ## Primary Directive
                       Analyze the issues above and generate a JSON array containing your triage decisions.
 
-                      Target File Path: /tmp/triaged_issues.json
-
                       Output Format (JSON Array):
                       [
                         {
@@ -149,20 +147,17 @@ jobs:
                           }
                         }
 
-                        console.log('Extracted content preview:', jsonStr.substring(0, 100));
                         const parsed = JSON.parse(jsonStr);
                         if (!Array.isArray(parsed)) {
-                              throw new Error("Parsed JSON is not an array");
+                          throw new Error("Parsed JSON is not an array");
                         }
-                        triagedIssues = jsonStr;
+                        triagedIssues = JSON.stringify(parsed);
+                        core.info(`Parsed ${parsed.length} triage decisions from Gemini response`);
                       } catch (error) {
                         core.warning(`Error parsing triaged issues from Gemini response: ${error.message}`);
                         const len = response.length;
                         const trimmedLen = response.trim().length;
-                        const previewStr = response.substring(0, 500);
-                        const isTruncated = len > 500;
-                        core.info(`Response Length: ${len}, Trimmed Length: ${trimmedLen}, Truncated: ${isTruncated}`);
-                        core.info(`Raw response preview: ${previewStr}`);
+                        core.info(`Response Length: ${len}, Trimmed Length: ${trimmedLen}`);
                       }
                       
                       core.setOutput('triaged_issues', triagedIssues);


### PR DESCRIPTION
Fixes an issue where \`google-github-actions/run-gemini-cli@v0\` fails with \`Gemini CLI stderr was not valid JSON\` and exits with code 1.
The root cause was using the \`run_shell_command\` tool with Gemini to write JSON via a Python script. If the tool fallback triggered (e.g., debug logs in stderr) or quoting issues occurred, the action's \`jq\` parser would crash.
This PR removes the tool from settings and refactors the prompt to instruct the model to directly output JSON. A robust JS extraction script replaces the file read logic, making the workflow stable.

---
*PR created automatically by Jules for task [4492530419692807885](https://jules.google.com/task/4492530419692807885) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Gemini CLIがstderrの非JSONログでクラッシュする問題に対処するため、`run_shell_command` ツールをsettingsから削除し、ファイル書き込み方式から直接JSON出力方式へリファクタリングしています。ただし、修正後のコードには根本的な問題があり、アクションの存在しない出力名を参照しているためトリアージ結果が常に空になります。

- `run_shell_command` をsettingsから削除し、Geminiへのプロンプトを直接JSON出力に変更した。
- `Collect outputs` ステップを `/tmp` ファイル読み取りから `gemini_response` 環境変数経由へ変更したが、`run-gemini-cli@v0` の実際のアウトプット名は `summary` であり `gemini_response` は存在しない。
- プロンプト内に廃止された `Target File Path: /tmp/triaged_issues.json` の記述が残っており、モデルを混乱させる可能性がある。
</details>


<details open><summary><h3>Confidence Score: 1/5</h3></summary>

このワークフロー変更はマージすべきではありません。修正の中心となる出力読み取りロジックが、アクションに存在しない出力名を参照しており、トリアージ結果が常に空になります。

変更の目的（Gemini CLIのJSONパースエラー回避）は正しいアプローチですが、`steps.gemini_issue_analysis.outputs.gemini_response` という参照が誤っており、run-gemini-cli@v0 の実際のアウトプット名 `summary` と一致していません。この誤りにより、修正後もワークフローは機能せずトリアージ結果が常に空になります。

.github/workflows/gemini-triage-bulk.yml の128行目のアクション出力名と、110行目の廃止されたファイルパス指示を要確認。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/gemini-triage-bulk.yml | run_shell_commandツール削除・直接JSON出力方式への変更。ただし outputs.gemini_response という存在しないアクション出力を参照しているため、修正後も常に空のトリアージ結果になる致命的な問題がある。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Gemini as run-gemini-cli@v0
    participant Script as collect_outputs (JS)

    GH->>Gemini: prompt (直接JSON出力を指示)
    Note over Gemini: ツールなしでJSONを生成
    Gemini-->>GH: outputs.summary (実際の出力名)
    Note over GH: outputs.gemini_response は存在しない
    GH->>Script: "GEMINI_RESPONSE=空文字列"
    Script->>Script: JSON.parse 失敗
    Script-->>GH: triaged_issues 常に空
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/gemini-triage-bulk.yml`, line 110-112 ([link](https://github.com/hiroki-org/audicle/blob/d09e80209228d1c54aa1c696f3e45c22d96e5bfd/.github/workflows/gemini-triage-bulk.yml#L110-L112)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **プロンプト内に廃止されたファイルパス指示が残っている**

   `run_shell_command` ツールを削除し直接JSON出力に変更したにもかかわらず、`Target File Path: /tmp/triaged_issues.json` という記述が残っています。この指示はモデルにファイル書き込みを試みるよう誘導しますが、ツールはもう存在しないため、モデルが混乱してクリーンなJSONを出力しない可能性があります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/gemini-triage-bulk.yml
   Line: 110-112

   Comment:
   **プロンプト内に廃止されたファイルパス指示が残っている**

   `run_shell_command` ツールを削除し直接JSON出力に変更したにもかかわらず、`Target File Path: /tmp/triaged_issues.json` という記述が残っています。この指示はモデルにファイル書き込みを試みるよう誘導しますが、ツールはもう存在しないため、モデルが混乱してクリーンなJSONを出力しない可能性があります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/gemini-triage-bulk.yml:128
**存在しないアクション出力を参照している**

`google-github-actions/run-gemini-cli@v0` の公式ドキュメントによると、このアクションが公開するアウトプットは `summary`（Gemini CLIの実行結果）と `error` の2つのみです。`gemini_response` は存在しません。

そのため `process.env.GEMINI_RESPONSE` は常に空文字列になり、`JSON.parse('')` が例外をスローしてcatchブロックへ落ち、`triagedIssues` は常にデフォルト値 `'[]'` になります。このPRの修正全体が機能せず、トリアージ結果は常に空になります。正しい出力名は `steps.gemini_issue_analysis.outputs.summary` と思われます。

### Issue 2 of 3
.github/workflows/gemini-triage-bulk.yml:110-112
**プロンプト内に廃止されたファイルパス指示が残っている**

`run_shell_command` ツールを削除し直接JSON出力に変更したにもかかわらず、`Target File Path: /tmp/triaged_issues.json` という記述が残っています。この指示はモデルにファイル書き込みを試みるよう誘導しますが、ツールはもう存在しないため、モデルが混乱してクリーンなJSONを出力しない可能性があります。

```suggestion
                      Output Format (JSON Array):
```

### Issue 3 of 3
.github/workflows/gemini-triage-bulk.yml:135-144
**JSONの抽出が不完全でサイレントフォールバックが起きる**

Geminiが前置き文とともにJSON配列を返した場合、どちらの正規表現にもマッチせず、`response.trim()` 全体を `JSON.parse` しようとして失敗します。結果として `triagedIssues` は `'[]'` にサイレントフォールバックします。配列リテラルを直接検索する正規表現を追加することで対応できます。

```suggestion
                        let jsonStr = response.trim();
                        const jsonMatch = response.match(/```json\n([\s\S]*?)\n```/);
                        if (jsonMatch) {
                          jsonStr = jsonMatch[1];
                        } else {
                          const anyMatch = response.match(/```\n([\s\S]*?)\n```/);
                          if (anyMatch) {
                            jsonStr = anyMatch[1];
                          } else {
                            const arrayMatch = response.match(/(\[[\s\S]*\])/);
                            if (arrayMatch) {
                              jsonStr = arrayMatch[1];
                            }
                          }
                        }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent Gemini CLI parsing error in..."](https://github.com/hiroki-org/audicle/commit/d09e80209228d1c54aa1c696f3e45c22d96e5bfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31114976)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->