### PR TITLE
🧪 Add useUserSettings hook tests

### DIFF
--- a/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
@@ -207,54 +207,40 @@ describe("useUserSettings hook", () => {
       expect(result.current.error?.message).toBe("Network request failed");
     });
 
-    it("should invalidate user settings query with undefined email when session is missing", async () => {
+    it("should reject without network request when session is missing", async () => {
       (useSession as jest.Mock).mockReturnValue({
         data: null,
         status: "unauthenticated",
       });
-      const mockResponse = { success: true };
       const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
-
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      } as Response);
 
       const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
 
       result.current.mutate(mockSettings);
 
-      await waitFor(() => {
-        expect(result.current.isSuccess).toBe(true);
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-          queryKey: ["user-settings", undefined],
-        });
-      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("ログインが必要です");
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
     });
 
-    it("should invalidate user settings query with undefined email when user has no email", async () => {
+    it("should reject without network request when user has no email", async () => {
       (useSession as jest.Mock).mockReturnValue({
         data: { user: {} },
         status: "authenticated",
       });
-      const mockResponse = { success: true };
       const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
-
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      } as Response);
 
       const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
 
       result.current.mutate(mockSettings);
 
-      await waitFor(() => {
-        expect(result.current.isSuccess).toBe(true);
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-          queryKey: ["user-settings", undefined],
-        });
-      });
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("ログインが必要です");
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
+++ b/packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx
@@ -1,0 +1,260 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUserSettings, useUpdateUserSettingsMutation } from "../useUserSettings";
+import React from "react";
+import { useSession } from "next-auth/react";
+import type { UserSettings } from "@/types/settings";
+
+const originalFetch = global.fetch;
+
+// Mock next-auth/react
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+describe("useUserSettings hook", () => {
+  let queryClient: QueryClient;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
+  let wrapper: React.FC<{ children: React.ReactNode }>;
+  const mockSession = {
+    data: { user: { email: "test@example.com" } },
+    status: "authenticated",
+  };
+  const mockSettings: UserSettings = {
+    playback_speed: 1.5,
+    voice_model: "ja-JP-Standard-B",
+    language: "ja-JP",
+    color_theme: "purple",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (!global.fetch) {
+      Object.defineProperty(global, "fetch", {
+        configurable: true,
+        writable: true,
+        value: jest.fn(),
+      });
+    }
+    fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockRejectedValue(new Error("fetch mock not configured"));
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    (useSession as jest.Mock).mockReturnValue(mockSession);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (!originalFetch) {
+      delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  describe("useUserSettings", () => {
+    it("should fetch user settings successfully", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSettings,
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/get");
+      expect(result.current.data).toEqual(mockSettings);
+    });
+
+    it("should handle API error with specific message", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Specific error message" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Specific error message");
+    });
+
+    it("should handle API error with default message", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("設定の取得に失敗しました");
+    });
+
+    it("should not fetch if userEmail is missing", async () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: null,
+        status: "unauthenticated",
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("should not fetch if session user has no email", async () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: { user: {} },
+        status: "authenticated",
+      });
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("should surface network errors", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("Network request failed"));
+
+      const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Network request failed");
+    });
+  });
+
+  describe("useUpdateUserSettingsMutation", () => {
+    it("should update user settings successfully and invalidate queries", async () => {
+      const mockResponse = { success: true };
+
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ["user-settings", "test@example.com"],
+        });
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/settings/update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(mockSettings),
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+    });
+
+    it("should handle mutation API error with specific message", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Mutation specific error" }),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Mutation specific error");
+    });
+
+    it("should handle mutation API error with default message", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("設定の保存に失敗しました");
+    });
+
+    it("should surface mutation network errors", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("Network request failed"));
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error?.message).toBe("Network request failed");
+    });
+
+    it("should invalidate user settings query with undefined email when session is missing", async () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: null,
+        status: "unauthenticated",
+      });
+      const mockResponse = { success: true };
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ["user-settings", undefined],
+        });
+      });
+    });
+
+    it("should invalidate user settings query with undefined email when user has no email", async () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: { user: {} },
+        status: "authenticated",
+      });
+      const mockResponse = { success: true };
+      const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const { result } = renderHook(() => useUpdateUserSettingsMutation(), { wrapper });
+
+      result.current.mutate(mockSettings);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ["user-settings", undefined],
+        });
+      });
+    });
+  });
+});

