### PR TITLE
🔒 Fix unauthenticated access bypass in synthesize API

### DIFF
--- a/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
+++ b/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
@@ -55,6 +55,7 @@ describe('/api/synthesize route', () => {
         mockSynthesizeSpeech.mockReset();
         mockSynthesizeSpeech.mockResolvedValue([{ audioContent: Buffer.from('fake-audio') }]);
         process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = JSON.stringify({ project_id: 'test' });
+        process.env.ALLOWED_EMAILS = 'user@example.com';
     });
 
     it('returns 400 if body missing text and chunks', async () => {

--- a/packages/web-app-vercel/app/api/synthesize/route.ts
+++ b/packages/web-app-vercel/app/api/synthesize/route.ts
@@ -87,7 +87,7 @@ function parseTTSError(error: unknown): TTSErrorInfo {
 }
 
 // 許可リスト（環境変数から取得、カンマ区切り）
-const ALLOWED_EMAILS = process.env.ALLOWED_EMAILS?.split(',').map(e => e.trim()) || [];
+const getAllowedEmails = () => process.env.ALLOWED_EMAILS?.split(',').map(e => e.trim()) || [];
 
 // 人気記事判定の閾値（本番環境では5以上に調整することを推奨）
 // 現在は2に設定して開発/テスト環境での最適化検証を行う
@@ -349,7 +349,7 @@ export async function POST(request: NextRequest) {
         }
 
         // 許可リストチェック
-        if (ALLOWED_EMAILS.length > 0 && !ALLOWED_EMAILS.includes(session.user.email)) {
+        if (!getAllowedEmails().includes(session.user.email)) {
             log('warn', 'アクセスが拒否されました', { email: session.user.email });
             return NextResponse.json({ error: 'Access denied' }, { status: 403, headers: corsHeaders });
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a security vulnerability in the `/api/synthesize` endpoint where the access control check was skipped if `ALLOWED_EMAILS` was an empty array (i.e. `ALLOWED_EMAILS.length === 0`). The fix restricts access to only explicitly allowed emails. If the list is empty, all access is denied (fail-closed behavior).

⚠️ **Risk:** The potential impact if left unfixed
Any authenticated user could access the speech synthesis API if the allowed emails list was empty or unconfigured. Since Google Cloud TTS is a billed service, this vulnerability could be exploited to cause excessive resource usage and financial cost.

🛡️ **Solution:** How the fix addresses the vulnerability
The condition `ALLOWED_EMAILS.length > 0 && !ALLOWED_EMAILS.includes(session.user.email)` has been changed to strictly evaluate `!getAllowedEmails().includes(session.user.email)`. The environment variable `ALLOWED_EMAILS` is evaluated dynamically inside a function now, guaranteeing proper fail-closed validation when `ALLOWED_EMAILS` is empty or undefined, and allowing test suites to mock `process.env.ALLOWED_EMAILS`.

---
*PR created automatically by Jules for task [8249362254835845804](https://jules.google.com/task/8249362254835845804) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `/api/synthesize` エンドポイントのアクセス制御バグを修正します。`ALLOWED_EMAILS` が空の場合にチェックがスキップされ、任意の認証済みユーザーがGoogle Cloud TTSにアクセスできてしまう脆弱性（フェイルオープン）を、フェイルクローズ動作に変更しています。

- `ALLOWED_EMAILS` の評価をモジュール初期化時から `getAllowedEmails()` 関数による動的評価に変更し、`process.env` のモック差し替えを可能にした
- アクセス制御の条件を `ALLOWED_EMAILS.length > 0 && !includes(email)` から単純な `!getAllowedEmails().includes(email)` に変更し、リストが空または未設定の場合はすべてのアクセスを拒否するようにした
- テストの `beforeEach` に `ALLOWED_EMAILS` のセットアップを追加したが、修正した脆弱性そのものを検証するテストケース（空リスト→403、許可外メール→403）は追加されていない
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

route.ts のロジック変更自体は正しく、フェイルクローズ動作が実現されている。テストファイルに検証の抜けがある。

アクセス制御の修正コード自体は意図通りに動作するが、修正対象の脆弱性シナリオ（ALLOWED_EMAILS が空または未設定の場合に 403 を返すこと、許可外メールで 403 を返すこと）を検証するテストが存在しない。将来この条件が誤って変更された場合に検知する手段がなく、セキュリティ上の回帰リスクが残る。

テストファイル __tests__/route.test.ts に注目が必要 — 修正した脆弱性ケースを直接カバーするテストシナリオが追加されておらず、セキュリティ回帰の検知力が低い。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/synthesize/route.ts | 許可リストの評価をモジュール読み込み時から関数呼び出し時に変更し、空リストでのフェイルオープンを修正。ロジック自体は正しくフェイルクローズ動作になっている。 |
| packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts | ALLOWED_EMAILS のセットアップを追加したが、修正した脆弱性（空リストや許可外メール → 403）を検証するテストケースがなく、afterEach でのenv変数クリーンアップも欠如している。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant POST as POST /api/synthesize
    participant Auth as auth()
    participant Env as process.env

    Client->>POST: リクエスト
    POST->>Auth: セッション取得
    Auth-->>POST: session (or null)

    alt セッションなし or email なし
        POST-->>Client: 401 Unauthorized
    else 認証済み
        POST->>Env: ALLOWED_EMAILS 取得 (getAllowedEmails)
        Env-->>POST: string[] (空の場合 [])
        alt email が許可リストに含まれない（空リスト含む）
            POST-->>Client: 403 Access denied
        else email が許可リストに含まれる
            POST->>POST: TTS処理・音声合成
            POST-->>Client: 200 audioUrls
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts`, line 52-59 ([link](https://github.com/hiroki-org/audicle/blob/4fea681ce6bf99dda8e90b7486bb3fdbb70749ac/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts#L52-L59)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **修正した脆弱性を検証するテストが欠如しています**

   このPRの主目的は「`ALLOWED_EMAILS` が空の場合にアクセスが通過してしまう」バグの修正ですが、その動作を検証するテストが追加されていません。`ALLOWED_EMAILS` が未設定または空文字のケース（403を期待）、および許可リストに含まれないメールアドレスのケース（403を期待）のテストがないため、将来の変更でこの脆弱性が再発しても検知できません。少なくとも以下の2ケースが必要です：①`process.env.ALLOWED_EMAILS` を削除した状態でのアクセス → 403、②許可されていないメールでのアクセス → 403。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
   Line: 52-59

   Comment:
   **修正した脆弱性を検証するテストが欠如しています**

   このPRの主目的は「`ALLOWED_EMAILS` が空の場合にアクセスが通過してしまう」バグの修正ですが、その動作を検証するテストが追加されていません。`ALLOWED_EMAILS` が未設定または空文字のケース（403を期待）、および許可リストに含まれないメールアドレスのケース（403を期待）のテストがないため、将来の変更でこの脆弱性が再発しても検知できません。少なくとも以下の2ケースが必要です：①`process.env.ALLOWED_EMAILS` を削除した状態でのアクセス → 403、②許可されていないメールでのアクセス → 403。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts`, line 53-59 ([link](https://github.com/hiroki-org/audicle/blob/4fea681ce6bf99dda8e90b7486bb3fdbb70749ac/packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts#L53-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `beforeEach` で `process.env.ALLOWED_EMAILS` を上書きしていますが、対応する `afterEach` でのリセットがありません。テストスイートの実行後もこの環境変数が `'user@example.com'` のまま残るため、他のテストファイルに副作用を与える可能性があります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts
   Line: 53-59

   Comment:
   `beforeEach` で `process.env.ALLOWED_EMAILS` を上書きしていますが、対応する `afterEach` でのリセットがありません。テストスイートの実行後もこの環境変数が `'user@example.com'` のまま残るため、他のテストファイルに副作用を与える可能性があります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts:52-59
**修正した脆弱性を検証するテストが欠如しています**

このPRの主目的は「`ALLOWED_EMAILS` が空の場合にアクセスが通過してしまう」バグの修正ですが、その動作を検証するテストが追加されていません。`ALLOWED_EMAILS` が未設定または空文字のケース（403を期待）、および許可リストに含まれないメールアドレスのケース（403を期待）のテストがないため、将来の変更でこの脆弱性が再発しても検知できません。少なくとも以下の2ケースが必要です：①`process.env.ALLOWED_EMAILS` を削除した状態でのアクセス → 403、②許可されていないメールでのアクセス → 403。

### Issue 2 of 2
packages/web-app-vercel/app/api/synthesize/__tests__/route.test.ts:53-59
`beforeEach` で `process.env.ALLOWED_EMAILS` を上書きしていますが、対応する `afterEach` でのリセットがありません。テストスイートの実行後もこの環境変数が `'user@example.com'` のまま残るため、他のテストファイルに副作用を与える可能性があります。

```suggestion
    let originalAllowedEmails: string | undefined;

    beforeEach(() => {
        jest.clearAllMocks();
        mockSynthesizeSpeech.mockReset();
        mockSynthesizeSpeech.mockResolvedValue([{ audioContent: Buffer.from('fake-audio') }]);
        process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = JSON.stringify({ project_id: 'test' });
        originalAllowedEmails = process.env.ALLOWED_EMAILS;
        process.env.ALLOWED_EMAILS = 'user@example.com';
    });

    afterEach(() => {
        if (originalAllowedEmails === undefined) {
            delete process.env.ALLOWED_EMAILS;
        } else {
            process.env.ALLOWED_EMAILS = originalAllowedEmails;
        }
    });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix unauthenticated access bypass in ..."](https://github.com/hiroki-org/audicle/commit/4fea681ce6bf99dda8e90b7486bb3fdbb70749ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36382258)</sub>

<!-- /greptile_comment -->