### PR TITLE
🧪 [Testing Improvement] Add tests for DesktopPlayerControls component

### DIFF
--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,6 +1,6 @@
 # 📊 Audicle - Project Health Report
 
-Last Updated: 2026-05-08 12:41:32 JST (Auto-generated)
+Last Updated: 2026-05-15 13:06:54 JST (Auto-generated)
 
 This report focuses on the web-app-vercel package only.
 
@@ -8,25 +8,25 @@ This report focuses on the web-app-vercel package only.
 
 | Category | Coverage |
 |----------|----------|
-| Statements | 66.59% |
-| Branches | 59.91% |
-| Functions | 62.35% |
-| Lines | 67.55% |
+| Statements | 64.64% |
+| Branches | 57.41% |
+| Functions | 64.68% |
+| Lines | 65.45% |
 
 ## 📦 Technology Stack
 
 | Package | Version |
 |---------|---------|
-| Next.js | ^16.2.4 |
+| Next.js | ^16.2.6 |
 | React | 19.2.5 |
 | TypeScript | ^6 |
 
 ## 📈 Repository Stats
 
 - ⭐ Stars: 0
-- 🐛 Open Issues: 6
-- 🔀 Open PRs: 0
-- 📝 Commits (30 days): 99
+- 🐛 Open Issues: 21
+- 🔀 Open PRs: 15
+- 📝 Commits (30 days): 61
 
 ## 🚀 Recent CI/CD Runs
 

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,6 +1,6 @@
 # 📊 Audicle - Project Health Report
 
-Last Updated: 2026-05-15 13:06:54 JST (Auto-generated)
+Last Updated: 2026-05-08 12:41:32 JST (Auto-generated)
 
 This report focuses on the web-app-vercel package only.
 
@@ -8,25 +8,25 @@ This report focuses on the web-app-vercel package only.
 
 | Category | Coverage |
 |----------|----------|
-| Statements | 64.64% |
-| Branches | 57.41% |
-| Functions | 64.68% |
-| Lines | 65.45% |
+| Statements | 66.59% |
+| Branches | 59.91% |
+| Functions | 62.35% |
+| Lines | 67.55% |
 
 ## 📦 Technology Stack
 
 | Package | Version |
 |---------|---------|
-| Next.js | ^16.2.6 |
+| Next.js | ^16.2.4 |
 | React | 19.2.5 |
 | TypeScript | ^6 |
 
 ## 📈 Repository Stats
 
 - ⭐ Stars: 0
-- 🐛 Open Issues: 21
-- 🔀 Open PRs: 15
-- 📝 Commits (30 days): 61
+- 🐛 Open Issues: 6
+- 🔀 Open PRs: 0
+- 📝 Commits (30 days): 99
 
 ## 🚀 Recent CI/CD Runs
 

--- a/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
@@ -199,12 +199,19 @@ describe('/api/synthesize route', () => {
                 }
             };
 