--- a/packages/web-app-vercel/lib/hooks/useUserSettings.ts
+++ b/packages/web-app-vercel/lib/hooks/useUserSettings.ts
@@ -33,6 +33,10 @@ export function useUpdateUserSettingsMutation() {
 
     return useMutation({
         mutationFn: async (settings: UserSettings) => {
+            if (!userEmail) {
+                throw new Error("ログインが必要です");
+            }
+
             const response = await fetch("/api/settings/update", {
                 method: "PUT",
                 headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Adds unit coverage for useUserSettings and useUpdateUserSettingsMutation
- Covers success, API errors, network errors, missing session, and missing email invalidation behavior

## Validation
- npm run test:unit -- --coverage=false lib/hooks/__tests__/useUserSettings.test.tsx
- npm run test:unit -- --coverage=false
- npm run lint

Supersedes #784 because that Jules-managed source branch kept receiving unrelated automation rewrites after review fixes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `useUserSettings` と `useUpdateUserSettingsMutation` の単体テストを追加し、合わせてミューテーション実行前の未認証ガード（`!userEmail` による早期 `throw`）を実装側に追加しています。

- **テスト**: 成功・APIエラー（メッセージあり/デフォルト）・ネットワークエラー・未認証・メール欠落の全パターンをカバーし、`invalidateQueries` の呼び出しキーも検証している。
- **実装変更**: `mutationFn` の先頭に `!userEmail` ガードを追加し、未認証時にネットワークリクエストが発火しないよう修正した。`onSuccess` の `userEmail` クロージャーはミューテーション飛行中にセッションが変化すると古い値を参照する可能性があり、対応するパターンへの移行を検討することを推奨する。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト追加と小さな実装修正のみで、既存の動作に破壊的変更はない。安全にマージ可能。

変更はテストファイルの新規追加と `mutationFn` 先頭への早期 throw 追加の2点のみ。通常の使用では問題が発生しない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/lib/hooks/useUserSettings.ts | ミューテーション開始前に `!userEmail` チェックを追加。`onSuccess` が `userEmail` クロージャーを参照するためログアウト競合時にキャッシュ無効化がずれる可能性あり。 |
| packages/web-app-vercel/lib/hooks/__tests__/useUserSettings.test.tsx | 成功・APIエラー・ネットワークエラー・未認証・メール欠落の全シナリオをカバー。フックの主要動作を網羅的にテストしており問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component
    participant useUpdateUserSettingsMutation
    participant fetch
    participant QueryClient

    Component->>useUpdateUserSettingsMutation: mutate(settings)
    useUpdateUserSettingsMutation->>useUpdateUserSettingsMutation: !userEmail? throw ログインが必要です
    Note over useUpdateUserSettingsMutation: 認証済みの場合のみ続行
    useUpdateUserSettingsMutation->>fetch: PUT /api/settings/update
    fetch-->>useUpdateUserSettingsMutation: response
    alt response.ok
        useUpdateUserSettingsMutation->>QueryClient: invalidateQueries([user-settings, userEmail])
        Note over QueryClient: userEmail は onSuccess 呼出し時点のクロージャー値
        QueryClient-->>Component: "isSuccess=true"
    else not ok
        useUpdateUserSettingsMutation-->>Component: "isError=true"
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/lib/hooks/useUserSettings.ts:35-53
`onSuccess` コールバック内の `userEmail` はフックが最後にレンダリングされた時点のクロージャー値を参照します。ミューテーションが実行中にユーザーがログアウトしてセッションが変化すると、再レンダリング後の `userEmail` は `undefined` になるため、`invalidateQueries` が `["user-settings", undefined]` を対象として呼ばれ、元のキャッシュが無効化されません。`mutationFn` の戻り値にミューテーション開始時点のメールを含めて `onSuccess` に渡すパターンへの変更を検討してください。

```suggestion
        mutationFn: async (settings: UserSettings) => {
            if (!userEmail) {
                throw new Error("ログインが必要です");
            }

            const response = await fetch("/api/settings/update", {
                method: "PUT",
                headers: { "Content-Type": "application/json" },
                body: JSON.stringify(settings),
            });
            if (!response.ok) {
                const data = await response.json();
                throw new Error(data.error || "設定の保存に失敗しました");
            }
            const capturedEmail = userEmail;
            return { ...(await response.json()), _capturedEmail: capturedEmail };
        },
        onSuccess: (data) => {
            queryClient.invalidateQueries({ queryKey: ["user-settings", data._capturedEmail] });
        },
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix unauthenticated settings mutation gu..."](https://github.com/hiroki-org/audicle/commit/9497459e9f91451a8a93601e6778a10625c216a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32557106)</sub>

<!-- /greptile_comment -->