### PR TITLE
🧪 [testing improvement] Add missing URL validation tests for share-target POST endpoint

### DIFF
--- a/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/share-target/__tests__/route.test.ts
@@ -337,6 +337,98 @@ describe('Share Target Route Handlers', () => {
         })
     })
 
+
+    describe('URL validation during POST request', () => {
+        it('http:// スキームは許可される', async () => {
+            mockAuth.mockResolvedValue({
+                user: { id: 'test-user', email: 'test@example.com' },
+                expires: '2025-12-31',
+            })
+
+            mockGetOrCreateDefaultPlaylist.mockResolvedValue({
+                playlist: {
+                    id: 'playlist-1',
+                    owner_email: 'test@example.com',
+                    name: '読み込んだ記事',
+                    visibility: 'private',
+                    is_default: true,
+                    allow_fork: true,
+                    created_at: '2025-01-01T00:00:00Z',
+                    updated_at: '2025-01-01T00:00:00Z',
+                    items: [],
+                    item_count: 0,
+                },
+            })
+
+            const mockUpsertArticle = supabaseLocal.upsertArticle as jest.MockedFunction<
+                typeof supabaseLocal.upsertArticle
+            >
+            mockUpsertArticle.mockResolvedValue({
+                id: 'article-1',
+                owner_email: 'test@example.com',
+                url: 'http://example.com',
+                title: 'Test Article',
+                created_at: '2025-01-01T00:00:00Z',
+                updated_at: '2025-01-01T00:00:00Z',
+                last_read_position: 0,
+            })
+
+            const mockAddPlaylistItem = supabaseLocal.addPlaylistItem as jest.MockedFunction<
+                typeof supabaseLocal.addPlaylistItem
+            >
+            mockAddPlaylistItem.mockResolvedValue({
+                id: 'item-1',
+                playlist_id: 'playlist-1',
+                article_id: 'article-1',
+                position: 0,
+                added_at: '2025-01-01T00:00:00Z',
+            })
+
+            const formData = new FormData()
+            formData.append('url', 'http://example.com')
+
+            const request = new NextRequest('http://localhost:3000/share-target', {
+                method: 'POST',
+                body: formData
+            })
+
+            const response = await POST(request)
+
+            expect(response.status).toBe(307)
+            expect(response.headers.get('Location')).toContain('/share-target/success')
+        })
+
+        it('javascript: スキームは拒否される', async () => {
+            const formData = new FormData()
+            formData.append('url', 'javascript:alert(1)')
+
+            const request = new NextRequest('http://localhost:3000/share-target', {
+                method: 'POST',
+                body: formData
+            })
+
+            const response = await POST(request)
+
+            expect(response.status).toBe(307)
+            expect(response.headers.get('Location')).toContain('/share-target/error')
+        })
+
+        it('data: スキームは拒否される', async () => {
+            const formData = new FormData()
+            formData.append('url', 'data:text/html,<h1>test</h1>')
+
+            const request = new NextRequest('http://localhost:3000/share-target', {
+                method: 'POST',
+                body: formData
+            })
+
+            const response = await POST(request)
+
+            expect(response.status).toBe(307)
+            expect(response.headers.get('Location')).toContain('/share-target/error')
+        })
+    })
+
     describe('validateUrl function', () => {
         it('http URL は true を返す', () => {
             expect(validateUrl('http://example.com')).toBe(true)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses a testing gap in `packages/web-app-vercel/app/share-target/route.ts` where URL validation edge cases (like `javascript:` or `data:` schemes) during POST requests were not explicitly covered by tests.

📊 **Coverage:** What scenarios are now tested
- Valid `http://` schema inputs proceed to default playlist processing and database update.
- Invalid `javascript:` schema inputs are accurately rejected and redirected to the error page.
- Invalid `data:` schema inputs are accurately rejected and redirected to the error page.

✨ **Result:** The improvement in test coverage
By adding the missing `describe('URL validation during POST request')` block with the equivalent cases tested on the `GET` handler, we have increased branch coverage predictability and ensured regressions don't compromise security via unsafe protocols.

---
*PR created automatically by Jules for task [587362873014748007](https://jules.google.com/task/587362873014748007) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `share-target` の POST エンドポイントに対するURLバリデーションテストを追加します。`javascript:` スキームと `data:` スキームの拒否、および `http://` スキームの許可を検証する `describe('URL validation during POST request')` ブロックが新設されています。

- `javascript:` スキームのPOST拒否テストは新規で有益なカバレッジの追加となっている。
- `data:` スキームのPOST拒否テストは既存の `describe('POST handler')` ブロック内（155行目）と重複しており、テスト構造の肥大化を招く。
- `http://` 許可テストはリダイレクト先のみを検証しており、認証やDB呼び出しのモック検証が不足している。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなし。既存の動作を破壊するリスクは低い。

追加されたテストのうち javascript: スキームの拒否テストは新規のカバレッジとして有益だが、data: スキームのテストは既存テストと重複しており、http:// 成功ケースはモック呼び出しの検証が欠けているため、テストとしての信頼性がやや低い。プロダクションコードには一切変更がないため、マージによるランタイムへの影響はない。

packages/web-app-vercel/app/share-target/__tests__/route.test.ts — 重複テストとモック検証の不足を要確認。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/share-target/__tests__/route.test.ts | POST ハンドラの URL バリデーションテストを追加。`javascript:` スキームのテストは新規で有益だが、`data:` スキームテストは既存の POST ハンドラブロックと重複しており、`http://` 成功ケースのモック呼び出し検証が不足している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /share-target] --> B{url in formData?}
    B -- No --> C[Redirect to /]
    B -- Yes --> D{validateUrl check}
    D -- Invalid: javascript/data --> E[Redirect to /share-target/error]
    D -- Valid: http/https --> F{Auth check}
    F -- Not logged in --> G[Redirect to /auth/signin]
    F -- Logged in --> H[handleShareTarget]
    H --> I{Get default playlist}
    I -- Error --> E
    I -- Success --> J[Upsert article]
    J --> K[Add to playlist]
    K --> L[Redirect to /share-target/success]
    style D fill:#ffffcc,stroke:#cccc00
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/app/share-target/__tests__/route.test.ts:416-429
**`data:` スキームの POST テストが重複している**

`describe('URL validation during POST request')` 内に追加された `data:` スキームの拒否テスト（416〜429行目）は、既存の `describe('POST handler')` ブロック（155〜168行目）にある `'無効なURLスキームの場合はエラーページにリダイレクト'` テストと実質的に同じ内容です。どちらのテストも同じコードパスを実行しており、この重複はテストスイートの肥大化を招き、将来の変更時に両方を同期して更新するメンテナンスコストが生じます。

### Issue 2 of 2
packages/web-app-vercel/app/share-target/__tests__/route.test.ts:342-399
**`http://` 許可テストにモック呼び出しの検証が欠けている**

新しい `http://` スキーム許可テスト（342〜399行目）は、リダイレクト先が `/share-target/success` になることしか確認していません。`describe('POST handler')` 内の既存成功テスト（187〜247行目）では `expect(mockAuth).toHaveBeenCalled()` や `expect(mockGetOrCreateDefaultPlaylist).toHaveBeenCalledWith(...)` で各モックの呼び出しを検証しています。この検証がない場合、実装が認証をスキップしたり DB 呼び出しを省いたりしていてもテストが通過してしまうため、`mockAuth`・`mockGetOrCreateDefaultPlaylist`・`mockUpsertArticle` の呼び出し検証を追加することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add edge case URL validation tests..."](https://github.com/hiroki-org/audicle/commit/c1874207ff7cdfef253bb544b47cc6dcffa241a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36381771)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->