### PR TITLE
🧹 [Code Health] Remove explicit any type in playlists route

### DIFF
--- a/packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts
+++ b/packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { requireAuth } from '@/lib/api-auth'
-import type { Playlist } from '@/types/playlist'
+import type { Playlist, PlaylistWithItems } from '@/types/playlist'
 import { resolveArticleId } from '@/lib/api-helpers'
 
 export async function GET(
@@ -41,7 +41,7 @@ export async function GET(
         }
 
         // Remove the nested playlist_items array before returning
-        const formattedPlaylists = playlists ? (playlists as any[]).map(p => {
+        const formattedPlaylists = playlists ? (playlists as PlaylistWithItems[]).map(p => {
             const { playlist_items, ...rest } = p;
             return rest;
         }) : []


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the explicit `any` array casting (`playlists as any[]`) in `packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts` and replaced it with the strongly typed `PlaylistWithItems[]`.

💡 **Why:** How this improves maintainability
Using explicit `any` bypasses TypeScript's type checker, which can lead to runtime errors when properties are misspelled or change. Replacing it with the specific `PlaylistWithItems` type ensures that the `playlist_items` property being destructured actually exists on the object, improving code safety and developer tooling support.

✅ **Verification:** How you confirmed the change is safe
Ran lint checks (`npm run lint`), unit tests (`npm run test:unit`), integration tests (`npm run test:integration`), and type checking (`npx tsc --noEmit`) to verify that the change resolves type warnings and does not break existing logic.

✨ **Result:** The improvement achieved
TypeScript now fully checks the mapping logic, preventing potential regressions if the Supabase return type or `PlaylistWithItems` interface changes in the future, while maintaining identical runtime behavior.

---
*PR created automatically by Jules for task [12519753800197928542](https://jules.google.com/task/12519753800197928542) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts` 内の `as any[]` キャストを `as PlaylistWithItems[]` に置き換えることで、TypeScriptの型チェックを有効化しコードの堅牢性を改善するものです。

- `(playlists as any[])` を `(playlists as PlaylistWithItems[])` に変更し、デストラクチャリングで `playlist_items` プロパティにアクセスする箇所が型安全になった。
- `PlaylistWithItems` 型をインポートに追加しており、型定義との整合性が保たれている。ただし Supabase のクエリが `article_id` のみを選択しているため、`playlist_items` フィールドの実際の形状と型定義の間に軽微な乖離が残っている。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は限定的で、`any[]` から具体的な型へのキャスト置き換えのみ。ロジックへの影響はなくマージ自体は安全。

Supabaseが返す `playlist_items` の実際の形状（`article_id` のみ）が `PlaylistWithItems.playlist_items` の型定義（`PlaylistItemWithArticle[]`）と厳密には一致していないため、キャストの正確さに軽微な乖離が残る。ただし `playlist_items` はすぐにデストラクチャリングで破棄されるため、現時点でランタイムへの影響はない。

特に注意が必要なファイルはない。`types/playlist.ts` の `PlaylistWithItems` インターフェースの `playlist_items` フィールド型を実際のクエリ結果に合わせて精緻化できる余地がある。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts | `any[]` キャストを `PlaylistWithItems[]` に置き換え。型安全性は向上しているが、`playlist_items` フィールドの型がSupabaseの実際の返却値（`article_id` のみ）と厳密には一致していない点が残っている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route as GET /api/articles/[id]/playlists
    participant Auth as requireAuth()
    participant Supabase

    Client->>Route: GET リクエスト
    Route->>Auth: 認証チェック
    Auth-->>Route: userEmail
    Route->>Supabase: "playlists テーブルをクエリ (*, playlist_items!inner(article_id))"
    Supabase-->>Route: playlists (PlaylistWithItems[]) ※ as キャスト
    Route->>Route: playlist_items を destructuring で除外 → Playlist[] に整形
    Route-->>Client: JSON レスポンス (Playlist[])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/app/api/articles/[id]/playlists/route.ts:44-46
**`PlaylistWithItems` の型定義とSupabaseの実際の返却値の不一致**

Supabaseのクエリは `.select('*, playlist_items!inner(article_id)')` で `article_id` のみを取得しているため、実際に返ってくる `playlist_items` は `{ article_id: string }[]` 相当です。一方、`PlaylistWithItems.playlist_items` の型は `PlaylistItemWithArticle[]` と定義されており、`id`・`playlist_id`・`position`・`added_at` などを含む完全なフィールドセットを期待しています。`playlist_items` はこの後すぐ破棄されるため今は問題になりませんが、キャストの型が実データの形状と乖離しており、将来別の用途でこの値を使おうとすると誤解を招く可能性があります。`PlaylistWithItems` 内の `playlist_items` を `{ article_id: string }[]` などより正確な型にするか、このルートで新たな型エイリアスを定義することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Fix explicit any type in articles/\[id..."](https://github.com/hiroki-org/audicle/commit/872dd222d2775c8b49db943d044ef85523ddca04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36381738)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->