### PR TITLE
🧪 Add error path test for share-target POST handler

### DIFF
--- a/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
@@ -246,6 +246,21 @@ describe('Share Target Route Handlers', () => {
             expect(mockGetOrCreateDefaultPlaylist).toHaveBeenCalledWith('test@example.com')
         })
 
+
+        it('formDataのパース中にエラーが発生した場合はエラーページにリダイレクト', async () => {
+            const request = new NextRequest('http://localhost:3000/share-target', {
+                method: 'POST',
+            })
+            // Mock formData to throw error
+            request.formData = jest.fn().mockRejectedValue(new Error('Mocked form data error'))
+
+            const response = await POST(request)
+
+            expect(response.status).toBe(307)
+            expect(response.headers.get('Location')).toContain('/share-target/error')
+            expect(response.headers.get('Location')).toContain(encodeURIComponent('リクエストの処理に失敗しました'))
+        })
+
         it('デフォルトプレイリスト取得失敗時はエラーページにリダイレクト', async () => {
             mockAuth.mockResolvedValue({
                 user: { id: 'test-user', email: 'test@example.com' },

--- a/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
@@ -251,14 +251,15 @@ describe('Share Target Route Handlers', () => {
             const request = new NextRequest('http://localhost:3000/share-target', {
                 method: 'POST',
             })
-            // Mock formData to throw error
-            request.formData = jest.fn().mockRejectedValue(new Error('Mocked form data error'))
+            // formData をエラーを投げるようにモック
+            jest.spyOn(request, 'formData').mockRejectedValue(new Error('Mocked form data error'))
 
             const response = await POST(request)
 
             expect(response.status).toBe(307)
             expect(response.headers.get('Location')).toContain('/share-target/error')
             expect(response.headers.get('Location')).toContain(encodeURIComponent('リクエストの処理に失敗しました'))
+            expect(mockAuth).not.toHaveBeenCalled()
         })
 
         it('デフォルトプレイリスト取得失敗時はエラーページにリダイレクト', async () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for error handling when `request.formData()` fails during POST requests to the share target route.
📊 **Coverage:** What scenarios are now tested: The catch block in `POST` handler of `share-target/route.ts` is fully covered, verifying that exceptions during form data parsing lead to a 307 redirect to the correct error page.
✨ **Result:** The improvement in test coverage: Increased confidence and line coverage for `packages/web-app-vercel/app/share-target/route.ts`.

---
*PR created automatically by Jules for task [5834043030633327877](https://jules.google.com/task/5834043030633327877) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `share-target/route.ts` の `POST` ハンドラーで `request.formData()` が失敗した際のエラーパスをカバーするテストを追加します。これにより、catch ブロックの行カバレッジが補完されます。

- `formData()` が例外を投げた際に 307 リダイレクトでエラーページへ遷移することを検証するテストを1件追加
- `auth()` が呼ばれないことを `expect(mockAuth).not.toHaveBeenCalled()` で明示的にアサートし、catch ブロックが正しい位置で例外を捉えていることを保証
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなくマージ安全。

追加されたテストは既存の本番コードの catch ブロックを正確に対象としており、アサーションも適切（ステータス 307、Location ヘッダーのエラーメッセージ、auth 未呼び出し）。テスト以外のファイルへの変更は一切なく、既存テストへの影響もない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/share-target/__tests__/route.test.ts | POSTハンドラーのcatchブロックをカバーする新しいエラーパステストを1件追加。アサーションは適切で、既存スタイルとも一致している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /share-target"] --> B["request.formData()"]
    B -->|"success"| C{"sharedUrl == null?"}
    B -->|"throws"| E["catch block (NEW TEST)"]
    C -->|"null"| D["307 redirect to /"]
    C -->|"exists"| F{"validateUrl"}
    F -->|"invalid"| G["307 redirect to /share-target/error"]
    F -->|"valid"| H["auth()"]
    H -->|"not logged in"| I["307 redirect to /auth/signin"]
    H -->|"logged in"| J["handleShareTarget"]
    J --> K["307 redirect to /share-target/success"]
    E --> L["307 redirect to /share-target/error"]
```

<sub>Reviews (2): Last reviewed commit: ["test: address share target form data rev..."](https://github.com/hiroki-org/audicle/commit/da1d8f0f1b1c2ae3ec9bda9b5b19d87664a100b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33869512)</sub>

<!-- /greptile_comment -->