### PR TITLE
ci: use local Supabase fallback for PR checks

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,18 +16,25 @@ jobs:
     name: テストデータ投入
     runs-on: ubuntu-latest
     steps:
+      - name: Use local fallback
+        if: ${{ vars.CI_USE_REMOTE_SUPABASE != 'true' }}
+        run: echo "PR CI is using the in-memory Supabase fallback; remote test database seed is disabled."
       - name: Checkout code
+        if: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' }}
         uses: actions/checkout@v6.0.2
       - name: Setup Node.js
+        if: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: packages/web-app-vercel/package-lock.json
       - name: Install dependencies
+        if: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' }}
         run: npm ci
         working-directory: packages/web-app-vercel
       - name: Seed test database
+        if: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' }}
         run: npm run seed-test-data
         working-directory: packages/web-app-vercel
         env:
@@ -131,7 +138,7 @@ jobs:
 
   build:
     name: Build
-    needs: [setup, seed-test-db]
+    needs: setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -153,8 +160,8 @@ jobs:
         working-directory: packages/web-app-vercel
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXT_PUBLIC_AUTH_ENV: test
       - name: Upload build artifact
@@ -167,11 +174,11 @@ jobs:
 
   e2e-pr:
     name: E2E (PR-small)
-    needs: [setup, build, e2e-auth, seed-test-db]
+    needs: [setup, build, e2e-auth]
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
@@ -222,18 +229,18 @@ jobs:
           AUTH_ENV: test
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
 
   e2e-theme-fouc:
     name: E2E Theme FOUC
-    needs: [setup, build, seed-test-db]
+    needs: [setup, build]
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
     steps:
@@ -276,8 +283,8 @@ jobs:
           AUTH_ENV: test
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -289,8 +296,8 @@ jobs:
     needs: [setup, build]
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
     steps:
@@ -332,8 +339,8 @@ jobs:
           AUTH_ENV: test
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
       - name: Debug - Check auth files

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -174,7 +174,7 @@ jobs:
 
   e2e-pr:
     name: E2E (PR-small)
-    needs: [setup, build, e2e-auth]
+    needs: [setup, build, e2e-auth, seed-test-db]
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
@@ -238,7 +238,7 @@ jobs:
 
   e2e-theme-fouc:
     name: E2E Theme FOUC
-    needs: [setup, build]
+    needs: [setup, build, seed-test-db]
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_WEB_SERVER_COMMAND: "AUTH_ENV=test npm run start"
+  CI_WEB_SERVER_COMMAND: "AUTH_ENV=test NEXT_PUBLIC_AUTH_ENV=test npm run start"
 
 jobs:
   seed-test-db:
@@ -181,6 +181,7 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+      NEXT_PUBLIC_AUTH_ENV: test
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -227,6 +228,7 @@ jobs:
         working-directory: packages/web-app-vercel
         env:
           AUTH_ENV: test
+          NEXT_PUBLIC_AUTH_ENV: test
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
@@ -243,6 +245,7 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+      NEXT_PUBLIC_AUTH_ENV: test
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6
@@ -281,6 +284,7 @@ jobs:
         env:
           NODE_ENV: test
           AUTH_ENV: test
+          NEXT_PUBLIC_AUTH_ENV: test
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}
@@ -300,6 +304,7 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || '' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+      NEXT_PUBLIC_AUTH_ENV: test
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6
@@ -337,6 +342,7 @@ jobs:
         working-directory: packages/web-app-vercel
         env:
           AUTH_ENV: test
+          NEXT_PUBLIC_AUTH_ENV: test
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.CI_USE_REMOTE_SUPABASE == 'true' && secrets.NEXT_PUBLIC_SUPABASE_URL || '' }}

--- a/packages/web-app-vercel/app/api/playlists/[id]/items/route.ts
+++ b/packages/web-app-vercel/app/api/playlists/[id]/items/route.ts
@@ -4,6 +4,13 @@ import * as supabaseLocal from '@/lib/supabaseLocal'
 import { requireAuth } from '@/lib/api-auth'
 import { Article, PlaylistItem } from '@/types/playlist'
 
