### PR TITLE
🧹 [Refactor]: Strongly type Google Cloud TTS credentials

### DIFF
--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -133,7 +133,21 @@ function getTTSClient(): TextToSpeechClient | null {
     // file-path variants. This helps when people paste multi-line JSON into
     // env files; we prefer single-line JSON, but fall back to base64.
 
-    const tryParseJson = (s: string): unknown | null => {
+    interface GoogleAuthCredentials {
+    type?: string;
+    project_id?: string;
+    private_key_id?: string;
+    private_key?: string;
+    client_email?: string;
+    client_id?: string;
+    auth_uri?: string;
+    token_uri?: string;
+    auth_provider_x509_cert_url?: string;
+    client_x509_cert_url?: string;
+    universe_domain?: string;
+}
+
+    const tryParseJson = (s: string): GoogleAuthCredentials | null => {
         try {
             return JSON.parse(s);
         } catch (e) {
@@ -188,7 +202,7 @@ function getTTSClient(): TextToSpeechClient | null {
     // best-effort cast.
     ttsCLient = new TextToSpeechClient({
 
-        credentials: credentials as any,
+        credentials,
     });
     return ttsCLient;
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the `any` casting of `credentials` when instantiating the `TextToSpeechClient` from `@google-cloud/text-to-speech` in `packages/web-app-vercel/app/api/synthesize/route.ts`.
💡 **Why:** This improves maintainability by accurately representing the expected shape of Google service account credentials using an explicitly defined TypeScript interface, removing a bypass of the type system.
✅ **Verification:** I confirmed the change is safe by successfully compiling and running lint, unit, and integration tests for the modified API route to ensure no runtime regressions.
✨ **Result:** A properly typed, safer `GoogleAuthCredentials` definition that removes unnecessary `as any` casts and improves code readability.

---
*PR created automatically by Jules for task [7450613408796324499](https://jules.google.com/task/7450613408796324499) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Google Cloud TTS クライアント初期化時の `credentials as any` キャストを、新たに定義した `GoogleAuthCredentials` インターフェースに置き換えるリファクタリングです。

- `getTTSClient()` 関数内に `GoogleAuthCredentials` インターフェースを定義し、`tryParseJson` の返り値型と `credentials` の型を明示化しました。
- `TextToSpeechClient` へ渡す際の `as any` キャストを削除し、型安全性を向上させています。
- ただし、インターフェースが関数スコープ内（しかもインデント不統一）に配置されており、モジュールレベルへの移動が推奨されます。また、既存の「best-effort cast」コメントが変更後のコードと矛盾しており、削除が必要です。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

スタイル上の改善点はあるが、ロジックやランタイム動作への影響はなく、マージ自体は安全です。

変更はコンパイルが通っており、ランタイム動作は変わりません。ただし、インターフェースの配置場所（関数内部・インデント不統一）、古くなったコメントの残存、および公式型 JWTInput を使わず手動定義している点は、今後のメンテナンス性に影響する可能性があります。

packages/web-app-vercel/app/api/synthesize/route.ts — インターフェースの配置と古くなったコメントを確認してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/synthesize/route.ts | `as any` キャストを除去し `GoogleAuthCredentials` インターフェースを導入。インターフェースが関数内部に定義されている点（インデント不統一・再利用不可）と古くなったコメントの残存が要改善。型の完全性についても公式の `JWTInput` 型の利用を検討する余地あり。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTTSClient 呼び出し] --> B{既存クライアントあり?}
    B -- Yes --> C[既存の ttsCLient を返す]
    B -- No --> D{keyFile 環境変数が存在?}
    D -- Yes --> E[keyFilename でクライアント生成]
    D -- No --> F{CREDENTIALS_JSON 環境変数あり?}
    F -- No --> G{非本番 or CI?}
    G -- Yes --> H[null を返す]
    G -- No --> I[エラーをスロー]
    F -- Yes --> J["JSON として直接パース → GoogleAuthCredentials"]
    J -- 失敗 --> K[エスケープ解除して再パース]
    K -- 失敗 --> L[base64 デコードしてパース]
    L -- 失敗 --> M{ファイルパス形式?}
    M -- Yes --> N[keyFilename でクライアント生成]
    M -- No --> O[エラーをスロー]
    J -- 成功 --> P["credentials を TextToSpeechClient に渡す"]
    K -- 成功 --> P
    L -- 成功 --> P
    P --> Q[ttsCLient を返す]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/web-app-vercel/app/api/synthesize/route.ts`, line 200-203 ([link](https://github.com/hiroki-org/audicle/blob/176ed358cfda990a0c277daf3ea79c7cbd0b0c83/packages/web-app-vercel/app/api/synthesize/route.ts#L200-L203)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> インターフェース導入に伴い、既存の「best-effort cast」に関するコメントが古くなっています。削除するか実態に合わせて更新してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/app/api/synthesize/route.ts
   Line: 200-203

   Comment:
   インターフェース導入に伴い、既存の「best-effort cast」に関するコメントが古くなっています。削除するか実態に合わせて更新してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/web-app-vercel/app/api/synthesize/route.ts:136-148
**関数内部でのインターフェース定義**

`GoogleAuthCredentials` インターフェースが `getTTSClient()` 関数の内部に定義されているため、再利用・エクスポートができません。また、インターフェース本体のインデントがゼロになっており、関数内の他のコードとスタイルが一致していません。モジュールレベル（関数の外）に移動することで、可読性が向上し、テストコードなどからも参照できるようになります。

### Issue 2 of 3
packages/web-app-vercel/app/api/synthesize/route.ts:200-203
インターフェース導入に伴い、既存の「best-effort cast」に関するコメントが古くなっています。削除するか実態に合わせて更新してください。

```suggestion
    ttsCLient = new TextToSpeechClient({
```

### Issue 3 of 3
packages/web-app-vercel/app/api/synthesize/route.ts:136-148
**`google-auth-library` の公式型を使用することを検討**

独自の `GoogleAuthCredentials` を定義する代わりに、`google-auth-library` が公開している `JWTInput` 型をインポートして使用できます（`TextToSpeechClient` は内部的にこの型を使用しています）。`google-auth-library` はすでに `@google-cloud/text-to-speech` の依存関係に含まれているため、追加インストール不要で `import type { JWTInput } from 'google-auth-library'` として利用できます。手動定義では `client_secret`、`quota_project_id` などのフィールドが漏れていますが、公式型を使えばドリフトが防げます。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Replace \`any\` cast with proper..."](https://github.com/hiroki-org/audicle/commit/176ed358cfda990a0c277daf3ea79c7cbd0b0c83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36382052)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->