### PR TITLE
🧪 Add test coverage for non-Error resolution failure in bulk_update route

### DIFF
--- a/packages/web-app-vercel/app/api/playlists/bulk_update/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/playlists/bulk_update/__tests__/route.test.ts
@@ -101,6 +101,19 @@ describe('POST /api/playlists/bulk_update', () => {
         expect(data.error).toBe('addToPlaylistIds and removeFromPlaylistIds must be arrays')
     })
 
+    it('should return 404 with fallback message if article resolution fails with non-Error', async () => {
+        ;(resolveArticleId as jest.Mock).mockRejectedValue('String Error')
+        const request = createRequest({
+            articleId: mockArticleId,
+            addToPlaylistIds: ['playlist-1'],
+            removeFromPlaylistIds: ['playlist-2'],
+        })
+        const response = await POST(request)
+        expect(response.status).toBe(404)
+        const data = await response.json()
+        expect(data.error).toBe('Article resolution failed')
+    })
+
     it('should return 404 if article resolution fails', async () => {
         ;(resolveArticleId as jest.Mock).mockRejectedValue(new Error('Article not found'))
 


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `packages/web-app-vercel/app/api/playlists/bulk_update/__tests__/route.test.ts` to cover the non-`Error` rejection path in the `resolveArticleId` catch block.
📊 **Coverage:** The test suite now explicitly covers the fallback logic (`error instanceof Error ? error.message : 'Article resolution failed'`) in `resolveArticleId`, ensuring the 404 status and fallback error message are correctly returned when a raw string or non-standard error is thrown.
✨ **Result:** Test coverage for `app/api/playlists/bulk_update/route.ts` is now at 100% across statements, branches, functions, and lines. All unit tests and the linter pass successfully.

---
*PR created automatically by Jules for task [3015544698332946521](https://jules.google.com/task/3015544698332946521) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`resolveArticleId` の catch ブロック内にある `error instanceof Error ? error.message : 'Article resolution failed'` の三項演算子において、非 `Error` オブジェクト（生の文字列など）がスローされた場合のフォールバックパスをカバーするテストケースを1件追加するPRです。

- `resolveArticleId` を文字列 `'String Error'` でリジェクトさせ、ステータス 404・メッセージ `'Article resolution failed'` が返ることを検証している。
- 変更はテストファイル1件のみで、本番コードへの影響はない。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストファイルのみの変更であり、本番コードへの影響はない。

追加されたテストは既存のパターンと整合しており、resolveArticleId の catch ブロック内で非 Error オブジェクトがスローされた場合の三項演算子フォールバックパスを正確に検証している。モックの設定・アサーションともに正しく、リグレッションリスクはない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/playlists/bulk_update/__tests__/route.test.ts | 非Errorオブジェクトで拒否された場合のフォールバックメッセージを検証するテストケースを1件追加。既存のパターンと一致しており、対象ブランチを正確にカバーしている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト
    participant POST as POST ハンドラ
    participant resolveArticleId as resolveArticleId (モック)

    Test->>POST: POST /api/playlists/bulk_update
    POST->>resolveArticleId: resolveArticleId(articleId, userEmail)
    resolveArticleId-->>POST: reject('String Error') ← 非Errorオブジェクト
    POST-->>Test: "404 { error: 'Article resolution failed' }"
    Note over POST: error instanceof Error → false<br/>フォールバックメッセージを使用
```

<sub>Reviews (1): Last reviewed commit: ["test(api): Add test case for non-Error r..."](https://github.com/hiroki-org/audicle/commit/16e7bcad0a106065aca7216cb9a6dcfd1b9c6e90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36381897)</sub>

<!-- /greptile_comment -->