+type LocalPlaylist = Awaited<ReturnType<typeof supabaseLocal.getPlaylistsForOwner>>[number]
+
+async function findOwnedLocalPlaylist(id: string, userEmail: string): Promise<LocalPlaylist | null> {
+    const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
+    return playlists.find((candidate) => candidate.id === id) ?? null
+}
+
 export async function POST(
     request: Request,
     context: { params: Promise<{ id: string }> }
@@ -18,8 +25,7 @@ export async function POST(
         let playlistError: { message?: string } | null = null
 
         if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-            const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
-            const found = playlists.find((candidate) => candidate.id === id)
+            const found = await findOwnedLocalPlaylist(id, userEmail)
             if (found) {
                 playlist = { owner_email: found.owner_email }
             } else {
@@ -193,12 +199,12 @@ export async function GET(
         // プレイリストの所有権を確認
         let playlist: { owner_email: string } | null = null
         let playlistError: { message?: string } | null = null
+        let localPlaylist: LocalPlaylist | null = null
 
         if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-            const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
-            const found = playlists.find((candidate) => candidate.id === id)
-            if (found) {
-                playlist = { owner_email: found.owner_email }
+            localPlaylist = await findOwnedLocalPlaylist(id, userEmail)
+            if (localPlaylist) {
+                playlist = { owner_email: localPlaylist.owner_email }
             } else {
                 playlistError = { message: 'Playlist not found' }
             }
@@ -218,6 +224,13 @@ export async function GET(
 
         if (playlist.owner_email !== userEmail) {
             return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        }
+
+        if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+            const items = [...(localPlaylist?.items ?? [])].sort(
+                (a, b) => (a.position ?? 0) - (b.position ?? 0),
+            )
+            return NextResponse.json(items)
         }
 
         // プレイリストアイテム（関連する記事情報付き）を取得

--- a/packages/web-app-vercel/app/api/playlists/[id]/items/route.ts
+++ b/packages/web-app-vercel/app/api/playlists/[id]/items/route.ts
@@ -14,11 +14,26 @@ export async function POST(
         if (response) return response
 
         // プレイリストの所有権を確認
-        const { data: playlist, error: playlistError } = await supabase
-            .from('playlists')
-            .select('owner_email')
-            .eq('id', id)
-            .single()
+        let playlist: { owner_email: string } | null = null
+        let playlistError: { message?: string } | null = null
+
+        if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+            const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
+            const found = playlists.find((candidate) => candidate.id === id)
+            if (found) {
+                playlist = { owner_email: found.owner_email }
+            } else {
+                playlistError = { message: 'Playlist not found' }
+            }
+        } else {
+            const resp = await supabase
+                .from('playlists')
+                .select('owner_email')
+                .eq('id', id)
+                .single()
+            playlist = resp.data
+            playlistError = resp.error
+        }
 
         if (playlistError || !playlist) {
             return NextResponse.json({ error: 'Playlist not found' }, { status: 404 })
@@ -176,11 +191,26 @@ export async function GET(
         if (response) return response
 
         // プレイリストの所有権を確認
-        const { data: playlist, error: playlistError } = await supabase
-            .from('playlists')
-            .select('owner_email')
-            .eq('id', id)
-            .single()
+        let playlist: { owner_email: string } | null = null
+        let playlistError: { message?: string } | null = null
+
+        if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+            const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
+            const found = playlists.find((candidate) => candidate.id === id)
+            if (found) {
+                playlist = { owner_email: found.owner_email }
+            } else {
+                playlistError = { message: 'Playlist not found' }
+            }
+        } else {
+            const resp = await supabase
+                .from('playlists')
+                .select('owner_email')
+                .eq('id', id)
+                .single()
+            playlist = resp.data
+            playlistError = resp.error
+        }
 
         if (playlistError || !playlist) {
             return NextResponse.json({ error: 'Playlist not found' }, { status: 404 })

--- a/packages/web-app-vercel/app/api/playlists/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/playlists/__tests__/route.test.ts
@@ -180,4 +180,39 @@ describe('/api/playlists route', () => {
             article_id: data.article.id,
         })
     })
+
+    it('GET /items uses the local playlist fallback when Supabase is not configured', async () => {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL
+
+        const supabaseLocal = require('@/lib/supabaseLocal')
+        supabaseLocal.resetInMemorySupabase()
+        const playlist = await supabaseLocal.createPlaylist('test@example.com', 'Local Playlist')
+        const article = await supabaseLocal.upsertArticle(
+            'test@example.com',
+            'https://example.com/?id=banana',
+            'Banana',
+            null,
+            0,
+        )
+        const item = await supabaseLocal.addPlaylistItem(playlist.id, article.id)
+
+        const mockRequest = new Request(`http://localhost:3000/api/playlists/${playlist.id}/items`)
+        const itemsModule = require('../[id]/items/route')
+        const res = await itemsModule.GET(mockRequest, {
+            params: Promise.resolve({ id: playlist.id }),
+        })
+
+        expect(res.status).toBe(200)
+        const data = await res.json()
+        expect(data).toHaveLength(1)
+        expect(data[0]).toMatchObject({
+            id: item.id,
+            playlist_id: playlist.id,
+            article_id: article.id,
+            article: {
+                title: 'Banana',
+                url: 'https://example.com/?id=banana',
+            },
+        })
+    })
 })

--- a/packages/web-app-vercel/app/api/playlists/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/playlists/__tests__/route.test.ts
@@ -144,4 +144,40 @@ describe('/api/playlists route', () => {
         // because our supabase mock returns playlist_items in the parent route mock,
         // here we assume the items array is returned (mock stub may vary)
     })
+
+    it('POST /items uses the local playlist fallback when Supabase is not configured', async () => {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL
+
+        const supabaseLocal = require('@/lib/supabaseLocal')
+        supabaseLocal.resetInMemorySupabase()
+        const playlist = await supabaseLocal.createPlaylist('test@example.com', 'Local Playlist')
+
+        const mockRequest = new Request(`http://localhost:3000/api/playlists/${playlist.id}/items`, {
+            method: 'POST',
+            body: JSON.stringify({
+                article_url: 'https://example.com/?id=apple',
+                article_title: 'Apple',
+                thumbnail_url: null,
+                last_read_position: 0,
+            }),
+            headers: { 'Content-Type': 'application/json' },
+        })
+
+        const itemsModule = require('../[id]/items/route')
+        const res = await itemsModule.POST(mockRequest, {
+            params: Promise.resolve({ id: playlist.id }),
+        })
+
+        expect(res.status).toBe(200)
+        const data = await res.json()
+        expect(data.article).toMatchObject({
+            owner_email: 'test@example.com',
+            title: 'Apple',
+            url: 'https://example.com/?id=apple',
+        })
+        expect(data.item).toMatchObject({
+            playlist_id: playlist.id,
+            article_id: data.article.id,
+        })
+    })
 })

--- a/packages/web-app-vercel/app/page.tsx
+++ b/packages/web-app-vercel/app/page.tsx
@@ -26,6 +26,8 @@ import { STORAGE_KEYS } from "@/lib/constants";
 import type { PlaylistItemWithArticle } from "@/types/playlist";
 import { getArticlesCache } from "@/lib/local-cache";
 import { ArticleListSkeleton } from "@/components/ArticleListSkeleton";
+import { usePlaylistPlayback } from "@/contexts/PlaylistPlaybackContext";
+import { createReaderUrl } from "@/lib/urlBuilder";
 
 const ARTICLE_SORT_BY_OPTIONS = [
   "newest",
@@ -50,6 +52,7 @@ export default function Home() {
   const { data: fetchedPlaylistData, isLoading, error } = useDefaultPlaylistItems();
   const playlistData = fetchedPlaylistData || cachedPlaylist;
   const removeFromPlaylistMutation = useRemoveFromPlaylistMutation();
+  const { startPlaylistPlayback } = usePlaylistPlayback();
 
   const [sortBy, setSortBy] = useState<ArticleSortBy>(() => {
     if (typeof window === "undefined") return "newest";
@@ -137,11 +140,21 @@ export default function Home() {
 
   const handleArticleClick = useCallback(
     (item: PlaylistItemWithArticle) => {
-      if (item.article?.url) {
-        router.push(`/reader?url=${encodeURIComponent(item.article.url)}`);
+      const index = sortedItems.findIndex((sortedItem) => sortedItem.id === item.id);
+      const selectedItem = index >= 0 ? sortedItems[index] : item;
+
+      if (!selectedItem.article?.url) {
+        return;
       }
+
+      if (playlistId && playlistName && index >= 0) {
+        startPlaylistPlayback(playlistId, playlistName, sortedItems, index, sortBy);
+        return;
+      }
+
+      router.push(createReaderUrl({ articleUrl: selectedItem.article.url }));
     },
-    [router]
+    [playlistId, playlistName, router, sortBy, sortedItems, startPlaylistPlayback]
   );
 
   const handlePlaylistAdd = useCallback((id: string) => {
@@ -252,11 +265,21 @@ export default function Home() {
             </div>
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:gap-6 lg:gap-8">
-              {sortedItems.map((item) => (
+              {sortedItems.map((item, index) => (
                 <ArticleCard
                   key={item.id}
                   item={item}
                   onArticleClick={handleArticleClick}
+                  href={
+                    item.article?.url
+                      ? createReaderUrl({
+                        articleUrl: item.article.url,
+                        playlistId,
+                        playlistIndex: index,
+                        autoplay: false,
+                      })
+                      : undefined
+                  }
                   onPlaylistAdd={handlePlaylistAdd}
                   onRemove={handleRemoveFromHome}
                 />

--- a/packages/web-app-vercel/lib/__tests__/playlist-utils.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/playlist-utils.test.ts
@@ -53,8 +53,28 @@ describe('getOrCreateDefaultPlaylist', () => {
       const existingPlaylist = {
         id: '1',
         is_default: true,
-        playlist_items: [],
-        items: [],
+        playlist_items: [{
+          id: 'raw-item-1',
+          playlist_id: '1',
+          article_id: 'article-1',
+          position: 1,
+          added_at: new Date().toISOString(),
+        }],
+        items: [{
+          id: 'item-1',
+          playlist_id: '1',
+          article_id: 'article-1',
+          position: 1,
+          added_at: new Date().toISOString(),
+          article: {
+            id: 'article-1',
+            owner_email: userEmail,
+            url: 'https://example.com/?id=apple',
+            title: 'Apple',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        }],
         owner_email: userEmail,
         name: 'Default Playlist',
         description: 'Default playlist description',
@@ -71,6 +91,8 @@ describe('getOrCreateDefaultPlaylist', () => {
       expect(playlist).toBeDefined();
       expect(playlist?.id).toBe('1');
       expect(playlist?.is_default).toBe(true);
+      expect(playlist?.items).toHaveLength(1);
+      expect(playlist?.items[0].article?.title).toBe('Apple');
       expect(mockedSupabaseLocal.getPlaylistsForOwner).toHaveBeenCalledWith(userEmail);
       expect(mockedSupabaseLocal.createPlaylist).not.toHaveBeenCalled();
       expect(mockedSupabaseLocal.setDefaultPlaylist).not.toHaveBeenCalled();

--- a/packages/web-app-vercel/lib/__tests__/supabase.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/supabase.test.ts
@@ -1,0 +1,70 @@
+const createClientMock = jest.fn(() => ({ from: jest.fn() }));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: (...args: unknown[]) => createClientMock(...args),
+}));
+
+const ORIGINAL_ENV = process.env;
+
+describe('supabase client environment guard', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    createClientMock.mockClear();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PHASE;
+    delete process.env.AUTH_ENV;
+    delete process.env.NEXT_PUBLIC_AUTH_ENV;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('requires Supabase configuration in normal production runtime', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(() => jest.isolateModules(() => require('../supabase'))).toThrow(
+      'Missing required Supabase environment variables in production',
+    );
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it('allows production runtime without Supabase config when auth test mode is active', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_ENV = 'test';
+
+    jest.isolateModules(() => require('../supabase'));
+
+    expect(createClientMock).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'build-time-placeholder-anon-key',
+    );
+  });
+
+  it('allows production runtime without Supabase config when public auth test mode is active', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_AUTH_ENV = 'test';
+
+    jest.isolateModules(() => require('../supabase'));
+
+    expect(createClientMock).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'build-time-placeholder-anon-key',
+    );
+  });
+
+  it('uses configured Supabase credentials in production runtime', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example-project.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+    jest.isolateModules(() => require('../supabase'));
+
+    expect(createClientMock).toHaveBeenCalledWith(
+      'https://example-project.supabase.co',
+      'anon-key',
+    );
+  });
+});

--- a/packages/web-app-vercel/lib/__tests__/supabase.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/supabase.test.ts
@@ -4,13 +4,20 @@ jest.mock('@supabase/supabase-js', () => ({
   createClient: (...args: unknown[]) => createClientMock(...args),
 }));
 
-const ORIGINAL_ENV = process.env;
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
+}
 
 describe('supabase client environment guard', () => {
   beforeEach(() => {
     jest.resetModules();
     createClientMock.mockClear();
-    process.env = { ...ORIGINAL_ENV };
+    restoreEnv();
     delete process.env.NEXT_PHASE;
     delete process.env.AUTH_ENV;
     delete process.env.NEXT_PUBLIC_AUTH_ENV;
@@ -19,7 +26,7 @@ describe('supabase client environment guard', () => {
   });
 
   afterAll(() => {
-    process.env = ORIGINAL_ENV;
+    restoreEnv();
   });
 
   it('requires Supabase configuration in normal production runtime', () => {

--- a/packages/web-app-vercel/lib/__tests__/user-initialization.test.ts
+++ b/packages/web-app-vercel/lib/__tests__/user-initialization.test.ts
@@ -27,6 +27,10 @@ describe('initializeNewUser', () => {
     jest.resetAllMocks();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.AUTH_ENV;
+    delete process.env.NEXT_PUBLIC_AUTH_ENV;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   });
 
   afterEach(() => {
@@ -44,6 +48,27 @@ describe('initializeNewUser', () => {
 
     expect(result).toEqual({ success: true });
     expect(mockedSupabase.from).toHaveBeenCalledWith('user_settings');
+    expect(mockedGetOrCreateDefaultPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('should use local initialization in test auth runtime without Supabase config', async () => {
+    process.env.AUTH_ENV = 'test';
+    mockedGetOrCreateDefaultPlaylist.mockResolvedValue({ playlist: undefined });
+
+    const result = await initializeNewUser(userId, userEmail);
+
+    expect(result).toEqual({ success: true });
+    expect(mockedSupabase.from).not.toHaveBeenCalled();
+    expect(mockedGetOrCreateDefaultPlaylist).toHaveBeenCalledWith(userEmail);
+  });
+
+  it('should skip local playlist creation in test auth runtime when email is empty', async () => {
+    process.env.NEXT_PUBLIC_AUTH_ENV = 'test';
+
+    const result = await initializeNewUser(userId, '');
+
+    expect(result).toEqual({ success: true });
+    expect(mockedSupabase.from).not.toHaveBeenCalled();
     expect(mockedGetOrCreateDefaultPlaylist).not.toHaveBeenCalled();
   });
 

--- a/packages/web-app-vercel/lib/auth-env.ts
+++ b/packages/web-app-vercel/lib/auth-env.ts
@@ -1,0 +1,9 @@
+export function isTestAuthRuntime(): boolean {
+    return process.env.AUTH_ENV === 'test' || process.env.NEXT_PUBLIC_AUTH_ENV === 'test'
+}
+
+export function hasSupabaseRuntimeConfig(): boolean {
+    return Boolean(
+        process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    )
+}

--- a/packages/web-app-vercel/lib/playlist-utils.ts
+++ b/packages/web-app-vercel/lib/playlist-utils.ts
@@ -46,7 +46,12 @@ export async function getOrCreateDefaultPlaylist(userEmail: string): Promise<Def
         const playlists = await supabaseLocal.getPlaylistsForOwner(userEmail)
         const defaultPlaylist = playlists.find(p => p.is_default)
         if (defaultPlaylist) {
-            const { playlist_items: items = [], ...playlistData } = defaultPlaylist
+            const {
+                playlist_items: rawPlaylistItems = [],
+                items: playlistItems = rawPlaylistItems,
+                ...playlistData
+            } = defaultPlaylist
+            const items = playlistItems
             return { playlist: { ...playlistData, items, item_count: items.length } }
         }
         // create one

--- a/packages/web-app-vercel/lib/playlist-utils.ts
+++ b/packages/web-app-vercel/lib/playlist-utils.ts
@@ -47,11 +47,10 @@ export async function getOrCreateDefaultPlaylist(userEmail: string): Promise<Def
         const defaultPlaylist = playlists.find(p => p.is_default)
         if (defaultPlaylist) {
             const {
-                playlist_items: rawPlaylistItems = [],
-                items: playlistItems = rawPlaylistItems,
+                playlist_items = [],
+                items = playlist_items,
                 ...playlistData
             } = defaultPlaylist
-            const items = playlistItems
             return { playlist: { ...playlistData, items, item_count: items.length } }
         }
         // create one

--- a/packages/web-app-vercel/lib/supabase.ts
+++ b/packages/web-app-vercel/lib/supabase.ts
@@ -2,11 +2,13 @@ import { createClient } from '@supabase/supabase-js'
 
 const isProductionBuildPhase = process.env.NEXT_PHASE === 'phase-production-build'
 const isProductionRuntime = process.env.NODE_ENV === 'production' && !isProductionBuildPhase
+const isTestAuthRuntime =
+    process.env.AUTH_ENV === 'test' || process.env.NEXT_PUBLIC_AUTH_ENV === 'test'
 const hasSupabaseConfig = Boolean(
     process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
 )
 
-if (isProductionRuntime && !hasSupabaseConfig) {
+if (isProductionRuntime && !isTestAuthRuntime && !hasSupabaseConfig) {
     throw new Error('Missing required Supabase environment variables in production')
 }
 

--- a/packages/web-app-vercel/lib/supabase.ts
+++ b/packages/web-app-vercel/lib/supabase.ts
@@ -1,14 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
+import { hasSupabaseRuntimeConfig, isTestAuthRuntime } from './auth-env'
 
 const isProductionBuildPhase = process.env.NEXT_PHASE === 'phase-production-build'
 const isProductionRuntime = process.env.NODE_ENV === 'production' && !isProductionBuildPhase
-const isTestAuthRuntime =
-    process.env.AUTH_ENV === 'test' || process.env.NEXT_PUBLIC_AUTH_ENV === 'test'
-const hasSupabaseConfig = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-)
+const hasSupabaseConfig = hasSupabaseRuntimeConfig()
 
-if (isProductionRuntime && !isTestAuthRuntime && !hasSupabaseConfig) {
+if (isProductionRuntime && !isTestAuthRuntime() && !hasSupabaseConfig) {
     throw new Error('Missing required Supabase environment variables in production')
 }
 

--- a/packages/web-app-vercel/lib/user-initialization.ts
+++ b/packages/web-app-vercel/lib/user-initialization.ts
@@ -6,6 +6,16 @@ export interface UserInitializationResult {
     error?: string
 }
 
+function shouldUseLocalUserInitialization(): boolean {
+    const isTestAuthRuntime =
+        process.env.AUTH_ENV === 'test' || process.env.NEXT_PUBLIC_AUTH_ENV === 'test'
+    const hasSupabaseConfig = Boolean(
+        process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    )
+
+    return isTestAuthRuntime && !hasSupabaseConfig
+}
+
 /**
  * 新規ユーザー登録時の初期化処理
  * - user_settings を作成（既に存在する場合はスキップする）
@@ -17,6 +27,17 @@ export interface UserInitializationResult {
  */
 export async function initializeNewUser(userId: string, userEmail: string): Promise<UserInitializationResult> {
     try {
+        if (shouldUseLocalUserInitialization()) {
+            if (userEmail) {
+                const playlistResult = await getOrCreateDefaultPlaylist(userEmail);
+                if (playlistResult.error) {
+                    console.error('Failed to create default playlist:', playlistResult.error);
+                }
+            }
+
+            return { success: true }
+        }
+
         // user_settings が既に存在するか確認
         const { data: existingSettings, error: checkError } = await supabase
             .from('user_settings')

--- a/packages/web-app-vercel/lib/user-initialization.ts
+++ b/packages/web-app-vercel/lib/user-initialization.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase'
 import { getOrCreateDefaultPlaylist } from './playlist-utils'
+import { hasSupabaseRuntimeConfig, isTestAuthRuntime } from './auth-env'
 
 export interface UserInitializationResult {
     success: boolean
@@ -7,13 +8,7 @@ export interface UserInitializationResult {
 }
 
 function shouldUseLocalUserInitialization(): boolean {
-    const isTestAuthRuntime =
-        process.env.AUTH_ENV === 'test' || process.env.NEXT_PUBLIC_AUTH_ENV === 'test'
-    const hasSupabaseConfig = Boolean(
-        process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    )
-
-    return isTestAuthRuntime && !hasSupabaseConfig
+    return isTestAuthRuntime() && !hasSupabaseRuntimeConfig()
 }
 
 /**

--- a/packages/web-app-vercel/playwright.config.ts
+++ b/packages/web-app-vercel/playwright.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
             NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || '',
             NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'http://localhost:3000',
             AUTH_ENV: process.env.AUTH_ENV || '',
+            NEXT_PUBLIC_AUTH_ENV: process.env.NEXT_PUBLIC_AUTH_ENV || (process.env.AUTH_ENV === 'test' ? 'test' : ''),
             // Ensure TEST_USER_EMAIL has a fallback to match auth.setup.ts and lib/auth.ts
             TEST_USER_EMAIL: process.env.TEST_USER_EMAIL || 'test@example.com',
             TEST_USER_PASSWORD: process.env.TEST_USER_PASSWORD || 'password',


### PR DESCRIPTION
## Summary
- make the PR seed job use the in-memory Supabase fallback unless CI_USE_REMOTE_SUPABASE=true
- stop PR build/e2e jobs from inheriting broken remote Supabase secrets by default
- allow AUTH_ENV=test production runtime to use placeholder Supabase config and cover the guard with unit tests

## Verification
- npm run lint (passes with existing warnings)
- npm run test:unit -- lib/__tests__/supabase.test.ts
- TZ=UTC npm run test:integration
- npm run build
- CI_WEB_SERVER_COMMAND="AUTH_ENV=test npm run start" AUTH_ENV=test NEXTAUTH_SECRET=test-secret NEXTAUTH_URL=http://localhost:3000 npm run test:e2e -- tests/e2e/theme-fouc.spec.ts --project=theme-fouc

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはPR CIをローカルのインメモリSupabase実装にデフォルトで切り替え、`CI_USE_REMOTE_SUPABASE=true` を明示的に設定した場合のみリモートSupabaseを使用するよう変更します。あわせて `AUTH_ENV=test` 本番ランタイムで Supabase 設定なしでも動作できるガード条件の拡張と、`GET /api/playlists/[id]/items` のローカルフォールバック対応が含まれます。

- **CI ワークフロー**: `build`・各E2Eジョブのsupabase secretsを `CI_USE_REMOTE_SUPABASE == 'true'` の場合のみ注入するよう変更し、`seed-test-db` ジョブも同フラグでスキップするよう条件分岐を追加
- **lib/supabase.ts**: `isTestAuthRuntime()` 条件を追加して `AUTH_ENV=test` 本番ランタイムでのプレースホルダー使用を許可し、対応するユニットテストを追加
- **lib/playlist-utils.ts・route.ts**: ローカルフォールバック時に `items`（記事データ付き）を正しく取得できるよう destructuring ロジックおよびGETハンドラーのインメモリパスを修正
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

ローカルインメモリフォールバックへの切り替えとテスト認証ランタイムのガード拡張は正しく実装されており、リモートモード時のE2EジョブもseedTestdb依存を保持しているためマージして安全です。

CIフォールバックのロジック・ガード条件・ローカルフォールバックのGETハンドラー修正・playlist-utilsのdestructuring修正はすべて正しく動作しており、ユニットテスト・統合テスト・E2Eテストでカバーされています。page.tsxの機能変更が混在していますが、著者が動作確認済みである旨を記載しています。

.github/workflows/ci-pr.yml の CI_USE_REMOTE_SUPABASE=true パスはCI環境変数の設定次第で実際に動作するため、リモートモードへの切り替え時には再検証を推奨します。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci-pr.yml | `CI_USE_REMOTE_SUPABASE` フラグによる条件分岐を全ジョブに追加。E2Eジョブは引き続き `seed-test-db` を `needs` に保持しており、リモートモード時の競合状態は回避されている。 |
| packages/web-app-vercel/lib/supabase.ts | `isTestAuthRuntime()` ガードを追加してAUTH_ENV=test本番ランタイムでの例外送出を抑制。行12のコメントは実態と乖離しており要更新（前スレッドで既指摘）。 |
| packages/web-app-vercel/lib/auth-env.ts | 新規ファイル。`isTestAuthRuntime()` と `hasSupabaseRuntimeConfig()` を分離した純粋なヘルパー関数。複数箇所で再利用されており適切な抽象化。 |
| packages/web-app-vercel/app/api/playlists/[id]/items/route.ts | GETハンドラーにローカルフォールバックを追加（前スレッドで指摘されていた未対応箇所を解消）。`findOwnedLocalPlaylist` ヘルパーを共通化しPOST・GETで再利用。 |
| packages/web-app-vercel/lib/playlist-utils.ts | destructuring を `{ playlist_items = [], items = playlist_items, ... }` に変更し、記事データ付きの `items` を優先的に使用するよう修正。対応するテストも更新済み。 |
| packages/web-app-vercel/app/page.tsx | プレイリスト再生コンテキストの統合と `ArticleCard` への `href` prop 追加が含まれる。CIフォールバック対応の範囲を超えた機能追加だが、E2Eテスト確認済みとのこと。 |
| packages/web-app-vercel/lib/__tests__/supabase.test.ts | 新規テストファイル。通常本番・AUTH_ENV=test・設定済み認証情報の3ケースをカバー。`jest.isolateModules` でモジュールレベルの副作用を適切にリセット。 |
| packages/web-app-vercel/lib/__tests__/user-initialization.test.ts | テスト認証ランタイム時のローカル初期化パスおよびメール空文字時のスキップ動作を追加テスト。`beforeEach` で環境変数をクリーンアップするよう改善。 |
| packages/web-app-vercel/app/api/playlists/__tests__/route.test.ts | POST/GETそれぞれのローカルフォールバック動作を網羅する統合テストを追加。`resetInMemorySupabase` でテスト間の状態分離も適切。 |
| packages/web-app-vercel/lib/__tests__/playlist-utils.test.ts | フィクスチャに `playlist_items`（生データ）と `items`（記事データ付き）の両フィールドを追加し、記事データが正しく返されることをアサートするよう更新。 |
| packages/web-app-vercel/playwright.config.ts | `NEXT_PUBLIC_AUTH_ENV` を `AUTH_ENV=test` から自動導出するフォールバック追加。webサーバーへの環境変数伝播を確実にする。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[モジュールロード: supabase.ts] --> B{isProductionRuntime?}
    B -- No --> E[プレースホルダー使用]
    B -- Yes --> C{isTestAuthRuntime?\nAUTH_ENV=test or\nNEXT_PUBLIC_AUTH_ENV=test}
    C -- Yes --> E
    C -- No --> D{hasSupabaseRuntimeConfig?\nURL and ANON_KEY 設定済み}
    D -- No --> F[throw Error:\nMissing Supabase env vars]
    D -- Yes --> G[実際のSupabase認証情報を使用]
    E --> H{ルートハンドラー呼び出し}
    G --> H
    H --> I{NEXT_PUBLIC_SUPABASE_URL 設定済み?}
    I -- No --> J[supabaseLocalフォールバック\nインメモリDB]
    I -- Yes --> K[リアルSupabaseクライアント]
    subgraph CI判定
        L{CI_USE_REMOTE_SUPABASE == true?}
        L -- No --> M[secrets注入スキップ\n→ NEXT_PUBLIC_SUPABASE_URL = 空文字]
        L -- Yes --> N[secrets注入\n→ リモートSupabase使用]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/web-app-vercel/lib/supabase.ts`, line 15 ([link](https://github.com/hiroki-org/audicle/blob/cd7d51060e89edef5b23d580f8e95667cf1a7e23/packages/web-app-vercel/lib/supabase.ts#L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `AUTH_ENV=test` が有効な場合も本プレースホルダーは実行時に使用されるようになったため、コメントが実態と合っていません。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/supabase.ts
   Line: 15

   Comment:
   `AUTH_ENV=test` が有効な場合も本プレースホルダーは実行時に使用されるようになったため、コメントが実態と合っていません。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `packages/web-app-vercel/lib/supabase.ts`, line 15 ([link](https://github.com/hiroki-org/audicle/blob/cd7d51060e89edef5b23d580f8e95667cf1a7e23/packages/web-app-vercel/lib/supabase.ts#L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> コメント「only reachable during build/test/local development paths」が不正確になりました。`isTestAuthRuntime` の追加により、`AUTH_ENV=test` を設定した本番ランタイムでもプレースホルダーが使われるようになったため、コメントを更新しておくと意図が明確になります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/lib/supabase.ts
   Line: 15

   Comment:
   コメント「only reachable during build/test/local development paths」が不正確になりました。`isTestAuthRuntime` の追加により、`AUTH_ENV=test` を設定した本番ランタイムでもプレースホルダーが使われるようになったため、コメントを更新しておくと意図が明確になります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `packages/web-app-vercel/app/api/playlists/[id]/items/route.ts`, line 224-235 ([link](https://github.com/hiroki-org/audicle/blob/b3f4e7a663b96c001e2ed263d314f970c6b325c1/packages/web-app-vercel/app/api/playlists/[id]/items/route.ts#L224-L235)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **GET ハンドラーのアイテム取得がローカルフォールバックに対応していない**

   `POST` ではプレイリストのオーナー確認・記事の upsert・アイテム追加のすべてに `if (!process.env.NEXT_PUBLIC_SUPABASE_URL)` 分岐が追加されていますが、`GET` はオーナー確認のみ分岐しており、その後のアイテム取得（`supabase.from('playlist_items')...`）は常にリアル Supabase クライアントを使用します。CI のデフォルト（`NEXT_PUBLIC_SUPABASE_URL` 未設定）では、プレースホルダー URL へのリクエストとなり、実際のアイテムが返らず `GET /api/playlists/[id]/items` が正常に機能しません。`supabaseLocal.getPlaylistsForOwner` で取得したプレイリストのアイテムを返すブランチを追加する必要があります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/app/api/playlists/[id]/items/route.ts
   Line: 224-235

   Comment:
   **GET ハンドラーのアイテム取得がローカルフォールバックに対応していない**

   `POST` ではプレイリストのオーナー確認・記事の upsert・アイテム追加のすべてに `if (!process.env.NEXT_PUBLIC_SUPABASE_URL)` 分岐が追加されていますが、`GET` はオーナー確認のみ分岐しており、その後のアイテム取得（`supabase.from('playlist_items')...`）は常にリアル Supabase クライアントを使用します。CI のデフォルト（`NEXT_PUBLIC_SUPABASE_URL` 未設定）では、プレースホルダー URL へのリクエストとなり、実際のアイテムが返らず `GET /api/playlists/[id]/items` が正常に機能しません。`supabaseLocal.getPlaylistsForOwner` で取得したプレイリストのアイテムを返すブランチを追加する必要があります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/app/page.tsx:140-160
**PRスコープ外の機能追加**

`handleArticleClick` の `startPlaylistPlayback` 統合と `ArticleCard` への `href` 追加は CI Supabase フォールバックとは直接関係のない機能変更です。`ArticleCard` がどのように `href` と `onArticleClick` を同時に受け取る場合の挙動（例: デフォルトのリンクナビゲーション vs `startPlaylistPlayback` の両方が起動しないか）は、`ArticleCard` 実装の確認が必要です。単一PRに機能追加とCIインフラ変更が混在すると差分のレビューが難しくなるため、可能であれば別PRとして分離することを検討してください。


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: return local playlist items in PR f..."](https://github.com/hiroki-org/audicle/commit/414724ce04f0cf1dfe81f148611e2c493f29fe43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35573189)</sub>

<!-- /greptile_comment -->