### PR TITLE
🧪 [Add tests for useUserSettings hooks]

### DIFF
--- a/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
@@ -1,0 +1,183 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUserSettings, useUpdateUserSettingsMutation } from "../useUserSettings";
+import React from "react";
+import { useSession } from "next-auth/react";
+import { UserSettings, DEFAULT_SETTINGS } from "@/types/settings";
+
+const originalFetch = global.fetch;
+
+// Mock next-auth/react
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+describe("useUserSettings hooks", () => {
+  let queryClient: QueryClient;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
+  const mockSession = {
+    data: { user: { email: "test@example.com" } },
+    status: "authenticated",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (!global.fetch) {
+      Object.defineProperty(global, "fetch", {
+        configurable: true,
+        writable: true,
+        value: jest.fn(),
+      });
+    }
+    fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockRejectedValue(new Error("fetch mock not configured"));
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    (useSession as jest.Mock).mockReturnValue(mockSession);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (!originalFetch) {
+      delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  describe("useUserSettings", () => {
+    it("should fetch user settings successfully", async () => {
+      const mockSettings: UserSettings = {
+        ...DEFAULT_SETTINGS,
+        playback_speed: 1.5,
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSettings,
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/get");
+      expect(result.current.data).toEqual(mockSettings);
+    });
+
+    it("should handle API error", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Custom error message" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Custom error message");
+    });
+
+    it("should use default error message on failure if no specific error provided", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("設定の取得に失敗しました");
+    });
+
+    it("should not fetch if userEmail is missing", async () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: null,
+        status: "unauthenticated",
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("useUpdateUserSettingsMutation", () => {
+    it("should update user settings successfully and invalidate cache", async () => {
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      const newSettings: UserSettings = {
+        ...DEFAULT_SETTINGS,
+        playback_speed: 2.0,
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(newSettings);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newSettings),
+      });
+
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ["user-settings", "test@example.com"],
+      });
+    });
+
+    it("should handle mutation API error", async () => {
+      const newSettings: UserSettings = {
+        ...DEFAULT_SETTINGS,
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Update failed custom message" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(newSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Update failed custom message");
+    });
+
+    it("should use default error message on mutation failure", async () => {
+      const newSettings: UserSettings = {
+        ...DEFAULT_SETTINGS,
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(newSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("設定の保存に失敗しました");
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Created a new unit test suite for the `useUserSettings` and `useUpdateUserSettingsMutation` hooks in `packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx` which were previously untested.

📊 **Coverage:**
- `useUserSettings`: Tests the successful fetch scenario, API error handling with specific or default messages, and the skipping of execution when session data is missing.
- `useUpdateUserSettingsMutation`: Tests the successful mutation along with cache invalidation (`queryClient.invalidateQueries`), as well as various error handling scenarios.

✨ **Result:** Enhanced the automated test coverage for user settings state management. The addition of this suite improves codebase reliability and catches potential regressions in the frontend's interactions with settings APIs.

---
*PR created automatically by Jules for task [12907210706556822776](https://jules.google.com/task/12907210706556822776) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `useUserSettings` および `useUpdateUserSettingsMutation` フックを対象とした新規ユニットテストスイートを追加しています。主要な成功ケース・APIエラーハンドリング・セッション欠如時のスキップ・キャッシュ無効化の確認が含まれており、既存フックの基本的な動作を網羅しています。

- `useUserSettings`: 成功フェッチ・APIエラー（カスタムメッセージ・デフォルトメッセージ）・未認証時のクエリスキップの4テストを追加
- `useUpdateUserSettingsMutation`: 成功ミューテーション＋`invalidateQueries` 検証・APIエラー（カスタム・デフォルト）の3テストを追加
- `fetch` スパイを `beforeEach` で初期化し、`jest.restoreAllMocks()` でクリーンアップする構成を採用
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更で既存の実装コードには影響なし。マージしても安全。

新規テストファイルのみの追加であり、プロダクションコードへの変更はない。主要なシナリオは適切にカバーされているが、ミューテーション側での未認証シナリオおよびネットワーク障害ケースが欠けており、これらは将来のリグレッション検出に役立てられる機会として残っている。

packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx — ミューテーション未認証時とネットワーク障害時のテストケース追加を検討
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx | useUserSettings と useUpdateUserSettingsMutation の新規テストスイート。主要な成功・エラーケースをカバーしているが、ミューテーション側での未認証シナリオとネットワーク障害ケースが欠けている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストコード
    participant Hook as useUserSettings / useUpdateUserSettingsMutation
    participant Fetch as fetch (モック)
    participant QC as QueryClient

    Note over Test,QC: useUserSettings — 成功ケース
    Test->>Hook: renderHook()
    Hook->>Fetch: GET /api/settings/get
    Fetch-->>Hook: ok:true, UserSettings
    Hook-->>Test: "isSuccess=true"

    Note over Test,QC: useUserSettings — 未認証スキップ
    Test->>Hook: "renderHook() session=null"
    Hook-->>Test: "fetchStatus=idle"

    Note over Test,QC: useUpdateUserSettingsMutation — 成功+キャッシュ無効化
    Test->>Hook: renderHook()
    Test->>Hook: mutate(newSettings)
    Hook->>Fetch: PUT /api/settings/update
    Fetch-->>Hook: ok:true
    Hook->>QC: invalidateQueries([user-settings, email])
    Hook-->>Test: "isSuccess=true"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:103-183
**未認証時のキャッシュ無効化シナリオが未テスト**

`useUserSettings` には「セッションがない場合はフェッチをスキップする」テストが用意されていますが、`useUpdateUserSettingsMutation` には対応するテストがありません。フック側の `onSuccess` は `userEmail` をクロージャでキャプチャするため、`userEmail` が `undefined` のときに `mutate` を呼ぶと `invalidateQueries({ queryKey: ["user-settings", undefined] })` が実行され、認証済みユーザーのクエリが正しく無効化されません。このエッジケースをテストで検証することで、潜在的な不整合を早期に検出できます。

### Issue 2 of 2
packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx:26-46
**ネットワークレベルのエラーケースが未テスト**

`beforeEach` では `fetch` のデフォルトを `mockRejectedValue(new Error("fetch mock not configured"))` に設定しています。これは未設定のテストを防ぐガードですが、各テストでは `mockResolvedValueOnce` のみが使われており、`fetch` 自体が拒否される（例：ネットワーク切断）シナリオのテストが存在しません。両フックで `fetch` がリジェクトした場合にエラーが正しくバブルアップするかどうかを確認するテストケースを追加することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add useUserSettings and useUpdateU..."](https://github.com/hiroki-org/audicle/commit/9699089276f1c877417f7a788a8050bfdf890352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31721944)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->