### PR TITLE
🧪 Add PeriodFilter unit tests

### DIFF
--- a/packages/web-app-vercel/components/PeriodFilter.tsx
+++ b/packages/web-app-vercel/components/PeriodFilter.tsx
@@ -5,7 +5,7 @@ import type { Period } from "@/types/stats";
 
 interface PeriodFilterProps {
   activePeriod: Period;
-  onPeriodChange: (period: Period) => void;
+  onPeriodChange: (_period: Period) => void;
 }
 
 const PERIOD_LABELS: Record<Period, string> = {
@@ -27,6 +27,7 @@ export function PeriodFilter({
         <Button
           key={period}
           onClick={() => onPeriodChange(period)}
+          aria-pressed={activePeriod === period}
           variant={activePeriod === period ? "default" : "outline"}
           size="sm"
           className={

--- a/packages/web-app-vercel/components/__tests__/PeriodFilter.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/PeriodFilter.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PeriodFilter } from "../PeriodFilter";
 
 describe("PeriodFilter", () => {
@@ -35,8 +36,8 @@ describe("PeriodFilter", () => {
     const weekButton = screen.getByRole("button", { name: "今週" });
 
     // 最初に today が active
-    expect(todayButton).toHaveClass("bg-primary");
-    expect(weekButton).not.toHaveClass("bg-primary");
+    expect(todayButton).toHaveAttribute("aria-pressed", "true");
+    expect(weekButton).toHaveAttribute("aria-pressed", "false");
 
     // week を active に変更
     rerender(
@@ -46,11 +47,13 @@ describe("PeriodFilter", () => {
       />
     );
 
-    expect(todayButton).not.toHaveClass("bg-primary");
-    expect(weekButton).toHaveClass("bg-primary");
+    expect(todayButton).toHaveAttribute("aria-pressed", "false");
+    expect(weekButton).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("calls onPeriodChange with the correct period when a button is clicked", () => {
+  it("calls onPeriodChange with the correct period when a button is clicked", async () => {
+    const user = userEvent.setup();
+
     render(
       <PeriodFilter
         activePeriod="today"
@@ -59,23 +62,23 @@ describe("PeriodFilter", () => {
     );
 
     // week ボタンをクリック
-    fireEvent.click(screen.getByRole("button", { name: "今週" }));
+    await user.click(screen.getByRole("button", { name: "今週" }));
     expect(mockOnPeriodChange).toHaveBeenCalledTimes(1);
-    expect(mockOnPeriodChange).toHaveBeenCalledWith("week");
+    expect(mockOnPeriodChange).toHaveBeenNthCalledWith(1, "week");
 
     // month ボタンをクリック
-    fireEvent.click(screen.getByRole("button", { name: "今月" }));
+    await user.click(screen.getByRole("button", { name: "今月" }));
     expect(mockOnPeriodChange).toHaveBeenCalledTimes(2);
-    expect(mockOnPeriodChange).toHaveBeenCalledWith("month");
+    expect(mockOnPeriodChange).toHaveBeenNthCalledWith(2, "month");
 
     // all ボタンをクリック
-    fireEvent.click(screen.getByRole("button", { name: "全期間" }));
+    await user.click(screen.getByRole("button", { name: "全期間" }));
     expect(mockOnPeriodChange).toHaveBeenCalledTimes(3);
-    expect(mockOnPeriodChange).toHaveBeenCalledWith("all");
+    expect(mockOnPeriodChange).toHaveBeenNthCalledWith(3, "all");
 
     // today ボタンをクリック
-    fireEvent.click(screen.getByRole("button", { name: "今日" }));
+    await user.click(screen.getByRole("button", { name: "今日" }));
     expect(mockOnPeriodChange).toHaveBeenCalledTimes(4);
-    expect(mockOnPeriodChange).toHaveBeenCalledWith("today");
+    expect(mockOnPeriodChange).toHaveBeenNthCalledWith(4, "today");
   });
 });

--- a/packages/web-app-vercel/components/__tests__/PeriodFilter.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/PeriodFilter.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PeriodFilter } from "../PeriodFilter";
+
+describe("PeriodFilter", () => {
+  const mockOnPeriodChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all period buttons correctly", () => {
+    render(
+      <PeriodFilter
+        activePeriod="today"
+        onPeriodChange={mockOnPeriodChange}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "今日" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "今週" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "今月" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "全期間" })).toBeInTheDocument();
+  });
+
+  it("applies active styling to the currently active period button", () => {
+    const { rerender } = render(
+      <PeriodFilter
+        activePeriod="today"
+        onPeriodChange={mockOnPeriodChange}
+      />
+    );
+
+    const todayButton = screen.getByRole("button", { name: "今日" });
+    const weekButton = screen.getByRole("button", { name: "今週" });
+
+    // 最初に today が active
+    expect(todayButton).toHaveClass("bg-primary");
+    expect(weekButton).not.toHaveClass("bg-primary");
+
+    // week を active に変更
+    rerender(
+      <PeriodFilter
+        activePeriod="week"
+        onPeriodChange={mockOnPeriodChange}
+      />
+    );
+
+    expect(todayButton).not.toHaveClass("bg-primary");
+    expect(weekButton).toHaveClass("bg-primary");
+  });
+
+  it("calls onPeriodChange with the correct period when a button is clicked", () => {
+    render(
+      <PeriodFilter
+        activePeriod="today"
+        onPeriodChange={mockOnPeriodChange}
+      />
+    );
+
+    // week ボタンをクリック
+    fireEvent.click(screen.getByRole("button", { name: "今週" }));
+    expect(mockOnPeriodChange).toHaveBeenCalledTimes(1);
+    expect(mockOnPeriodChange).toHaveBeenCalledWith("week");
+
+    // month ボタンをクリック
+    fireEvent.click(screen.getByRole("button", { name: "今月" }));
+    expect(mockOnPeriodChange).toHaveBeenCalledTimes(2);
+    expect(mockOnPeriodChange).toHaveBeenCalledWith("month");
+
+    // all ボタンをクリック
+    fireEvent.click(screen.getByRole("button", { name: "全期間" }));
+    expect(mockOnPeriodChange).toHaveBeenCalledTimes(3);
+    expect(mockOnPeriodChange).toHaveBeenCalledWith("all");
+
+    // today ボタンをクリック
+    fireEvent.click(screen.getByRole("button", { name: "今日" }));
+    expect(mockOnPeriodChange).toHaveBeenCalledTimes(4);
+    expect(mockOnPeriodChange).toHaveBeenCalledWith("today");
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit coverage for PeriodFilter rendering, active styling, and period change callbacks
- Replacement for #781, whose bot-managed branch repeatedly reintroduced unrelated main diffs

## Verification
- npm run test -- components/__tests__/PeriodFilter.test.tsx --coverage=false
- npm run lint -- components/__tests__/PeriodFilter.test.tsx

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PeriodFilter コンポーネントにユニットテストを追加し、各ボタンに `aria-pressed` アクセシビリティ属性を追加したPRです。過去のレビュー指摘（`userEvent` への統一・`toHaveBeenNthCalledWith` の使用・`aria-pressed` によるアクティブ状態検証）がすべて適切に対応されています。

- `PeriodFilter.tsx`: `aria-pressed={activePeriod === period}` を追加し、テストから独立した形でアクティブ状態をアクセシビリティ属性で表現。
- `PeriodFilter.test.tsx`: レンダリング確認・`aria-pressed` によるスタイル検証・`userEvent` + `toHaveBeenNthCalledWith` を使ったコールバック検証の3ケースを新規追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更（コンポーネント側はアクセシビリティ属性の追加のみ）でリグレッションリスクは非常に低い。

コンポーネント変更は aria-pressed の追加のみで既存の動作に影響しない。テストファイルは過去のレビュー指摘をすべて取り込み、userEvent・toHaveBeenNthCalledWith・aria-pressed 検証で適切に実装されている。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/PeriodFilter.tsx | aria-pressed 属性の追加とインターフェース型定義のパラメータ名変更（_period）のみ。機能的な変更なし。 |
| packages/web-app-vercel/components/__tests__/PeriodFilter.test.tsx | PeriodFilter の新規ユニットテストファイル。レンダリング・aria-pressed による active 状態・userEvent を使ったコールバック検証の3ケースをカバー。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test (userEvent)
    participant C as PeriodFilter
    participant B as Button (shadcn/ui)
    participant CB as onPeriodChange callback

    T->>C: "render(activePeriod="today")"
    C->>B: "aria-pressed={true} (today)"
    C->>B: "aria-pressed={false} (week/month/all)"

    T->>C: "rerender(activePeriod="week")"
    C->>B: "aria-pressed={false} (today)"
    C->>B: "aria-pressed={true} (week)"

    T->>B: user.click("今週")
    B->>C: onClick()
    C->>CB: onPeriodChange("week")
    CB-->>T: toHaveBeenNthCalledWith(1, "week") ✓
```

<sub>Reviews (3): Last reviewed commit: ["test: align PeriodFilter interactions wi..."](https://github.com/hiroki-org/audicle/commit/2e094e60a76c59c0d5466e35bdcd4ed44ee573ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32550340)</sub>

<!-- /greptile_comment -->