### PR TITLE
🧹 [code health improvement] Fix typing and unused variable issue in storage.ts

### DIFF
--- a/packages/web-app/lib/storage.ts
+++ b/packages/web-app/lib/storage.ts
@@ -100,10 +100,11 @@ export const articleStorage = {
   // 記事を追加
   add: (article: Omit<Article, "id" | "createdAt"> & { chunks: Chunk[] }): Article => {
     // createdAtが渡されても無視するように除外
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { chunks, ...temp } = article as any;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { createdAt, ...rest } = temp;
+    const { chunks, ...temp } = article;
+    const rest = { ...temp };
+    if ('createdAt' in rest) {
+        delete (rest as typeof rest & { createdAt?: number }).createdAt;
+    }
 
     const newArticle: Article = {
       ...rest,


### PR DESCRIPTION
🎯 **What:** Removed eslint overrides by destructuring correctly without using explicit 'any' type casting in packages/web-app/lib/storage.ts.
💡 **Why:** Reduces reliance on `any` and eslint overrides, improving type safety and readability.
✅ **Verification:** Verified by passing local `npm run lint` and `npm run test` suites.
✨ **Result:** Cleaned up TypeScript usage in the file and resolved potential future typing errors.

---
*PR created automatically by Jules for task [15719516711688018493](https://jules.google.com/task/15719516711688018493) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PR #868 reviews `packages/web-app/lib/storage.ts` to remove `as any` casts and eslint-disable comments from the `add` function, replacing them with a runtime `in` check and `delete`. The change is functionally correct but introduces a redundant object copy (`const rest = { ...temp }`) since `temp` is already a new object from the rest spread.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

動作として正しく、`as any` の除去という目的は達成されているためマージ自体は安全。

`createdAt` を除外するロジックは実行時・型システムの両面で意図どおり機能しており、既存の動作を壊すリスクはない。中間オブジェクト `temp` をさらにスプレッドする冗長なコピーが残っているが、機能上の問題は生じない。

packages/web-app/lib/storage.ts の `add` 関数内、103〜107行目のスプレッド処理を確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app/lib/storage.ts | `add` 関数内の `as any` と eslint-disable コメントを削除し、実行時チェックと型キャストによる `delete` に置き換え。動作は正しいが `const rest = { ...temp }` の不要なオブジェクトコピーが残っている。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app/lib/storage.ts:103-107
**シンプルな代替実装**

`createdAt` はパラメータ型 `Omit<Article, "id" | "createdAt">` で既に除外されているため、最初のデストラクチャリングで `rest` と命名することで中間変数 `temp` と `const rest = { ...temp }` の余分なコピーを省けます。

```suggestion
    const { chunks, ...rest } = article;
    if ('createdAt' in rest) {
        delete (rest as typeof rest & { createdAt?: number }).createdAt;
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 \[code health improvement\] Fix typing ..."](https://github.com/hiroki-org/audicle/commit/537d595b661417ff90b025c3868120be67bf6817) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36381734)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->