### PR TITLE
🧪 Add error path test for invalid JSON in settings PUT route

### DIFF
--- a/packages/web-app-vercel/app/api/settings/update/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/settings/update/__tests__/route.test.ts
@@ -250,6 +250,22 @@ describe('PUT /api/settings/update', () => {
         );
     });
 
+    it('returns 400 if JSON parsing fails', async () => {
+        (auth as jest.Mock).mockResolvedValue({ user: { id: 'test-user-id' } });
+
+        const request = new NextRequest('http://localhost:3000/api/settings/update', {
+            method: 'PUT',
+            body: 'invalid-json',
+        });
+
+        const response = await PUT(request);
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({ error: 'Invalid JSON body', success: false });
+        expect(consoleErrorMock).toHaveBeenCalledWith('Error parsing request body:', expect.any(Error));
+    });
+
     it('returns 500 if an unexpected exception occurs', async () => {
         (auth as jest.Mock).mockRejectedValue(new Error('Unexpected Error'));
 

--- a/packages/web-app-vercel/app/api/settings/update/route.ts
+++ b/packages/web-app-vercel/app/api/settings/update/route.ts
@@ -19,7 +19,17 @@ export async function PUT(request: NextRequest) {
         const userId = session.user.id
 
         // Parse request body
-        const body: UpdateSettingsRequest = await request.json()
+        let body: UpdateSettingsRequest
+        try {
+            body = await request.json()
+        } catch (error) {
+            console.error('Error parsing request body:', error)
+            return NextResponse.json(
+                { error: 'Invalid JSON body', success: false },
+                { status: 400 }
+            )
+        }
+
 
         // Validate input
         const { playback_speed, voice_model, language, color_theme } = body


### PR DESCRIPTION
🎯 **What:** The PUT route for updating user settings (`/api/settings/update`) did not explicitly handle invalid JSON payloads within `request.json()`, leading to an unhandled exception and a generic 500 error instead of a more appropriate 400 Bad Request error. We addressed this testing gap by gracefully parsing the JSON and catching errors.
📊 **Coverage:** A new test scenario ('returns 400 if JSON parsing fails') was added to the corresponding `route.test.ts` suite.
✨ **Result:** Test coverage for `app/api/settings/update/route.ts` is improved, and the endpoint is now more resilient against malformed client requests.

---
*PR created automatically by Jules for task [7811005884639130085](https://jules.google.com/task/7811005884639130085) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PUT `/api/settings/update` エンドポイントにおける不正な JSON ボディのエラーハンドリングを改善し、対応するテストケースを追加したPRです。

- `request.json()` の呼び出しを内部 try-catch で囲み、JSON パース失敗時に 500 ではなく適切な 400 レスポンスを返すよう修正。
- 新テスト `'returns 400 if JSON parsing fails'` を追加し、ステータスコード・レスポンスボディ・`console.error` 呼び出しをすべて検証。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

小規模で焦点の絞られた変更であり、既存のエラーハンドリング構造と整合しています。マージして問題ありません。

JSON パースエラーの catch は既存の外側 try-catch の内側に正しく配置されており、想定外の例外が外側に漏れることはありません。テストも追加されており動作検証できています。空行の重複という軽微なスタイル上の問題が1件あります。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/settings/update/route.ts | request.json() の呼び出しを try-catch で囲み、不正な JSON に対して 500 ではなく 400 を返すよう変更。空行が1行余分にある軽微なスタイル上の問題がある。 |
| packages/web-app-vercel/app/api/settings/update/__tests__/route.test.ts | 不正な JSON ボディに対する新しいテストケースを追加。ステータスコード、レスポンスボディ、console.error の呼び出しをすべて検証しており、適切に実装されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant PUT Route
    participant Auth
    participant JSON Parser
    participant Supabase

    Client->>PUT Route: PUT /api/settings/update (body)
    PUT Route->>Auth: auth()
    alt 未認証
        Auth-->>PUT Route: null / no user.id
        PUT Route-->>Client: 401 Unauthorized
    else 認証済み
        Auth-->>PUT Route: session
        PUT Route->>JSON Parser: request.json()
        alt 不正なJSON（新規追加）
            JSON Parser-->>PUT Route: throw SyntaxError
            PUT Route-->>Client: 400 Invalid JSON body
        else 正常なJSON
            JSON Parser-->>PUT Route: body
            PUT Route->>PUT Route: バリデーション
            alt バリデーションエラー
                PUT Route-->>Client: 400 Validation Error
            else バリデーション成功
                PUT Route->>Supabase: upsert(updateData)
                alt DBエラー
                    Supabase-->>PUT Route: error
                    PUT Route-->>Client: 500 Failed to update settings
                else 成功
                    Supabase-->>PUT Route: data
                    PUT Route-->>Client: 200 Settings updated successfully
                end
            end
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/app/api/settings/update/route.ts:25-34
try-catch ブロックの後に空行が2行あります。1行で統一してください。

```suggestion
        } catch (error) {
            console.error('Error parsing request body:', error)
            return NextResponse.json(
                { error: 'Invalid JSON body', success: false },
                { status: 400 }
            )
        }

        // Validate input
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gracefully handle invalid JSON in s..."](https://github.com/hiroki-org/audicle/commit/8579b3b151d8ba8cde478c4067127aa8ed2e70b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36382004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->