### PR TITLE
🔒 Fix: Prevent exposure of original error messages in synthesize route

### DIFF
--- a/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
@@ -199,19 +199,12 @@ describe('/api/synthesize route', () => {
                 }
             };
 
-            const originalEnv = process.env.NODE_ENV;
-            process.env.NODE_ENV = 'development';
-
-            try {
-                const res = await routeModule.POST(req as any);
-                expect(res.status).toBe(500);
-                const body = await res.json();
-                expect(body).toHaveProperty('error', 'Failed to synthesize speech');
-                expect(body).toHaveProperty('errorType', 'UNKNOWN');
-                expect(body).toHaveProperty('detail', 'Unexpected generic error');
-            } finally {
-                process.env.NODE_ENV = originalEnv;
-            }
+            const res = await routeModule.POST(req as any);
+            expect(res.status).toBe(500);
+            const body = await res.json();
+            expect(body).toHaveProperty('error', 'Failed to synthesize speech');
+            expect(body).toHaveProperty('errorType', 'UNKNOWN');
+            expect(body).not.toHaveProperty('detail');
         });
 
         it('returns appropriate status and message for TTSError via Google Cloud mock', async () => {

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -696,11 +696,8 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // When not in production, include the original error message for easier
-        // debugging. Do not include sensitive details in production.
         interface SynthesizeErrorResponse {
             error: string;
-            detail?: string;
             errorType?: string;
         }
 
@@ -708,9 +705,6 @@ export async function POST(request: NextRequest) {
             error: 'Failed to synthesize speech',
             errorType: 'UNKNOWN'
         };
-        if (process.env.NODE_ENV !== 'production' && error instanceof Error) {
-            responseBody.detail = error.message;
-        }
 
         return NextResponse.json(responseBody, { status: 500, headers: corsHeaders });
     }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `packages/web-app-vercel/app/api/synthesize/route.ts` API route was returning raw, unhandled error messages (via the `detail` property) to clients when errors occurred in non-production environments (`process.env.NODE_ENV !== 'production'`).

⚠️ **Risk:** The potential impact if left unfixed
Exposing internal error messages, even conditionally in non-production environments, poses a significant security risk. If a non-production environment (like a staging server) is exposed externally, attackers could gain unauthorized insights into the application's internal workings, database structure, or connected third-party systems through these unhandled error messages, facilitating further attacks. It's best practice to keep error responses vague and handle debugging via internal logs.

🛡️ **Solution:** How the fix addresses the vulnerability
The vulnerability was resolved by completely removing the `detail` property from the `SynthesizeErrorResponse` and deleting the block of code that conditionally assigned `error.message` to `detail`. Tests in `packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts` have also been updated to ensure the `detail` property is explicitly absent from the response body.

---
*PR created automatically by Jules for task [856474913270979510](https://jules.google.com/task/856474913270979510) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

非本番環境で内部エラーメッセージ（`error.message`）をクライアントに `detail` フィールドとして返していた脆弱性を修正するPRです。ステージング環境などが外部に公開されている場合に情報漏洩につながるリスクがありました。

- `route.ts`: `SynthesizeErrorResponse` インターフェースから `detail?` プロパティを削除し、`process.env.NODE_ENV !== 'production'` の条件分岐ブロックを完全に除去。全環境で一貫してメッセージを返すようになりました。
- `route.test.ts`: `NODE_ENV` を `development` に切り替える前後の処理を削除し、`expect(body).not.toHaveProperty('detail')` で `detail` が存在しないことを明示的に検証するテストに更新。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

汎用エラーハンドラーから内部メッセージの漏洩を除去する最小限の変更で、テストも適切に更新されている。

変更は2ファイルに限定されており、削除対象のコードパスは単純な条件分岐のみ。残りのエラーハンドリングロジック（SyntaxError、TTSError）には手が加えられておらず、テストが `detail` の不在を明示的に検証している。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/synthesize/route.ts | 汎用エラーハンドラーから `detail` プロパティ（`error.message` を含む）を削除。変更は最小限で正確。 |
| packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts | `NODE_ENV` の操作を削除し、レスポンスに `detail` が含まれないことを検証するテストに更新。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SynthesizeRoute as /api/synthesize (POST)
    participant Handler as Error Handler

    Client->>SynthesizeRoute: POST request
    SynthesizeRoute->>Handler: Unexpected Error thrown

    Note over Handler: Before fix (non-production)
    Handler-->>Client: "{ error, errorType, detail: error.message }"

    Note over Handler: After fix (all environments)
    Handler-->>Client: "{ error: "Failed to synthesize speech", errorType: "UNKNOWN" }"
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into jules-856474913..."](https://github.com/hiroki-org/audicle/commit/7797e25ed62c4647eeb4bafbab83c4768f15e4d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31721642)</sub>

<!-- /greptile_comment -->