### PR TITLE
🧹 refactor: deduplicate Media Session position state update logic

### DIFF
--- a/packages/web-app-vercel/hooks/useMediaSession.ts
+++ b/packages/web-app-vercel/hooks/useMediaSession.ts
@@ -302,5 +302,6 @@ export function useMediaSession({
   return {
     updateMetadata,
     updatePlaybackState,
+    updatePositionState,
   };
 }

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -672,9 +672,6 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
     [chunks, playFromIndex]
   );
 
-
-
-
   // Media Session APIの設定（バックグラウンド再生対応）
   const { updatePositionState } = useMediaSession({
     title: articleTitle || "記事を読み上げ中",
@@ -711,7 +708,6 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
   useEffect(() => {
     updatePositionStateRef.current = updatePositionState;
   }, [updatePositionState]);
-
 
   // クリーンアップ
   useEffect(() => {

--- a/packages/web-app-vercel/hooks/usePlayback.ts
+++ b/packages/web-app-vercel/hooks/usePlayback.ts
@@ -59,7 +59,6 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
     }
     return DEFAULT_PLAYBACK_RATE;
   });
-
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const currentAudioUrlRef = useRef<string | null>(null);
   const onArticleEndRef = useRef<(() => void) | undefined>(onArticleEnd);
@@ -71,6 +70,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
   // このRefを通じて呼び出すことで、常に最新の `playFromIndex` を参照できるようにし、循環参照を回避します。
   const playFromIndexRef = useRef<(index: number) => Promise<void>>(async () => { });
   const positionStateCleanupRef = useRef<(() => void) | null>(null);
+  const updatePositionStateRef = useRef<() => void>(() => {});
 
   // 現在のチャンクID
   const currentChunkId =
@@ -189,43 +189,6 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
     currentAudioUrlRef.current = null;
   }, []);
 
