### PR TITLE
🔒 [security] Fix XSS vulnerability in theme initialization script

### DIFF
--- a/packages/web-app-vercel/app/layout.tsx
+++ b/packages/web-app-vercel/app/layout.tsx
@@ -3,7 +3,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import ClientLayout from "./client-layout";
-import { DEFAULT_SETTINGS } from "@/types/settings";
+import { DEFAULT_SETTINGS, COLOR_THEMES } from "@/types/settings";
 import { STORAGE_KEYS } from "@/lib/constants";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
@@ -29,11 +29,22 @@ export default function RootLayout({
         <script
           data-storage-key={STORAGE_KEYS.COLOR_THEME}
           data-default-theme={DEFAULT_SETTINGS.color_theme}
+          data-valid-themes={COLOR_THEMES.map((t) => t.value).join(",")}
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
                 try {
-                  const theme = localStorage.getItem(document.currentScript.getAttribute('data-storage-key')) || document.currentScript.getAttribute('data-default-theme');
+                  const script = document.currentScript;
+                  const storageKey = script.getAttribute('data-storage-key');
+                  const defaultTheme = script.getAttribute('data-default-theme');
+                  const validThemes = script.getAttribute('data-valid-themes').split(',');
+
+                  let theme = localStorage.getItem(storageKey) || defaultTheme;
+
+                  if (!validThemes.includes(theme)) {
+                    theme = defaultTheme;
+                  }
+
                   document.documentElement.setAttribute('data-theme', theme);
                   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add('dark');

--- a/packages/web-app-vercel/app/layout.tsx
+++ b/packages/web-app-vercel/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
         <script
           data-storage-key={STORAGE_KEYS.COLOR_THEME}
           data-default-theme={DEFAULT_SETTINGS.color_theme}
-          data-valid-themes={COLOR_THEMES.map((t) => t.value).join(",")}
+          data-valid-themes={JSON.stringify(COLOR_THEMES.map((t) => t.value))}
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
@@ -37,12 +37,13 @@ export default function RootLayout({
                   const script = document.currentScript;
                   const storageKey = script.getAttribute('data-storage-key');
                   const defaultTheme = script.getAttribute('data-default-theme');
-                  const validThemes = script.getAttribute('data-valid-themes').split(',');
+                  const validThemes = JSON.parse(script.getAttribute('data-valid-themes') || '[]');
+                  const fallbackTheme = validThemes.includes(defaultTheme) ? defaultTheme : validThemes[0];
 
-                  let theme = localStorage.getItem(storageKey) || defaultTheme;
+                  let theme = localStorage.getItem(storageKey) || fallbackTheme;
 
                   if (!validThemes.includes(theme)) {
-                    theme = defaultTheme;
+                    theme = fallbackTheme;
                   }
 
                   document.documentElement.setAttribute('data-theme', theme);

--- a/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
@@ -11,10 +11,6 @@ const COLOR_MAP: Record<string, string> = {
 }
 
 test.describe('Theme FOUC prevention', () => {
-    test.beforeEach(async ({ page }) => {
-        // No-op: keep default context handling. We'll create unauthenticated contexts per-test.
-    })
-
     test('Guest: localStorage theme is applied before hydration', async ({ browser }) => {
         const theme = 'purple'
         const ctx = await browser.newContext()
@@ -78,6 +74,20 @@ test.describe('Theme FOUC prevention', () => {
     test('Guest: default ocean when localStorage not set', async ({ browser }) => {
         // No theme in localStorage
         const ctx = await browser.newContext()
+        const p = await ctx.newPage()
+        p.on('console', msg => console.log('PAGE LOG:', msg.type(), msg.text()))
+        await p.goto('/', { waitUntil: 'domcontentloaded' })
+
+        const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
+        expect(domTheme).toBe('ocean')
+        await ctx.close()
+    })
+
+    test('Guest: invalid localStorage theme falls back before hydration', async ({ browser }) => {
+        const ctx = await browser.newContext()
+        await ctx.addInitScript({
+            content: `localStorage.setItem('${THEME_STORAGE_KEY}', 'invalid,theme')`,
+        })
         const p = await ctx.newPage()
         p.on('console', msg => console.log('PAGE LOG:', msg.type(), msg.text()))
         await p.goto('/', { waitUntil: 'domcontentloaded' })

--- a/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test'
+import { DEFAULT_SETTINGS } from '../../types/settings'
 
 const THEME_STORAGE_KEY = 'audicle-color-theme'
+const DEFAULT_THEME = DEFAULT_SETTINGS.color_theme
 const THEMES = ['ocean', 'purple', 'forest', 'rose', 'orange'] as const
 const COLOR_MAP: Record<string, string> = {
     ocean: 'hsl(199 89% 48%)',
@@ -79,7 +81,7 @@ test.describe('Theme FOUC prevention', () => {
         await p.goto('/', { waitUntil: 'domcontentloaded' })
 
         const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
-        expect(domTheme).toBe('ocean')
+        expect(domTheme).toBe(DEFAULT_THEME)
         await ctx.close()
     })
 
@@ -93,7 +95,7 @@ test.describe('Theme FOUC prevention', () => {
         await p.goto('/', { waitUntil: 'domcontentloaded' })
 
         const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
-        expect(domTheme).toBe('ocean')
+        expect(domTheme).toBe(DEFAULT_THEME)
         await ctx.close()
     })
 })


### PR DESCRIPTION
🎯 **What:** Fixed a potential Cross-Site Scripting (XSS) vulnerability in the theme initialization script within `layout.tsx`.
⚠️ **Risk:** The script was reading a theme value directly from `localStorage` and using it to set a `data-theme` attribute on the `<html>` element. An attacker who could poison `localStorage` (e.g., via another XSS or physical access) could potentially inject malicious code or attributes.
🛡️ **Solution:** Implemented an allowlist validation. The valid theme values are passed to the script via a `data-valid-themes` attribute, and the script now verifies the `localStorage` value against this list before application. If the value is invalid, it falls back to the default theme. The use of `dangerouslySetInnerHTML` is maintained to prevent React from escaping logical operators in the script, while the security risk is mitigated by the input validation.

---
*PR created automatically by Jules for task [13006902076261982761](https://jules.google.com/task/13006902076261982761) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはlayout.tsxのテーマ初期化スクリプトにおけるXSS脆弱性を修正します。localStorageから読み取ったテーマ値をアローリストで検証してから適用するよう変更し、有効テーマ一覧はJSONシリアライズして`data-valid-themes`属性経由でスクリプトに渡しています。

- `COLOR_THEMES`の値をサーバーサイドで`JSON.stringify`して`data-valid-themes`属性に埋め込み、クライアント側で`JSON.parse`して検証するフローに変更。`defaultTheme`自体もアローリストに含まれるか確認してフォールバック値を決定する二重防御を実装。
- E2EテストにはDEFAULT_THEMEの動的参照への改善と、不正なlocalStorage値がフォールバックされることを確認する新テストケースを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はすべてテーマ初期化スクリプトのアローリスト検証に限定されており、サーバーサイドの定数から生成したJSONを正しく利用しているためマージ安全です。

localStorageの値をJSON形式のアローリストで検証するロジックは正確で、defaultThemeのフォールバック検証も含め二重に防御されています。E2Eテストが無効値のフォールバック動作を網羅しており、コードの正確性が十分に確認できます。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/layout.tsx | テーマ初期化スクリプトにアローリスト検証を追加。data-valid-themes属性にJSONで有効テーマ一覧を渡し、localStorageの値を検証してから適用する実装に変更。JSON形式採用により区切り文字の衝突リスクを排除。 |
| packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts | 無効なlocalStorage値のフォールバックを検証する新テストを追加。DEFAULT_THEMEをDEFAULT_SETTINGSから動的に取得するよう改善し、空のbeforeEachを削除。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[スクリプト実行開始] --> B[script属性からstorageKey / defaultTheme / validThemesを取得]
    B --> C[JSON.parseでvalidThemesを復元]
    C --> D{defaultThemeがvalidThemesに存在する?}
    D -- Yes --> E[fallbackTheme = defaultTheme]
    D -- No --> F["fallbackTheme = validThemes.at(0)"]
    E --> G[localStorageからテーマ値を取得]
    F --> G
    G --> H{取得値が存在する?}
    H -- No --> I[theme = fallbackTheme]
    H -- Yes --> J{validThemesに含まれる?}
    J -- Yes --> K[theme = localStorage値]
    J -- No --> I
    K --> L["setAttribute('data-theme', theme)"]
    I --> L
    L --> M{prefers-color-scheme: dark?}
    M -- Yes --> N["classList.add('dark')"]
    M -- No --> O[終了]
    N --> O
```

<sub>Reviews (4): Last reviewed commit: ["test: use default theme constant in them..."](https://github.com/hiroki-org/audicle/commit/70a9a39512ed9ba4b24491ad3b54e1d42b21a680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31718074)</sub>

<!-- /greptile_comment -->