### PR TITLE
🧹 [Code Health] Remove leftover console.log statements

### DIFF
--- a/packages/chrome-extension/background.js
+++ b/packages/chrome-extension/background.js
@@ -23,8 +23,6 @@ class RemoteAudioSynthesizer extends AudioSynthesizer {
   }
 
   async synthesize(text) {
-    console.log(`[${this.name}] Synthesizing: "${text}"`);
-    console.log(`[${this.name}] Server URL: ${this.serverUrl}`);
 
     try {
       const cleanedText = cleanText(text);


### PR DESCRIPTION
🎯 What: Removed leftover console.log statements in RemoteAudioSynthesizer.
💡 Why: Removes unnecessary noise in production logs, improving maintainability.
✅ Verification: Verified by checking git diff and running unit tests.
✨ Result: Cleaned up background.js without affecting functionality.

---
*PR created automatically by Jules for task [12558014801343350347](https://jules.google.com/task/12558014801343350347) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`RemoteAudioSynthesizer.synthesize()` 内の2つのデバッグ用 `console.log` を削除するコードクリーンアップPRです。変更自体は安全で機能への影響はありませんが、同じ目的で削除すべき `console.log` がファイル内に複数残っています。

- `RemoteAudioSynthesizer.synthesize()` の2行の `console.log`（合成テキストとサーバーURL）を削除
- `TestSynthesizer`（L86-88）、メッセージリスナーの `playbackStarted` / `playbackStopped` 処理（L335, L341）に同種の `console.log` が残存しており、クリーンアップが不完全
- `console.log` 削除後に意味のない空行が1行残っている（L26）
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能的な破壊変更はなく、マージしても動作に問題はありません。

`RemoteAudioSynthesizer` からの削除は正確ですが、同ファイル内の `TestSynthesizer`（L86-88）やメッセージリスナー（L335, L341）に同じ種類の `console.log` が残っており、PRの目的が完全には達成されていません。空行の残存も含め、コードヘルス改善としては不完全な状態です。

`packages/chrome-extension/background.js` — 残存する `console.log` の扱いを確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/chrome-extension/background.js | `RemoteAudioSynthesizer.synthesize()` から2つの `console.log` を削除。ただし `TestSynthesizer` (L86-88) とメッセージリスナー (L335, L341) に同種の `console.log` が残存しており、クリーンアップが不完全。削除後の空行も残っている。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Tab as Content Script
    participant BG as background.js (Message Listener)
    participant Factory as SynthesizerFactory
    participant Remote as RemoteAudioSynthesizer
    participant Server as Remote TTS Server

    Tab->>BG: "message { command: "play", text }"
    BG->>Factory: create(type, config)
    Factory-->>BG: synthesizer instance
    BG->>Remote: synthesize(text)
    Note over Remote: console.log 削除済み ✅
    Remote->>Server: "POST /synthesize/simple { text }"
    Server-->>Remote: audio blob
    Remote-->>BG: audioDataUrl
    BG->>Tab: "{ command: "playAudio", audioDataUrl }"
    Tab->>BG: "{ command: "playbackStarted" }"
    Note over BG: console.log 残存 ⚠️ (L335)
    BG->>BG: setActiveIcon()
    Tab->>BG: "{ command: "playbackStopped" }"
    Note over BG: console.log 残存 ⚠️ (L341)
    BG->>BG: setDefaultIcon()
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/chrome-extension/background.js`, line 335-341 ([link](https://github.com/hiroki-org/audicle/blob/381b6261ce81cca2913d84f03e884da11ad7a97a/packages/chrome-extension/background.js#L335-L341)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **メッセージリスナー内の `console.log` が未削除**

   このPRは「残存する `console.log` を削除する」目的ですが、メッセージリスナー内の2か所（`playbackStarted` / `playbackStopped` の処理）に `console.log` が残ったままです。これらは再生開始・停止のたびに実行される本番コードパスであり、`RemoteAudioSynthesizer` と同様に本番ログのノイズとなります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/chrome-extension/background.js
   Line: 335-341

   Comment:
   **メッセージリスナー内の `console.log` が未削除**

   このPRは「残存する `console.log` を削除する」目的ですが、メッセージリスナー内の2か所（`playbackStarted` / `playbackStopped` の処理）に `console.log` が残ったままです。これらは再生開始・停止のたびに実行される本番コードパスであり、`RemoteAudioSynthesizer` と同様に本番ログのノイズとなります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `packages/chrome-extension/background.js`, line 85-90 ([link](https://github.com/hiroki-org/audicle/blob/381b6261ce81cca2913d84f03e884da11ad7a97a/packages/chrome-extension/background.js#L85-L90)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`TestSynthesizer` の `console.log` も残存**

   PR の目的（本番ログのノイズ除去）と一貫させるなら、テスト用実装である `TestSynthesizer` の `console.log` も削除対象です。本番ビルドにこのクラスが含まれている場合、毎回の音声合成リクエストでログが出力されます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/chrome-extension/background.js
   Line: 85-90

   Comment:
   **`TestSynthesizer` の `console.log` も残存**

   PR の目的（本番ログのノイズ除去）と一貫させるなら、テスト用実装である `TestSynthesizer` の `console.log` も削除対象です。本番ビルドにこのクラスが含まれている場合、毎回の音声合成リクエストでログが出力されます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/chrome-extension/background.js:335-341
**メッセージリスナー内の `console.log` が未削除**

このPRは「残存する `console.log` を削除する」目的ですが、メッセージリスナー内の2か所（`playbackStarted` / `playbackStopped` の処理）に `console.log` が残ったままです。これらは再生開始・停止のたびに実行される本番コードパスであり、`RemoteAudioSynthesizer` と同様に本番ログのノイズとなります。

### Issue 2 of 3
packages/chrome-extension/background.js:85-90
**`TestSynthesizer` の `console.log` も残存**

PR の目的（本番ログのノイズ除去）と一貫させるなら、テスト用実装である `TestSynthesizer` の `console.log` も削除対象です。本番ビルドにこのクラスが含まれている場合、毎回の音声合成リクエストでログが出力されます。

```suggestion
  async synthesize(text) {
    const sampleUrl = chrome.runtime.getURL("sample.mp3");
```

### Issue 3 of 3
packages/chrome-extension/background.js:25-27
**削除後に空行が残存**

`console.log` 2行を削除した後、`async synthesize(text) {` の直後に意味のない空行が残っています。

```suggestion
  async synthesize(text) {
    try {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove leftover console.log statements f..."](https://github.com/hiroki-org/audicle/commit/381b6261ce81cca2913d84f03e884da11ad7a97a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35084789)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->