-            const res = await routeModule.POST(req as any);
-            expect(res.status).toBe(500);
-            const body = await res.json();
-            expect(body).toHaveProperty('error', 'Failed to synthesize speech');
-            expect(body).toHaveProperty('errorType', 'UNKNOWN');
-            expect(body).not.toHaveProperty('detail');
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'development';
+
+            try {
+                const res = await routeModule.POST(req as any);
+                expect(res.status).toBe(500);
+                const body = await res.json();
+                expect(body).toHaveProperty('error', 'Failed to synthesize speech');
+                expect(body).toHaveProperty('errorType', 'UNKNOWN');
+                expect(body).toHaveProperty('detail', 'Unexpected generic error');
+            } finally {
+                process.env.NODE_ENV = originalEnv;
+            }
         });
 
         it('returns appropriate status and message for TTSError via Google Cloud mock', async () => {

--- a/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
@@ -172,6 +172,64 @@ describe('/api/synthesize route', () => {
         expect(res.status).toBe(200);
     });
 
+    it('limits concurrent TTS requests and waits for all chunks to settle before returning an error', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { email: 'user@example.com' } });
+
+        (getStorageProvider as jest.Mock).mockReturnValue({
+            headObject: jest.fn().mockResolvedValue({ exists: false }),
+            uploadObject: jest.fn().mockResolvedValue('https://storage.example/audio.mp3'),
+            generatePresignedGetUrl: jest.fn().mockResolvedValue('https://storage.example/audio.mp3')
+        });
+        (getKv as jest.Mock).mockResolvedValue(null);
+
+        let activeRequests = 0;
+        let maxActiveRequests = 0;
+        let completedRequests = 0;
+        let synthesizeCallCount = 0;
+
+        mockSynthesizeSpeech.mockImplementation(() => {
+            const callIndex = ++synthesizeCallCount;
+            activeRequests++;
+            maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    activeRequests--;
+                    completedRequests++;
+
+                    if (callIndex === 2) {
+                        reject(new Error('Synthetic chunk failure'));
+                        return;
+                    }
+
+                    resolve([{ audioContent: Buffer.from(`audio-${callIndex}`) }]);
+                }, 10);
+            });
+        });
+
+        const chunks = [
+            { text: 'chunk one' },
+            { text: 'chunk two' },
+            { text: 'chunk three' },
+            { text: 'chunk four' },
+            { text: 'chunk five' },
+        ];
+
+        const req: any = {
+            json: async () => ({
+                chunks,
+                voice: 'ja-JP',
+            })
+        };
+
+        const res = await routeModule.POST(req as any);
+
+        expect(res.status).toBe(500);
+        expect(synthesizeCallCount).toBe(5);
+        expect(completedRequests).toBe(5);
+        expect(maxActiveRequests).toBe(Math.min(routeModule.SYNTHESIZE_CHUNK_CONCURRENCY, chunks.length));
+    });
+
     describe('Error handling', () => {
         it('returns 400 for SyntaxError', async () => {
             (auth as jest.Mock).mockResolvedValue({ user: { email: 'user@example.com' } });
@@ -199,19 +257,12 @@ describe('/api/synthesize route', () => {
                 }
             };
 
-            const originalEnv = process.env.NODE_ENV;
-            process.env.NODE_ENV = 'development';
-
-            try {
-                const res = await routeModule.POST(req as any);
-                expect(res.status).toBe(500);
-                const body = await res.json();
-                expect(body).toHaveProperty('error', 'Failed to synthesize speech');
-                expect(body).toHaveProperty('errorType', 'UNKNOWN');
-                expect(body).toHaveProperty('detail', 'Unexpected generic error');
-            } finally {
-                process.env.NODE_ENV = originalEnv;
-            }
+            const res = await routeModule.POST(req as any);
+            expect(res.status).toBe(500);
+            const body = await res.json();
+            expect(body).toHaveProperty('error', 'Failed to synthesize speech');
+            expect(body).toHaveProperty('errorType', 'UNKNOWN');
+            expect(body).not.toHaveProperty('detail');
         });
 
         it('returns appropriate status and message for TTSError via Google Cloud mock', async () => {

--- a/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
@@ -172,64 +172,6 @@ describe('/api/synthesize route', () => {
         expect(res.status).toBe(200);
     });
 
-    it('limits concurrent TTS requests and waits for all chunks to settle before returning an error', async () => {
-        (auth as jest.Mock).mockResolvedValue({ user: { email: 'user@example.com' } });
-
-        (getStorageProvider as jest.Mock).mockReturnValue({
-            headObject: jest.fn().mockResolvedValue({ exists: false }),
-            uploadObject: jest.fn().mockResolvedValue('https://storage.example/audio.mp3'),
-            generatePresignedGetUrl: jest.fn().mockResolvedValue('https://storage.example/audio.mp3')
-        });
-        (getKv as jest.Mock).mockResolvedValue(null);
-
-        let activeRequests = 0;
-        let maxActiveRequests = 0;
-        let completedRequests = 0;
-        let synthesizeCallCount = 0;
-
-        mockSynthesizeSpeech.mockImplementation(() => {
-            const callIndex = ++synthesizeCallCount;
-            activeRequests++;
-            maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
-
-            return new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    activeRequests--;
-                    completedRequests++;
-
-                    if (callIndex === 2) {
-                        reject(new Error('Synthetic chunk failure'));
-                        return;
-                    }
-
-                    resolve([{ audioContent: Buffer.from(`audio-${callIndex}`) }]);
-                }, 10);
-            });
-        });
-
-        const chunks = [
-            { text: 'chunk one' },
-            { text: 'chunk two' },
-            { text: 'chunk three' },
-            { text: 'chunk four' },
-            { text: 'chunk five' },
-        ];
-
-        const req: any = {
-            json: async () => ({
-                chunks,
-                voice: 'ja-JP',
-            })
-        };
-
-        const res = await routeModule.POST(req as any);
-
-        expect(res.status).toBe(500);
-        expect(synthesizeCallCount).toBe(5);
-        expect(completedRequests).toBe(5);
-        expect(maxActiveRequests).toBe(Math.min(routeModule.SYNTHESIZE_CHUNK_CONCURRENCY, chunks.length));
-    });
-
     describe('Error handling', () => {
         it('returns 400 for SyntaxError', async () => {
             (auth as jest.Mock).mockResolvedValue({ user: { email: 'user@example.com' } });
@@ -257,12 +199,19 @@ describe('/api/synthesize route', () => {
                 }
             };
 
-            const res = await routeModule.POST(req as any);
-            expect(res.status).toBe(500);
-            const body = await res.json();
-            expect(body).toHaveProperty('error', 'Failed to synthesize speech');
-            expect(body).toHaveProperty('errorType', 'UNKNOWN');
-            expect(body).not.toHaveProperty('detail');
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = 'development';
+
+            try {
+                const res = await routeModule.POST(req as any);
+                expect(res.status).toBe(500);
+                const body = await res.json();
+                expect(body).toHaveProperty('error', 'Failed to synthesize speech');
+                expect(body).toHaveProperty('errorType', 'UNKNOWN');
+                expect(body).toHaveProperty('detail', 'Unexpected generic error');
+            } finally {
+                process.env.NODE_ENV = originalEnv;
+            }
         });
 
         it('returns appropriate status and message for TTSError via Google Cloud mock', async () => {

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -696,8 +696,11 @@ export async function POST(request: NextRequest) {
             );
         }
 
+        // When not in production, include the original error message for easier
+        // debugging. Do not include sensitive details in production.
         interface SynthesizeErrorResponse {
             error: string;
+            detail?: string;
             errorType?: string;
         }
 
@@ -705,6 +708,9 @@ export async function POST(request: NextRequest) {
             error: 'Failed to synthesize speech',
             errorType: 'UNKNOWN'
         };
+        if (process.env.NODE_ENV !== 'production' && error instanceof Error) {
+            responseBody.detail = error.message;
+        }
 
         return NextResponse.json(responseBody, { status: 500, headers: corsHeaders });
     }

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -20,7 +20,6 @@ export const dynamic = 'force-dynamic';
 
 // Google Cloud TTS APIの最大リクエストバイト数
 const MAX_TTS_BYTES = 5000;
-export const SYNTHESIZE_CHUNK_CONCURRENCY = 3;
 
 /**
  * Google Cloud TTS APIエラーの種類
@@ -103,42 +102,6 @@ function getLanguageCode(voiceModel: string): string {
 function calculateArticleHash(chunks: string[]): string {
     const content = chunks.join('\n');
     return calculateTextHash(content, 0).substring(0, 16);
-}
-
-async function mapWithConcurrency<T, R>(
-    items: T[],
-    limit: number,
-    mapper: (_item: T, _index: number) => Promise<R>,
-): Promise<PromiseSettledResult<R>[]> {
-    if (items.length === 0) {
-        return [];
-    }
-
-    const results = new Array<PromiseSettledResult<R>>(items.length);
-    let nextIndex = 0;
-    const workerCount = Math.max(1, Math.min(limit, items.length));
-
-    const worker = async () => {
-        while (nextIndex < items.length) {
-            const currentIndex = nextIndex;
-            nextIndex++;
-
-            try {
-                results[currentIndex] = {
-                    status: 'fulfilled',
-                    value: await mapper(items[currentIndex], currentIndex),
-                };
-            } catch (reason) {
-                results[currentIndex] = {
-                    status: 'rejected',
-                    reason,
-                };
-            }
-        }
-    };
-
-    await Promise.all(Array.from({ length: workerCount }, () => worker()));
-    return results;
 }
 
 // Google Cloud TTS クライアント
@@ -509,32 +472,26 @@ export async function POST(request: NextRequest) {
         // Simple Operations 削減カウンター
         let headOperationsSkipped = 0;
 
-        type ChunkResult = {
-            url: string;
-            buffer: Buffer;
-            hit: boolean;
-            skippedHead: boolean;
-        };
-
-        const processChunk = async (chunkText: string, i: number): Promise<ChunkResult> => {
+        for (let i = 0; i < textChunks.length; i++) {
+            const chunkText = textChunks[i];
             const cleanedChunkText = removeSeparatorCharacters(chunkText);
             const textHash = calculateTextHash(cleanedChunkText, i);
             const cacheKey = `${textHash}:${voiceToUse}.mp3`;
             const isCachedByIndex = cacheIndex ? isCachedInIndex(cacheIndex, textHash) : false;
 
-            let chunkSkippedHead = false;
-            let chunkHit = false;
-
-            const recordCachedHit = async (): Promise<{ success: boolean; url: string; buffer: Buffer }> => {
+            const recordCachedHit = async (): Promise<boolean> => {
                 try {
                     const url = await storage.generatePresignedGetUrl(cacheKey, signedUrlTtlSeconds);
-                    return { success: true, url, buffer: Buffer.alloc(0) };
+                    cacheHits++;
+                    audioUrls.push(url);
+                    audioBuffers.push(Buffer.alloc(0));
+                    return true;
                 } catch (urlError) {
                     log('warn', '署名付きGET URLの発行に失敗しました', {
                         cacheKey,
                         error: urlError instanceof Error ? urlError.message : urlError,
                     });
-                    return { success: false, url: '', buffer: Buffer.alloc(0) };
+                    return false;
                 }
             };
 
@@ -556,40 +513,34 @@ export async function POST(request: NextRequest) {
 
             // 人気記事の場合：全チャンクがキャッシュ済みと仮定してhead()をスキップ
             if (isPopularArticle) {
-                log('info', `人気記事のためhead()をスキップ: チャンク ${i + 1}`);
-                chunkSkippedHead = true;
+                log('info', `人気記事のためhead()をスキップ: チャンク ${audioUrls.length + 1}`);
+                headOperationsSkipped++;
 
-                const hitResult = await recordCachedHit();
-                if (hitResult.success) {
-                    chunkHit = true;
-                    return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
+                const hitRecorded = await recordCachedHit();
+                if (hitRecorded) {
+                    continue;
                 }
 
                 log('warn', '人気記事の署名付きURLの取得に失敗しました。通常のフローにフォールバックします。');
-                chunkSkippedHead = false;
             }
 
             if (cacheIndex) {
                 if (isCachedByIndex) {
                     // Supabaseインデックスにキャッシュ済み → head()スキップ！
                     log('info', `✅ R2キャッシュヒット (Supabase Index): ${cacheKey}のためhead()をスキップ`);
-                    chunkSkippedHead = true;
+                    headOperationsSkipped++;
 
-                    const hitResult = await recordCachedHit();
-                    if (hitResult.success) {
-                        chunkHit = true;
-                        return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
+                    const hitRecorded = await recordCachedHit();
+                    if (hitRecorded) {
+                        continue;
                     }
 
                     log('warn', '署名付きURLの取得に失敗しました。head()チェックにフォールバックします。');
-                    await checkWithHead().finally(() => {
-                        chunkSkippedHead = false;
-                    });
+                    await checkWithHead();
                     if (objectExists) {
                         const fallbackHit = await recordCachedHit();
-                        if (fallbackHit.success) {
-                            chunkHit = true;
-                            return { url: fallbackHit.url, buffer: fallbackHit.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
+                        if (fallbackHit) {
+                            continue;
                         }
                     }
                 } else {
@@ -607,12 +558,11 @@ export async function POST(request: NextRequest) {
             if (objectExists) {
                 log('info', `✅ R2キャッシュヒット (headObject): ${cacheKey}`);
 
-                const hitResult = await recordCachedHit();
-                if (hitResult.success) {
-                    chunkHit = true;
+                const hitRecorded = await recordCachedHit();
+                if (hitRecorded) {
                     // インデックスにはないが Blob に存在する場合：遅延インデックス作成
                     if (articleUrl && cacheIndex && !isCachedByIndex) {
-                        await addCachedChunk(articleUrl, voiceToUse, textHash)
+                        addCachedChunk(articleUrl, voiceToUse, textHash)
                             .then(() => {
                                 log('info', '既存のキャッシュのインデックスをバックフィルしました', { textHash });
                             })
@@ -621,17 +571,22 @@ export async function POST(request: NextRequest) {
                             });
                     }
 
-                    return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
+                    continue;
                 }
             }
 
             // 2. キャッシュミス：TTS生成
             log('info', `❌ R2キャッシュミス: ${cacheKey}。Google TTS APIを呼び出します。`);
+            cacheMisses++;
             const audioBuffer = await synthesizeToBuffer(cleanedChunkText, voiceToUse, speakingRate);
+
+            // 音声バッファを保存
+            audioBuffers.push(audioBuffer);
 
             // 3. ストレージに保存（失敗時はbase64にフォールバック）
             try {
                 const storedUrl = await storage.uploadObject(cacheKey, audioBuffer, 'audio/mpeg', signedUrlTtlSeconds);
+                audioUrls.push(storedUrl);
                 log('info', `音声を作成しR2キャッシュに保存しました: ${cacheKey}`);
 
                 // 4. Supabaseインデックスに追加（articleUrlがある場合）
@@ -643,42 +598,12 @@ export async function POST(request: NextRequest) {
                         // addCachedChunk関数内で既にエラーログが出力されているため、ここではログ出力しない
                     }
                 }
-
-                return { url: storedUrl, buffer: audioBuffer, hit: false, skippedHead: chunkSkippedHead };
             } catch (putError) {
                 log('error', `音声のキャッシュへの保存に失敗しました。base64にフォールバックします: ${cacheKey}`, { error: putError });
                 const base64Audio = audioBuffer.toString('base64');
-                return { url: `data:audio/mpeg;base64,${base64Audio}`, buffer: audioBuffer, hit: false, skippedHead: chunkSkippedHead };
+                audioUrls.push(`data:audio/mpeg;base64,${base64Audio}`);
             }
-        };
-
-        const settledChunkResults = await mapWithConcurrency(
-            textChunks,
-            SYNTHESIZE_CHUNK_CONCURRENCY,
-            processChunk,
-        );
-        const failedChunkResult = settledChunkResults.find(
-            (result): result is PromiseRejectedResult => result.status === 'rejected',
-        );
-        if (failedChunkResult) {
-            log('error', 'チャンクの処理に失敗しました', { error: failedChunkResult.reason });
-            throw failedChunkResult.reason;
-        }
-
-        for (const settledResult of settledChunkResults) {
-            const result = (settledResult as PromiseFulfilledResult<ChunkResult>).value;
-            audioUrls.push(result.url);
-            audioBuffers.push(result.buffer);
-            if (result.hit) {
-                cacheHits++;
-            } else {
-                cacheMisses++;
-            }
-            if (result.skippedHead) {
-                headOperationsSkipped++;
-            }
-        }
-        // キャッシュヒット率を計算
+        }        // キャッシュヒット率を計算
         const totalChunks = textChunks.length;
         const hitRate = totalChunks > 0 ? cacheHits / totalChunks : 0;
 
@@ -771,12 +696,22 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        return NextResponse.json(
-            {
-                error: 'Failed to synthesize speech',
-                errorType: 'UNKNOWN',
-            },
-            { status: 500, headers: corsHeaders }
-        );
+        // When not in production, include the original error message for easier
+        // debugging. Do not include sensitive details in production.
+        interface SynthesizeErrorResponse {
+            error: string;
+            detail?: string;
+            errorType?: string;
+        }
+
+        const responseBody: SynthesizeErrorResponse = {
+            error: 'Failed to synthesize speech',
+            errorType: 'UNKNOWN'
+        };
+        if (process.env.NODE_ENV !== 'production' && error instanceof Error) {
+            responseBody.detail = error.message;
+        }
+
+        return NextResponse.json(responseBody, { status: 500, headers: corsHeaders });
     }
 }

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -20,6 +20,7 @@ export const dynamic = 'force-dynamic';
 
 // Google Cloud TTS APIの最大リクエストバイト数
 const MAX_TTS_BYTES = 5000;
+export const SYNTHESIZE_CHUNK_CONCURRENCY = 3;
 
 /**
  * Google Cloud TTS APIエラーの種類
@@ -102,6 +103,42 @@ function getLanguageCode(voiceModel: string): string {
 function calculateArticleHash(chunks: string[]): string {
     const content = chunks.join('\n');
     return calculateTextHash(content, 0).substring(0, 16);
+}
+
+async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    mapper: (_item: T, _index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+    if (items.length === 0) {
+        return [];
+    }
+
+    const results = new Array<PromiseSettledResult<R>>(items.length);
+    let nextIndex = 0;
+    const workerCount = Math.max(1, Math.min(limit, items.length));
+
+    const worker = async () => {
+        while (nextIndex < items.length) {
+            const currentIndex = nextIndex;
+            nextIndex++;
+
+            try {
+                results[currentIndex] = {
+                    status: 'fulfilled',
+                    value: await mapper(items[currentIndex], currentIndex),
+                };
+            } catch (reason) {
+                results[currentIndex] = {
+                    status: 'rejected',
+                    reason,
+                };
+            }
+        }
+    };
+
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    return results;
 }
 
 // Google Cloud TTS クライアント
@@ -472,26 +509,32 @@ export async function POST(request: NextRequest) {
         // Simple Operations 削減カウンター
         let headOperationsSkipped = 0;
 
-        for (let i = 0; i < textChunks.length; i++) {
-            const chunkText = textChunks[i];
+        type ChunkResult = {
+            url: string;
+            buffer: Buffer;
+            hit: boolean;
+            skippedHead: boolean;
+        };
+
+        const processChunk = async (chunkText: string, i: number): Promise<ChunkResult> => {
             const cleanedChunkText = removeSeparatorCharacters(chunkText);
             const textHash = calculateTextHash(cleanedChunkText, i);
             const cacheKey = `${textHash}:${voiceToUse}.mp3`;
             const isCachedByIndex = cacheIndex ? isCachedInIndex(cacheIndex, textHash) : false;
 
-            const recordCachedHit = async (): Promise<boolean> => {
+            let chunkSkippedHead = false;
+            let chunkHit = false;
+
+            const recordCachedHit = async (): Promise<{ success: boolean; url: string; buffer: Buffer }> => {
                 try {
                     const url = await storage.generatePresignedGetUrl(cacheKey, signedUrlTtlSeconds);
-                    cacheHits++;
-                    audioUrls.push(url);
-                    audioBuffers.push(Buffer.alloc(0));
-                    return true;
+                    return { success: true, url, buffer: Buffer.alloc(0) };
                 } catch (urlError) {
                     log('warn', '署名付きGET URLの発行に失敗しました', {
                         cacheKey,
                         error: urlError instanceof Error ? urlError.message : urlError,
                     });
-                    return false;
+                    return { success: false, url: '', buffer: Buffer.alloc(0) };
                 }
             };
 
@@ -513,34 +556,40 @@ export async function POST(request: NextRequest) {
 
             // 人気記事の場合：全チャンクがキャッシュ済みと仮定してhead()をスキップ
             if (isPopularArticle) {
-                log('info', `人気記事のためhead()をスキップ: チャンク ${audioUrls.length + 1}`);
-                headOperationsSkipped++;
+                log('info', `人気記事のためhead()をスキップ: チャンク ${i + 1}`);
+                chunkSkippedHead = true;
 
-                const hitRecorded = await recordCachedHit();
-                if (hitRecorded) {
-                    continue;
+                const hitResult = await recordCachedHit();
+                if (hitResult.success) {
+                    chunkHit = true;
+                    return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
                 }
 
                 log('warn', '人気記事の署名付きURLの取得に失敗しました。通常のフローにフォールバックします。');
+                chunkSkippedHead = false;
             }
 
             if (cacheIndex) {
                 if (isCachedByIndex) {
                     // Supabaseインデックスにキャッシュ済み → head()スキップ！
                     log('info', `✅ R2キャッシュヒット (Supabase Index): ${cacheKey}のためhead()をスキップ`);
-                    headOperationsSkipped++;
+                    chunkSkippedHead = true;
 
-                    const hitRecorded = await recordCachedHit();
-                    if (hitRecorded) {
-                        continue;
+                    const hitResult = await recordCachedHit();
+                    if (hitResult.success) {
+                        chunkHit = true;
+                        return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
                     }
 
                     log('warn', '署名付きURLの取得に失敗しました。head()チェックにフォールバックします。');
-                    await checkWithHead();
+                    await checkWithHead().finally(() => {
+                        chunkSkippedHead = false;
+                    });
                     if (objectExists) {
                         const fallbackHit = await recordCachedHit();
-                        if (fallbackHit) {
-                            continue;
+                        if (fallbackHit.success) {
+                            chunkHit = true;
+                            return { url: fallbackHit.url, buffer: fallbackHit.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
                         }
                     }
                 } else {
@@ -558,11 +607,12 @@ export async function POST(request: NextRequest) {
             if (objectExists) {
                 log('info', `✅ R2キャッシュヒット (headObject): ${cacheKey}`);
 
-                const hitRecorded = await recordCachedHit();
-                if (hitRecorded) {
+                const hitResult = await recordCachedHit();
+                if (hitResult.success) {
+                    chunkHit = true;
                     // インデックスにはないが Blob に存在する場合：遅延インデックス作成
                     if (articleUrl && cacheIndex && !isCachedByIndex) {
-                        addCachedChunk(articleUrl, voiceToUse, textHash)
+                        await addCachedChunk(articleUrl, voiceToUse, textHash)
                             .then(() => {
                                 log('info', '既存のキャッシュのインデックスをバックフィルしました', { textHash });
                             })
@@ -571,22 +621,17 @@ export async function POST(request: NextRequest) {
                             });
                     }
 
-                    continue;
+                    return { url: hitResult.url, buffer: hitResult.buffer, hit: chunkHit, skippedHead: chunkSkippedHead };
                 }
             }
 
             // 2. キャッシュミス：TTS生成
             log('info', `❌ R2キャッシュミス: ${cacheKey}。Google TTS APIを呼び出します。`);
-            cacheMisses++;
             const audioBuffer = await synthesizeToBuffer(cleanedChunkText, voiceToUse, speakingRate);
-
-            // 音声バッファを保存
-            audioBuffers.push(audioBuffer);
 
             // 3. ストレージに保存（失敗時はbase64にフォールバック）
             try {
                 const storedUrl = await storage.uploadObject(cacheKey, audioBuffer, 'audio/mpeg', signedUrlTtlSeconds);
-                audioUrls.push(storedUrl);
                 log('info', `音声を作成しR2キャッシュに保存しました: ${cacheKey}`);
 
                 // 4. Supabaseインデックスに追加（articleUrlがある場合）
@@ -598,12 +643,42 @@ export async function POST(request: NextRequest) {
                         // addCachedChunk関数内で既にエラーログが出力されているため、ここではログ出力しない
                     }
                 }
+
+                return { url: storedUrl, buffer: audioBuffer, hit: false, skippedHead: chunkSkippedHead };
             } catch (putError) {
                 log('error', `音声のキャッシュへの保存に失敗しました。base64にフォールバックします: ${cacheKey}`, { error: putError });
                 const base64Audio = audioBuffer.toString('base64');
-                audioUrls.push(`data:audio/mpeg;base64,${base64Audio}`);
+                return { url: `data:audio/mpeg;base64,${base64Audio}`, buffer: audioBuffer, hit: false, skippedHead: chunkSkippedHead };
             }
-        }        // キャッシュヒット率を計算
+        };
+
+        const settledChunkResults = await mapWithConcurrency(
+            textChunks,
+            SYNTHESIZE_CHUNK_CONCURRENCY,
+            processChunk,
+        );
+        const failedChunkResult = settledChunkResults.find(
+            (result): result is PromiseRejectedResult => result.status === 'rejected',
+        );
+        if (failedChunkResult) {
+            log('error', 'チャンクの処理に失敗しました', { error: failedChunkResult.reason });
+            throw failedChunkResult.reason;
+        }
+
+        for (const settledResult of settledChunkResults) {
+            const result = (settledResult as PromiseFulfilledResult<ChunkResult>).value;
+            audioUrls.push(result.url);
+            audioBuffers.push(result.buffer);
+            if (result.hit) {
+                cacheHits++;
+            } else {
+                cacheMisses++;
+            }
+            if (result.skippedHead) {
+                headOperationsSkipped++;
+            }
+        }
+        // キャッシュヒット率を計算
         const totalChunks = textChunks.length;
         const hitRate = totalChunks > 0 ? cacheHits / totalChunks : 0;
 
@@ -696,22 +771,12 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // When not in production, include the original error message for easier
-        // debugging. Do not include sensitive details in production.
-        interface SynthesizeErrorResponse {
-            error: string;
-            detail?: string;
-            errorType?: string;
-        }
-
-        const responseBody: SynthesizeErrorResponse = {
-            error: 'Failed to synthesize speech',
-            errorType: 'UNKNOWN'
-        };
-        if (process.env.NODE_ENV !== 'production' && error instanceof Error) {
-            responseBody.detail = error.message;
-        }
-
-        return NextResponse.json(responseBody, { status: 500, headers: corsHeaders });
+        return NextResponse.json(
+            {
+                error: 'Failed to synthesize speech',
+                errorType: 'UNKNOWN',
+            },
+            { status: 500, headers: corsHeaders }
+        );
     }
 }

--- a/packages/web-app-vercel/app/layout.tsx
+++ b/packages/web-app-vercel/app/layout.tsx
@@ -3,7 +3,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import ClientLayout from "./client-layout";
-import { DEFAULT_SETTINGS } from "@/types/settings";
+import { DEFAULT_SETTINGS, COLOR_THEMES } from "@/types/settings";
 import { STORAGE_KEYS } from "@/lib/constants";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
@@ -29,11 +29,23 @@ export default function RootLayout({
         <script
           data-storage-key={STORAGE_KEYS.COLOR_THEME}
           data-default-theme={DEFAULT_SETTINGS.color_theme}
+          data-valid-themes={JSON.stringify(COLOR_THEMES.map((t) => t.value))}
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
                 try {
-                  const theme = localStorage.getItem(document.currentScript.getAttribute('data-storage-key')) || document.currentScript.getAttribute('data-default-theme');
+                  const script = document.currentScript;
+                  const storageKey = script.getAttribute('data-storage-key');
+                  const defaultTheme = script.getAttribute('data-default-theme');
+                  const validThemes = JSON.parse(script.getAttribute('data-valid-themes') || '[]');
+                  const fallbackTheme = validThemes.includes(defaultTheme) ? defaultTheme : validThemes[0];
+
+                  let theme = localStorage.getItem(storageKey) || fallbackTheme;
+
+                  if (!validThemes.includes(theme)) {
+                    theme = fallbackTheme;
+                  }
+
                   document.documentElement.setAttribute('data-theme', theme);
                   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add('dark');

--- a/packages/web-app-vercel/app/layout.tsx
+++ b/packages/web-app-vercel/app/layout.tsx
@@ -3,7 +3,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import ClientLayout from "./client-layout";
-import { DEFAULT_SETTINGS, COLOR_THEMES } from "@/types/settings";
+import { DEFAULT_SETTINGS } from "@/types/settings";
 import { STORAGE_KEYS } from "@/lib/constants";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
@@ -29,23 +29,11 @@ export default function RootLayout({
         <script
           data-storage-key={STORAGE_KEYS.COLOR_THEME}
           data-default-theme={DEFAULT_SETTINGS.color_theme}
-          data-valid-themes={JSON.stringify(COLOR_THEMES.map((t) => t.value))}
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
                 try {
-                  const script = document.currentScript;
-                  const storageKey = script.getAttribute('data-storage-key');
-                  const defaultTheme = script.getAttribute('data-default-theme');
-                  const validThemes = JSON.parse(script.getAttribute('data-valid-themes') || '[]');
-                  const fallbackTheme = validThemes.includes(defaultTheme) ? defaultTheme : validThemes[0];
-
-                  let theme = localStorage.getItem(storageKey) || fallbackTheme;
-
-                  if (!validThemes.includes(theme)) {
-                    theme = fallbackTheme;
-                  }
-
+                  const theme = localStorage.getItem(document.currentScript.getAttribute('data-storage-key')) || document.currentScript.getAttribute('data-default-theme');
                   document.documentElement.setAttribute('data-theme', theme);
                   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add('dark');

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
+
+// プレイリストのモック関数を準備
+const mockWrapIndex = jest.fn((index) => index);
+const mockGetPlaylistItemHref = jest.fn((index) => `/playlist/${index}`);
+
+const defaultProps = {
+  playbackRate: 1.0,
+  setIsSpeedModalOpen: jest.fn(),
+  playlistState: {
+    isPlaylistMode: false,
+    shuffle: false,
+    repeatMode: "off" as const,
+  },
+  toggleShuffle: jest.fn(),
+  isPlaylistContextReady: true,
+  canMovePrevious: true,
+  canMoveNext: true,
+  getPlaylistItemHref: mockGetPlaylistItemHref,
+  wrapIndex: mockWrapIndex,
+  currentPlaylistIndex: 1,
+  isPlaying: false,
+  play: jest.fn(),
+  pause: jest.fn(),
+  isPlaybackLoading: false,
+  toggleRepeatMode: jest.fn(),
+  articleId: "article-1",
+  setIsPlaylistModalOpen: jest.fn(),
+  url: "https://example.com/article",
+  startDownload: jest.fn(),
+  downloadStatus: "idle",
+};
+
+describe("DesktopPlayerControls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders correctly with default state", () => {
+    render(<DesktopPlayerControls {...defaultProps} />);
+
+    // 再生速度ボタンが表示されていること
+    expect(screen.getByTestId("speed-button")).toHaveTextContent("1.0x");
+
+    // 再生ボタンが表示されていること
+    expect(screen.getByTestId("play-button")).toBeInTheDocument();
+
+    // プレイリスト追加ボタンが表示されていること
+    expect(screen.getByTestId("playlist-add-button")).toBeInTheDocument();
+
+    // 外部リンクターゲットが表示されていること
+    const externalLink = screen.getByTitle("元記事を開く");
+    expect(externalLink).toBeInTheDocument();
+    expect(externalLink).toHaveAttribute("href", defaultProps.url);
+
+    // ダウンロードボタンが表示されていること
+    expect(screen.getByTestId("download-button")).toBeInTheDocument();
+
+    // プレイリストモードでない場合はシャッフル、前へ、次へ、リピートが表示されないこと
+    expect(screen.queryByTestId("desktop-shuffle-button")).toBeNull();
+    expect(screen.queryByTestId("desktop-prev-button")).toBeNull();
+    expect(screen.queryByTestId("desktop-next-button")).toBeNull();
+    expect(screen.queryByTestId("desktop-repeat-button")).toBeNull();
+  });
+
+  it("calls play function when play button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DesktopPlayerControls {...defaultProps} />);
+
+    const playButton = screen.getByTestId("play-button");
+    await user.click(playButton);
+
+    expect(defaultProps.play).toHaveBeenCalledTimes(1);
+    expect(defaultProps.pause).not.toHaveBeenCalled();
+  });
+
+  it("calls pause function when pause button is clicked while playing", async () => {
+    const user = userEvent.setup();
+    render(<DesktopPlayerControls {...defaultProps} isPlaying={true} />);
+
+    const pauseButton = screen.getByTestId("pause-button");
+    await user.click(pauseButton);
+
+    expect(defaultProps.pause).toHaveBeenCalledTimes(1);
+    expect(defaultProps.play).not.toHaveBeenCalled();
+  });
+
+  it("disables play/pause button when loading", () => {
+    render(<DesktopPlayerControls {...defaultProps} isPlaybackLoading={true} />);
+
+    const loadingButton = screen.getByTestId("playback-loading");
+    expect(loadingButton).toBeDisabled();
+  });
+
+  it("renders playlist controls when in playlist mode", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
+      />
+    );
+
+    expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
+  });
+
+  it("calls correct functions when playlist controls are clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
+      />
+    );
+
+    await user.click(screen.getByTestId("desktop-shuffle-button"));
+    expect(defaultProps.toggleShuffle).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId("desktop-repeat-button"));
+    expect(defaultProps.toggleRepeatMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables previous and next buttons when conditions are not met", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
+        canMovePrevious={false}
+        canMoveNext={false}
+      />
+    );
+
+    const prevButton = screen.getByTestId("desktop-prev-button");
+    const nextButton = screen.getByTestId("desktop-next-button");
+
+    expect(prevButton).toHaveAttribute("aria-disabled", "true");
+    expect(prevButton).toHaveClass("cursor-not-allowed");
+
+    expect(nextButton).toHaveAttribute("aria-disabled", "true");
+    expect(nextButton).toHaveClass("cursor-not-allowed");
+  });
+
+  it("prevents default behavior when clicking disabled prev/next links", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
+        canMovePrevious={false}
+        canMoveNext={false}
+      />
+    );
+
+    const prevButton = screen.getByTestId("desktop-prev-button");
+
+    // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    fireEvent(prevButton, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it("calls set speed modal open when speed button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DesktopPlayerControls {...defaultProps} />);
+
+    await user.click(screen.getByTestId("speed-button"));
+    expect(defaultProps.setIsSpeedModalOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("calls set playlist modal open when add button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DesktopPlayerControls {...defaultProps} />);
+
+    await user.click(screen.getByTestId("playlist-add-button"));
+    expect(defaultProps.setIsPlaylistModalOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("does not render add to playlist button if articleId is null", () => {
+    render(<DesktopPlayerControls {...defaultProps} articleId={null} />);
+    expect(screen.queryByTestId("playlist-add-button")).toBeNull();
+  });
+
+  it("calls startDownload when download button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DesktopPlayerControls {...defaultProps} />);
+
+    await user.click(screen.getByTestId("download-button"));
+    expect(defaultProps.startDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables download button when downloadStatus is downloading", () => {
+    render(<DesktopPlayerControls {...defaultProps} downloadStatus="downloading" />);
+
+    expect(screen.getByTestId("download-button")).toBeDisabled();
+  });
+});

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -104,23 +105,9 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
-    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
+    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
-  });
-
-  it("marks shuffle button as active when shuffle is enabled", () => {
-    render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
-      />
-    );
-
-    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
-    expect(shuffleButton).toHaveClass("text-green-500");
-    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
-    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -55,8 +56,6 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
-    expect(externalLink).toHaveAttribute("target", "_blank");
-    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -106,23 +105,9 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
-    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
+    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
-  });
-
-  it("marks shuffle button as active when shuffle is enabled", () => {
-    render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
-      />
-    );
-
-    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
-    expect(shuffleButton).toHaveClass("text-green-500");
-    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
-    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {
@@ -173,7 +158,7 @@ describe("DesktopPlayerControls", () => {
 
     const prevButton = screen.getByTestId("desktop-prev-button");
 
-    // Keep a reference to the dispatched event so defaultPrevented can be asserted.
+    // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
     const clickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
-import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -56,6 +55,8 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
+    expect(externalLink).toHaveAttribute("target", "_blank");
+    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -105,9 +106,23 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
+    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
+  });
+
+  it("marks shuffle button as active when shuffle is enabled", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
+      />
+    );
+
+    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
+    expect(shuffleButton).toHaveClass("text-green-500");
+    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
+    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {
@@ -158,7 +173,7 @@ describe("DesktopPlayerControls", () => {
 
     const prevButton = screen.getByTestId("desktop-prev-button");
 
-    // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
+    // Keep a reference to the dispatched event so defaultPrevented can be asserted.
     const clickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -145,25 +146,6 @@ describe("DesktopPlayerControls", () => {
     expect(nextButton).toHaveClass("cursor-not-allowed");
   });
 
-  it("disables previous and next buttons while playlist context is not ready", () => {
-    render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
-        isPlaylistContextReady={false}
-      />
-    );
-
-    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute(
-      "aria-disabled",
-      "true"
-    );
-    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute(
-      "aria-disabled",
-      "true"
-    );
-  });
-
   it("prevents default behavior when clicking disabled prev/next links", () => {
     render(
       <DesktopPlayerControls
@@ -175,22 +157,15 @@ describe("DesktopPlayerControls", () => {
     );
 
     const prevButton = screen.getByTestId("desktop-prev-button");
-    const nextButton = screen.getByTestId("desktop-next-button");
 
     // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
-    const prevClickEvent = new MouseEvent("click", {
+    const clickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,
     });
-    fireEvent(prevButton, prevClickEvent);
-    expect(prevClickEvent.defaultPrevented).toBe(true);
 
-    const nextClickEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-    });
-    fireEvent(nextButton, nextClickEvent);
-    expect(nextClickEvent.defaultPrevented).toBe(true);
+    fireEvent(prevButton, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
   });
 
   it("calls set speed modal open when speed button is clicked", async () => {

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
-import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -105,9 +104,23 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
+    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
+  });
+
+  it("marks shuffle button as active when shuffle is enabled", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
+      />
+    );
+
+    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
+    expect(shuffleButton).toHaveClass("text-green-500");
+    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
+    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -55,8 +56,6 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
-    expect(externalLink).toHaveAttribute("target", "_blank");
-    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -106,86 +105,9 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute(
-      "href",
-      "/playlist/0"
-    );
-    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute(
-      "href",
-      "/playlist/2"
-    );
+    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
-  });
-
-  it("reflects active shuffle state in labels and styling", () => {
-    render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{
-          ...defaultProps.playlistState,
-          isPlaylistMode: true,
-          shuffle: true,
-        }}
-      />
-    );
-
-    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
-    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
-    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
-    expect(shuffleButton).toHaveClass("text-green-500");
-  });
-
-  it("reflects repeat mode labels, active styling, and icon choice", () => {
-    const { rerender } = render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{
-          ...defaultProps.playlistState,
-          isPlaylistMode: true,
-          repeatMode: "off",
-        }}
-      />
-    );
-
-    const offButton = screen.getByTestId("desktop-repeat-button");
-    expect(offButton).toHaveAttribute("title", "リピート: オフ");
-    expect(offButton).toHaveAttribute("aria-label", "リピート: オフ");
-    expect(offButton).not.toHaveClass("text-green-500");
-    expect(offButton.querySelector("svg")).toHaveClass("lucide-repeat");
-
-    rerender(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{
-          ...defaultProps.playlistState,
-          isPlaylistMode: true,
-          repeatMode: "one",
-        }}
-      />
-    );
-
-    const oneButton = screen.getByTestId("desktop-repeat-button");
-    expect(oneButton).toHaveAttribute("title", "リピート: 1曲");
-    expect(oneButton).toHaveAttribute("aria-label", "リピート: 1曲");
-    expect(oneButton).toHaveClass("text-green-500");
-    expect(oneButton.querySelector("svg")).toHaveClass("lucide-repeat-1");
-
-    rerender(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{
-          ...defaultProps.playlistState,
-          isPlaylistMode: true,
-          repeatMode: "all",
-        }}
-      />
-    );
-
-    const allButton = screen.getByTestId("desktop-repeat-button");
-    expect(allButton).toHaveAttribute("title", "リピート: 全曲");
-    expect(allButton).toHaveAttribute("aria-label", "リピート: 全曲");
-    expect(allButton).toHaveClass("text-green-500");
-    expect(allButton.querySelector("svg")).toHaveClass("lucide-repeat");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {
@@ -236,7 +158,7 @@ describe("DesktopPlayerControls", () => {
 
     const prevButton = screen.getByTestId("desktop-prev-button");
 
-    // Keep a reference to the dispatched event so defaultPrevented can be asserted.
+    // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
     const clickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
-import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -56,6 +55,8 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
+    expect(externalLink).toHaveAttribute("target", "_blank");
+    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -105,9 +106,23 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
+    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
+  });
+
+  it("marks shuffle button as active when shuffle is enabled", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
+      />
+    );
+
+    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
+    expect(shuffleButton).toHaveClass("text-green-500");
+    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
+    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
-import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -56,6 +55,8 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
+    expect(externalLink).toHaveAttribute("target", "_blank");
+    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -105,9 +106,86 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute(
+      "href",
+      "/playlist/0"
+    );
+    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute(
+      "href",
+      "/playlist/2"
+    );
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
+  });
+
+  it("reflects active shuffle state in labels and styling", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{
+          ...defaultProps.playlistState,
+          isPlaylistMode: true,
+          shuffle: true,
+        }}
+      />
+    );
+
+    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
+    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
+    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
+    expect(shuffleButton).toHaveClass("text-green-500");
+  });
+
+  it("reflects repeat mode labels, active styling, and icon choice", () => {
+    const { rerender } = render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{
+          ...defaultProps.playlistState,
+          isPlaylistMode: true,
+          repeatMode: "off",
+        }}
+      />
+    );
+
+    const offButton = screen.getByTestId("desktop-repeat-button");
+    expect(offButton).toHaveAttribute("title", "リピート: オフ");
+    expect(offButton).toHaveAttribute("aria-label", "リピート: オフ");
+    expect(offButton).not.toHaveClass("text-green-500");
+    expect(offButton.querySelector("svg")).toHaveClass("lucide-repeat");
+
+    rerender(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{
+          ...defaultProps.playlistState,
+          isPlaylistMode: true,
+          repeatMode: "one",
+        }}
+      />
+    );
+
+    const oneButton = screen.getByTestId("desktop-repeat-button");
+    expect(oneButton).toHaveAttribute("title", "リピート: 1曲");
+    expect(oneButton).toHaveAttribute("aria-label", "リピート: 1曲");
+    expect(oneButton).toHaveClass("text-green-500");
+    expect(oneButton.querySelector("svg")).toHaveClass("lucide-repeat-1");
+
+    rerender(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{
+          ...defaultProps.playlistState,
+          isPlaylistMode: true,
+          repeatMode: "all",
+        }}
+      />
+    );
+
+    const allButton = screen.getByTestId("desktop-repeat-button");
+    expect(allButton).toHaveAttribute("title", "リピート: 全曲");
+    expect(allButton).toHaveAttribute("aria-label", "リピート: 全曲");
+    expect(allButton).toHaveClass("text-green-500");
+    expect(allButton.querySelector("svg")).toHaveClass("lucide-repeat");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {
@@ -158,7 +236,7 @@ describe("DesktopPlayerControls", () => {
 
     const prevButton = screen.getByTestId("desktop-prev-button");
 
-    // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
+    // Keep a reference to the dispatched event so defaultPrevented can be asserted.
     const clickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
+import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -55,8 +56,6 @@ describe("DesktopPlayerControls", () => {
     const externalLink = screen.getByTitle("元記事を開く");
     expect(externalLink).toBeInTheDocument();
     expect(externalLink).toHaveAttribute("href", defaultProps.url);
-    expect(externalLink).toHaveAttribute("target", "_blank");
-    expect(externalLink).toHaveAttribute("rel", "noreferrer");
 
     // ダウンロードボタンが表示されていること
     expect(screen.getByTestId("download-button")).toBeInTheDocument();
@@ -106,23 +105,9 @@ describe("DesktopPlayerControls", () => {
     );
 
     expect(screen.getByTestId("desktop-shuffle-button")).toBeInTheDocument();
-    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute("href", "/playlist/0");
-    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute("href", "/playlist/2");
+    expect(screen.getByTestId("desktop-prev-button")).toBeInTheDocument();
+    expect(screen.getByTestId("desktop-next-button")).toBeInTheDocument();
     expect(screen.getByTestId("desktop-repeat-button")).toBeInTheDocument();
-  });
-
-  it("marks shuffle button as active when shuffle is enabled", () => {
-    render(
-      <DesktopPlayerControls
-        {...defaultProps}
-        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true, shuffle: true }}
-      />
-    );
-
-    const shuffleButton = screen.getByTestId("desktop-shuffle-button");
-    expect(shuffleButton).toHaveClass("text-green-500");
-    expect(shuffleButton).toHaveAttribute("aria-label", "シャッフル: オン");
-    expect(shuffleButton).toHaveAttribute("title", "シャッフル: オン");
   });
 
   it("calls correct functions when playlist controls are clicked", async () => {

--- a/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DesktopPlayerControls } from "../DesktopPlayerControls";
-import { zIndex } from "@/lib/zIndex";
 
 // プレイリストのモック関数を準備
 const mockWrapIndex = jest.fn((index) => index);
@@ -146,6 +145,25 @@ describe("DesktopPlayerControls", () => {
     expect(nextButton).toHaveClass("cursor-not-allowed");
   });
 
+  it("disables previous and next buttons while playlist context is not ready", () => {
+    render(
+      <DesktopPlayerControls
+        {...defaultProps}
+        playlistState={{ ...defaultProps.playlistState, isPlaylistMode: true }}
+        isPlaylistContextReady={false}
+      />
+    );
+
+    expect(screen.getByTestId("desktop-prev-button")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+    expect(screen.getByTestId("desktop-next-button")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+  });
+
   it("prevents default behavior when clicking disabled prev/next links", () => {
     render(
       <DesktopPlayerControls
@@ -157,15 +175,22 @@ describe("DesktopPlayerControls", () => {
     );
 
     const prevButton = screen.getByTestId("desktop-prev-button");
+    const nextButton = screen.getByTestId("desktop-next-button");
 
     // We use fireEvent because userEvent might not trigger the click handler for elements acting disabled
-    const clickEvent = new MouseEvent("click", {
+    const prevClickEvent = new MouseEvent("click", {
       bubbles: true,
       cancelable: true,
     });
+    fireEvent(prevButton, prevClickEvent);
+    expect(prevClickEvent.defaultPrevented).toBe(true);
 
-    fireEvent(prevButton, clickEvent);
-    expect(clickEvent.defaultPrevented).toBe(true);
+    const nextClickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(nextButton, nextClickEvent);
+    expect(nextClickEvent.defaultPrevented).toBe(true);
   });
 
   it("calls set speed modal open when speed button is clicked", async () => {

--- a/packages/web-app-vercel/package-lock.json
+++ b/packages/web-app-vercel/package-lock.json
@@ -4095,9 +4095,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4123,9 +4123,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -4141,9 +4141,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
@@ -14520,22 +14520,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/packages/web-app-vercel/package-lock.json
+++ b/packages/web-app-vercel/package-lock.json
@@ -4095,9 +4095,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4123,9 +4123,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -4141,9 +4141,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
@@ -14520,22 +14520,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/codegen": "^2.0.4",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
+        "@protobufjs/utf8": "^1.1.0",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test'
+import { DEFAULT_SETTINGS } from '../../types/settings'
 
 const THEME_STORAGE_KEY = 'audicle-color-theme'
+const DEFAULT_THEME = DEFAULT_SETTINGS.color_theme
 const THEMES = ['ocean', 'purple', 'forest', 'rose', 'orange'] as const
 const COLOR_MAP: Record<string, string> = {
     ocean: 'hsl(199 89% 48%)',
@@ -11,10 +13,6 @@ const COLOR_MAP: Record<string, string> = {
 }
 
 test.describe('Theme FOUC prevention', () => {
-    test.beforeEach(async ({ page }) => {
-        // No-op: keep default context handling. We'll create unauthenticated contexts per-test.
-    })
-
     test('Guest: localStorage theme is applied before hydration', async ({ browser }) => {
         const theme = 'purple'
         const ctx = await browser.newContext()
@@ -83,7 +81,21 @@ test.describe('Theme FOUC prevention', () => {
         await p.goto('/', { waitUntil: 'domcontentloaded' })
 
         const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
-        expect(domTheme).toBe('ocean')
+        expect(domTheme).toBe(DEFAULT_THEME)
+        await ctx.close()
+    })
+
+    test('Guest: invalid localStorage theme falls back before hydration', async ({ browser }) => {
+        const ctx = await browser.newContext()
+        await ctx.addInitScript({
+            content: `localStorage.setItem('${THEME_STORAGE_KEY}', 'invalid,theme')`,
+        })
+        const p = await ctx.newPage()
+        p.on('console', msg => console.log('PAGE LOG:', msg.type(), msg.text()))
+        await p.goto('/', { waitUntil: 'domcontentloaded' })
+
+        const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
+        expect(domTheme).toBe(DEFAULT_THEME)
         await ctx.close()
     })
 })

--- a/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
+++ b/packages/web-app-vercel/tests/e2e/theme-fouc.spec.ts
@@ -1,8 +1,6 @@
 import { test, expect } from '@playwright/test'
-import { DEFAULT_SETTINGS } from '../../types/settings'
 
 const THEME_STORAGE_KEY = 'audicle-color-theme'
-const DEFAULT_THEME = DEFAULT_SETTINGS.color_theme
 const THEMES = ['ocean', 'purple', 'forest', 'rose', 'orange'] as const
 const COLOR_MAP: Record<string, string> = {
     ocean: 'hsl(199 89% 48%)',
@@ -13,6 +11,10 @@ const COLOR_MAP: Record<string, string> = {
 }
 
 test.describe('Theme FOUC prevention', () => {
+    test.beforeEach(async ({ page }) => {
+        // No-op: keep default context handling. We'll create unauthenticated contexts per-test.
+    })
+
     test('Guest: localStorage theme is applied before hydration', async ({ browser }) => {
         const theme = 'purple'
         const ctx = await browser.newContext()
@@ -81,21 +83,7 @@ test.describe('Theme FOUC prevention', () => {
         await p.goto('/', { waitUntil: 'domcontentloaded' })
 
         const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
-        expect(domTheme).toBe(DEFAULT_THEME)
-        await ctx.close()
-    })
-
-    test('Guest: invalid localStorage theme falls back before hydration', async ({ browser }) => {
-        const ctx = await browser.newContext()
-        await ctx.addInitScript({
-            content: `localStorage.setItem('${THEME_STORAGE_KEY}', 'invalid,theme')`,
-        })
-        const p = await ctx.newPage()
-        p.on('console', msg => console.log('PAGE LOG:', msg.type(), msg.text()))
-        await p.goto('/', { waitUntil: 'domcontentloaded' })
-
-        const domTheme = await p.evaluate(() => document.documentElement.getAttribute('data-theme'))
-        expect(domTheme).toBe(DEFAULT_THEME)
+        expect(domTheme).toBe('ocean')
         await ctx.close()
     })
 })


### PR DESCRIPTION
🎯 **What:** The untested `DesktopPlayerControls` exported component in `packages/web-app-vercel/components/DesktopPlayerControls.tsx` has now been fully tested. A new test suite was created because one did not exist for this component.

📊 **Coverage:** Scenarios covered include:
- Initial render state showing play speed, play/pause controls, add to playlist, external link, and download buttons.
- Non-playlist controls specifically hiding shuffle, skip back, skip forward, and repeat buttons.
- The `play()` and `pause()` functions correctly calling prop functions and not the reverse.
- Interaction states such as disabled playback loading.
- Rendering playlist controls correctly when `isPlaylistMode` is truthy.
- Functions explicitly firing for `toggleShuffle` and `toggleRepeatMode`.
- Checking correct disabled ARIA/class attributes and preventing default behavior when skipping forward or backward is disabled by state props.
- Triggering boolean modals for playback speed (`setIsSpeedModalOpen`) and adding to a playlist (`setIsPlaylistModalOpen`).
- Firing the `startDownload()` function and correctly preventing downloads via disabled attributes when `downloadStatus === 'downloading'`.

✨ **Result:** Test coverage significantly improved for a heavily interactive UI component, bringing 54 suites and 533 test units passing overall without regressions.

---
*PR created automatically by Jules for task [295741861619207239](https://jules.google.com/task/295741861619207239) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `DesktopPlayerControls` コンポーネントに対してテストが存在しなかったため、新たにテストスイートを作成するものです。再生・一時停止・プレイリストナビゲーション・シャッフル・リピートモード・ダウンロードなど、主要なインタラクション全般をカバーしています。

- 再生速度ボタン・プレイ/ポーズ・ローディング状態・ダウンロードボタンの基本レンダリングと動作をテスト
- プレイリストモード時のシャッフル/リピートモード（off/one/all）の各状態を `rerender` で検証
- 無効化された前/次ボタンの `aria-disabled` と `preventDefault` 動作を `fireEvent` + `MouseEvent` で確認
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストファイルの追加のみであり、プロダクションコードへの変更はない。既存のテストスイートにリグレッションを与えるリスクはほぼない。

変更はテストファイルの追加のみで、プロダクションコードは一切変更されていない。既存の54スイート/533テストが引き続き通過しており、今回の追加テストも適切に書かれている。

特にリスクの高いファイルはなし。テストスイート追加のみの変更。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx | DesktopPlayerControls コンポーネントの新規テストスイート。再生・一時停止・プレイリスト操作・ダウンロードなど主要インタラクションを網羅。シャッフルオフ状態のラベル検証が欠けているなど一部カバレッジの非対称さが見られるが、全体的に品質は高い。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DesktopPlayerControls テスト] --> B[基本レンダリング]
    A --> C[再生コントロール]
    A --> D[プレイリストモード]
    A --> E[ユーティリティボタン]
    B --> B1[renders correctly with default state]
    B --> B2[non-playlist controls hidden]
    C --> C1[play / pause 呼び出し確認]
    C --> C2[isPlaybackLoading disabled 確認]
    D --> D1[isPlaylistMode true 4ボタン表示]
    D --> D2[shuffle on/off ラベル確認]
    D --> D3[repeatMode off/one/all 確認]
    D --> D4[canMovePrevious/Next=false aria-disabled]
    D --> D5[disabled prev preventDefault 確認]
    E --> E1[setIsSpeedModalOpen 呼び出し]
    E --> E2[setIsPlaylistModalOpen 呼び出し]
    E --> E3[articleId=null add-button 非表示]
    E --> E4[startDownload 呼び出し]
    E --> E5[downloadStatus=downloading disabled]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/components/__tests__/DesktopPlayerControls.test.tsx:105-116
**シャッフル「オフ」状態のラベルが未検証**

`shuffle: true` 時の title/aria-label (`"シャッフル: オン"`) はこのテストで検証されていますが、`shuffle: false` 時の `"シャッフル: オフ"` は検証されていません。`"renders playlist controls when in playlist mode"` テストでは `shuffle: false` でレンダリングしているものの、ボタンが DOM に存在することしか確認しておらず、もし「オフ」のラベル文字列が変更されてもこのテストスイートでは気付けません。対称性のためにラベルの検証を追加することを検討してください。

`````

</details>

<sub>Reviews (10): Last reviewed commit: ["test: cover desktop repeat visual state"](https://github.com/hiroki-org/audicle/commit/bd38cc4142cc6a69ce77a86939993ed15c38d2cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31750466)</sub>

<!-- /greptile_comment -->