### PR TITLE
🔒 Fix CORS allowed origins vulnerability using proper structural validation

### DIFF
--- a/packages/api-server/main.py
+++ b/packages/api-server/main.py
@@ -6,6 +6,7 @@ import asyncio
 import subprocess
 import json
 import os
+import urllib.parse
 import logging
 import re
 from typing import List, Pattern
@@ -17,15 +18,35 @@ from google.cloud import texttospeech
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+
+def _is_valid_origin(origin: str) -> bool:
+    try:
+        parsed = urllib.parse.urlparse(origin)
+        if parsed.scheme not in ["http", "https", "chrome-extension"]:
+            return False
+        if not parsed.netloc or "*" in parsed.netloc:
+            return False
+        if parsed.path and parsed.path != "/":
+            return False
+        if parsed.query or parsed.fragment:
+            return False
+        if "@" in parsed.netloc:
+            return False
+        return True
+    except Exception:
+        return False
+
+
 app = FastAPI(title="Audicle API Server", version="1.0.0")
 
 # CORS設定
 cors_origins_env = os.getenv("CORS_ALLOWED_ORIGINS")
 allow_origins = []
 if cors_origins_env:
-    allow_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
-    if "*" in allow_origins:
+    raw_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
+    if "*" in raw_origins:
         raise ValueError("CORS_ALLOWED_ORIGINS に '*' は使用できません。allow_credentials=True と組み合わせると起動に失敗します。")
+    allow_origins = [origin for origin in raw_origins if _is_valid_origin(origin)]
 
 if not allow_origins:
     raise ValueError("CORS_ALLOWED_ORIGINS 環境変数が設定されていないか、有効なオリジンがありません。フロントエンドからのアクセスを許可するために、有効なオリジンを指定してください。")


### PR DESCRIPTION
🎯 **What:** 
The application was directly splitting the `CORS_ALLOWED_ORIGINS` environment variable by comma without verifying the structure or validity of each provided origin, only ensuring it didn't strictly equal `*`.

⚠️ **Risk:** 
A misconfigured or maliciously manipulated environment variable could allow arbitrary and overly permissive CORS origins, circumventing intended security restrictions and exposing the API to cross-origin attacks. It could allow requests with credentials or invalid paths, depending on user input formatting.

🛡️ **Solution:** 
Replaced the simplistic string splitting with a robust parsing and validation mechanism using `urllib.parse`. The new logic explicitly ensures:
- The scheme is restricted to `http`, `https`, or `chrome-extension`.
- The `netloc` is present and does not contain arbitrary wildcards (`*`).
- Extraneous and potentially hazardous elements like queries, paths, fragments, and credentials (`@`) are explicitly disallowed.
This enforces a tight grip on valid origin strings while maintaining the flexibility of the environment variable.

---
*PR created automatically by Jules for task [13067061444212851846](https://jules.google.com/task/13067061444212851846) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CORS の許可オリジン設定を強化する変更で、カンマ区切りの文字列をそのまま受け入れる従来の処理に代わり、`urllib.parse` を使った `_is_valid_origin()` 関数でスキーム・ホスト名・クレデンシャル・パスなどを個別に検証するようになりました。

- `_is_valid_origin()` が追加され、スキームを `http`/`https`/`chrome-extension` に限定し、`netloc` に `*` や `@` を含むオリジン・クエリ・フラグメント付きの文字列を拒否します。
- 無効なオリジンはサイレントに除外されるため、`CORS_ALLOWED_ORIGINS` の一部が誤って設定されていても警告なしにサーバーが起動し、オペレーターが意図しない CORS ポリシーでデプロイしてしまうリスクがあります。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

無効なオリジンがサイレントに除外されるため、意図しない CORS 設定でサーバーが起動するリスクがある。マージ前に修正が望ましい。

バリデーション自体の方向性は正しいが、`_is_valid_origin()` に失敗したオリジンを黙って捨てるため、オペレーターが気づかないままサーバーが誤った許可セットで起動する可能性がある。全オリジンが無効な場合は起動時エラーになるが、一部だけ無効な混在ケースを検出する手段が現状ない。

packages/api-server/main.py の CORS フィルタリングロジック（46〜49行目）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api-server/main.py | `_is_valid_origin()` による CORS バリデーション追加。ただし無効なオリジンをサイレントに除外するため、一部のオリジンが意図せず無効化されてもサーバーが正常起動し、問題が気づかれないリスクがある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CORS_ALLOWED_ORIGINS 環境変数] --> B{cors_origins_env が存在?}
    B -- No --> E[ValueError: 環境変数未設定]
    B -- Yes --> C[カンマ分割 → raw_origins]
    C --> D{raw_origins に '*' が含まれる?}
    D -- Yes --> F[ValueError: ワイルドカード禁止]
    D -- No --> G[_is_valid_origin でフィルタ]
    G --> H{通過したオリジンが存在?}
    H -- No --> E2[ValueError: 有効なオリジンなし]
    H -- Yes --> I[allow_origins にセット]
    I --> J[CORSMiddleware に渡して起動]
    G -. 無効なオリジンはサイレントに除外 .-> G
    style G fill:#ff9999,stroke:#cc0000
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/api-server/main.py:46-49
**無効なオリジンがサイレントに除外される問題**

`_is_valid_origin()` の検証に失敗したオリジンは警告もエラーも出さずに静かに除外されます。例えば `CORS_ALLOWED_ORIGINS=https://good.example.com,not-an-origin` と設定した場合、`not-an-origin` は無言で捨てられ、サーバーは問題なく起動しますが `allow_origins` の内容は意図と異なります。`ValueError` を発生させるか、少なくとも `logger.warning` で除外されたオリジンを出力してオペレーターに知らせる必要があります。

```suggestion
    raw_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
    if "*" in raw_origins:
        raise ValueError("CORS_ALLOWED_ORIGINS に '*' は使用できません。allow_credentials=True と組み合わせると起動に失敗します。")
    invalid_origins = [o for o in raw_origins if not _is_valid_origin(o)]
    if invalid_origins:
        raise ValueError(
            f"CORS_ALLOWED_ORIGINS に無効なオリジンが含まれています: {invalid_origins}。"
            "スキーム (http/https/chrome-extension)、ホスト名のみを指定してください。"
        )
    allow_origins = [o for o in raw_origins if _is_valid_origin(o)]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix CORS allowed origins vulnerabilit..."](https://github.com/hiroki-org/audicle/commit/428283cd5ec15e4a95245bb8ee76b1c94dce3265) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36382020)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->