-  const updateMediaSessionPositionState = useCallback(() => {
-    if (!("mediaSession" in navigator)) return;
-    const mediaSession = navigator.mediaSession;
-    const setPositionState = (mediaSession as unknown as {
-      setPositionState?: (state: {
-        duration: number;
-        position?: number;
-        playbackRate?: number;
-      }) => void;
-    }).setPositionState;
-
-    if (!setPositionState || typeof setPositionState !== "function") return;
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    const duration = audio.duration;
-    if (typeof duration !== "number" || !Number.isFinite(duration) || duration <= 0) {
-      return;
-    }
-    const position =
-      typeof audio.currentTime === "number" && Number.isFinite(audio.currentTime)
-        ? Math.min(Math.max(audio.currentTime, 0), duration)
-        : undefined;
-
-    const playbackRate =
-      typeof audio.playbackRate === "number" && Number.isFinite(audio.playbackRate)
-        ? audio.playbackRate
-        : undefined;
-
-    try {
-      setPositionState.call(mediaSession, { duration, position, playbackRate });
-    } catch (error) {
-      // Safari/PWA など実装差分があり得るため、握りつぶさずログだけ残す
-      logger.warn('Failed to set Media Session position state', error);
-    }
-  }, []);
-
   const installPositionStateUpdater = useCallback((audio: HTMLAudioElement) => {
     if (typeof (audio as any).addEventListener !== "function") {
       return;
@@ -233,7 +196,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
 
     positionStateCleanupRef.current?.();
 
-    const handler = () => updateMediaSessionPositionState();
+    const handler = () => updatePositionStateRef.current();
     audio.addEventListener("timeupdate", handler);
     audio.addEventListener("durationchange", handler);
     audio.addEventListener("ratechange", handler);
@@ -248,7 +211,7 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       audio.removeEventListener("ratechange", handler);
       audio.removeEventListener("loadedmetadata", handler);
     };
-  }, [updateMediaSessionPositionState]);
+  }, []);
 
   const seekToSeconds = useCallback((positionSeconds: number) => {
     const audio = audioRef.current;
@@ -260,8 +223,8 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
         ? Math.min(Math.max(positionSeconds, 0), duration)
         : Math.max(positionSeconds, 0);
     audio.currentTime = next;
-    updateMediaSessionPositionState();
-  }, [updateMediaSessionPositionState]);
+    updatePositionStateRef.current();
+  }, []);
 
   const seekBySeconds = useCallback((deltaSeconds: number) => {
     const audio = audioRef.current;
@@ -709,8 +672,11 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
     [chunks, playFromIndex]
   );
 
+
+
+
   // Media Session APIの設定（バックグラウンド再生対応）
-  useMediaSession({
+  const { updatePositionState } = useMediaSession({
     title: articleTitle || "記事を読み上げ中",
     artist: articleAuthor,
     isPlaying,
@@ -741,6 +707,11 @@ export function usePlayback({ chunks, articleUrl, voiceModel, playbackSpeed, onC
       };
     },
   });
+
+  useEffect(() => {
+    updatePositionStateRef.current = updatePositionState;
+  }, [updatePositionState]);
+
 
   // クリーンアップ
   useEffect(() => {


### PR DESCRIPTION
🎯 **What:**
- Exported `updatePositionState` from `useMediaSession.ts`
- Replaced the redundant manual `updateMediaSessionPositionState` implementation in `usePlayback.ts` with the exported function from `useMediaSession.ts`
- Used a ref to avoid circular dependency in `usePlayback.ts` callbacks.

💡 **Why:** 
Improves code maintainability and DRY principles by centralizing Media Session state update logic inside a single hook (`useMediaSession`), preventing potential inconsistencies between the two implementations.

✅ **Verification:** 
- `npm run test` passed successfully in `packages/web-app-vercel`
- `npm run lint` reported no related errors
- Tested circular dependencies to ensure React hooks do not throw runtime initialization errors.

✨ **Result:** 
Reduced complexity in `usePlayback.ts` and achieved better separation of concerns by delegating all media session API updates to `useMediaSession.ts`.

---
*PR created automatically by Jules for task [12579415481251700648](https://jules.google.com/task/12579415481251700648) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`useMediaSession` に `updatePositionState` を追加でエクスポートし、`usePlayback` 側の重複実装 `updateMediaSessionPositionState` を削除したリファクタリング PR です。循環依存を `updatePositionStateRef` 経由で回避するパターンは `playFromIndexRef` と同じ手法で一貫性があります。

- `useMediaSession.ts`: `updatePositionState` を return オブジェクトに追加し、外部から呼び出し可能に。ロジック自体に変更はなし。
- `usePlayback.ts`: `updateMediaSessionPositionState`（43行）を削除し、`updatePositionStateRef` を使った間接呼び出しに置き換え。`installPositionStateUpdater` と `seekToSeconds` の依存配列がシンプルになった。
- 新旧実装の振る舞いは実質的に同等。唯一の差異として新実装では `playbackRate > 0` チェックが追加されており、これは Media Session 仕様的に正しい改善。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は既存ロジックの重複排除のみで、新たなコードパスは導入されていない。安全にマージ可能。

`updatePositionStateRef` の初期値はマウント後の最初の `useEffect` 実行前は no-op だが、実際に呼ばれうるのはユーザー操作（再生・シーク）以降であり、マウント後のエフェクト実行より必ず後になる。新旧の `updatePositionState` 実装の振る舞いは実質同等で、`playbackRate > 0` チェックの追加は仕様適合性の改善。循環依存の回避も既存の `playFromIndexRef` パターンと整合的。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/hooks/useMediaSession.ts | `updatePositionState` を return に追加しただけのシンプルな変更。ロジック自体は変わっていない。 |
| packages/web-app-vercel/hooks/usePlayback.ts | `updateMediaSessionPositionState` を削除し、`useMediaSession` から取得した `updatePositionState` を Ref 経由で呼び出すよう変更。循環依存の回避も適切に実装されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー操作
    participant UP as usePlayback
    participant UMS as useMediaSession
    participant Audio as HTMLAudioElement
    participant MS as navigator.mediaSession

    Note over UP: マウント時
    UP->>UMS: "useMediaSession({ getPositionState, ... })"
    UMS-->>UP: "{ updatePositionState }"
    UP->>UP: "useEffect: updatePositionStateRef.current = updatePositionState"

    Note over User: ユーザーが再生ボタンを押す
    User->>UP: play()
    UP->>UP: playFromIndex(index)
    UP->>Audio: audio.play()
    UP->>UP: installPositionStateUpdater(audio)
    Audio->>UP: timeupdate / durationchange イベント
    UP->>UP: updatePositionStateRef.current()
    UP->>UMS: updatePositionState()
    UMS->>UMS: getPositionStateRef.current()
    UMS->>MS: "setPositionState({ duration, position, playbackRate })"

    Note over User: シーク操作
    User->>UP: seekToSeconds(pos)
    UP->>Audio: "audio.currentTime = pos"
    UP->>UP: updatePositionStateRef.current()
    UP->>UMS: updatePositionState()
    UMS->>MS: setPositionState(...)
```

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/hiroki-org/audicle/commit/bfcb8bd020224e4e4edc33bae21702c63a0b6202) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32759799)</sub>

<!-- /greptile_comment -->