### PR TITLE
🧪 [test] Add tests for StorageManager component

### DIFF
--- a/packages/web-app-vercel/components/__tests__/StorageManager.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/StorageManager.test.tsx
@@ -28,7 +28,7 @@ describe("StorageManager", () => {
   const mockShowConfirm = jest.fn();
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     (useConfirmDialog as jest.Mock).mockReturnValue({
       showConfirm: mockShowConfirm,
       confirmDialog: <div data-testid="mock-confirm-dialog" />,
@@ -180,5 +180,42 @@ describe("StorageManager", () => {
 
     await waitFor(() => expect(clearAll).toHaveBeenCalled());
     await waitFor(() => expect(screen.getByText("ダウンロード済みの記事がありません")).toBeInTheDocument());
+  });
+
+  it("does not clear all if not confirmed", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    (getDownloadedArticles as jest.Mock).mockResolvedValue(mockArticles);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    mockShowConfirm.mockResolvedValue(false);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const clearAllButton = screen.getByRole("button", { name: "全て削除" });
+    fireEvent.click(clearAllButton);
+
+    await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled());
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(screen.getByText("https://example.com/1")).toBeInTheDocument();
+  });
+
+  it("handles clear all error", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    const clearError = new Error("Clear failed");
+    (getDownloadedArticles as jest.Mock).mockResolvedValue(mockArticles);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    (clearAll as jest.Mock).mockRejectedValue(clearError);
+    mockShowConfirm.mockResolvedValue(true);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const clearAllButton = screen.getByRole("button", { name: "全て削除" });
+    fireEvent.click(clearAllButton);
+
+    await waitFor(() => expect(screen.getByText("削除に失敗しました")).toBeInTheDocument());
+    expect(logger.error).toHaveBeenCalledWith("全削除に失敗", clearError);
   });
 });

--- a/packages/web-app-vercel/components/__tests__/StorageManager.test.tsx
+++ b/packages/web-app-vercel/components/__tests__/StorageManager.test.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import StorageManager from "../StorageManager";
+import { getDownloadedArticles, getStorageUsage, deleteArticle, clearAll } from "@/lib/indexedDB";
+import { useConfirmDialog } from "@/components/ConfirmDialog";
+import { logger } from "@/lib/logger";
+
+jest.mock("@/lib/indexedDB", () => ({
+  getDownloadedArticles: jest.fn(),
+  getStorageUsage: jest.fn(),
+  deleteArticle: jest.fn(),
+  clearAll: jest.fn(),
+}));
+
+jest.mock("@/components/ConfirmDialog", () => ({
+  useConfirmDialog: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+describe("StorageManager", () => {
+  const mockShowConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useConfirmDialog as jest.Mock).mockReturnValue({
+      showConfirm: mockShowConfirm,
+      confirmDialog: <div data-testid="mock-confirm-dialog" />,
+    });
+  });
+
+  it("renders loading state initially", () => {
+    (getDownloadedArticles as jest.Mock).mockReturnValue(new Promise(() => {}));
+    (getStorageUsage as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    render(<StorageManager />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no articles are downloaded", async () => {
+    (getDownloadedArticles as jest.Mock).mockResolvedValue([]);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 0, available: 100000 });
+
+    render(<StorageManager />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("0 B")).toBeInTheDocument();
+    expect(screen.getByText("ダウンロード済みの記事がありません")).toBeInTheDocument();
+  });
+
+  it("renders articles correctly", async () => {
+    const mockArticles = [
+      {
+        url: "https://example.com/1",
+        totalChunks: 3,
+        downloadedChunks: 3,
+        totalSize: 1024 * 1024 * 5, // 5MB
+        timestamp: 1672531200000, // 2023-01-01T00:00:00.000Z
+      },
+      {
+        url: "https://example.com/2",
+        totalChunks: 5,
+        downloadedChunks: 2,
+        totalSize: 1024 * 1024 * 2, // 2MB
+        timestamp: 1672617600000,
+      }
+    ];
+
+    (getDownloadedArticles as jest.Mock).mockResolvedValue(mockArticles);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 1024 * 1024 * 7, available: 100000000 });
+
+    render(<StorageManager />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("7.00 MB")).toBeInTheDocument(); // Storage
+
+    // Check article 1 (Complete)
+    expect(screen.getByText("https://example.com/1")).toBeInTheDocument();
+    expect(screen.getByText("3 / 3 チャンク")).toBeInTheDocument();
+    expect(screen.getByText("✓ 完全")).toBeInTheDocument();
+    expect(screen.getByText("5.00 MB")).toBeInTheDocument();
+
+    // Check article 2 (Partial)
+    expect(screen.getByText("https://example.com/2")).toBeInTheDocument();
+    expect(screen.getByText("2 / 5 チャンク")).toBeInTheDocument();
+    expect(screen.getByText("⚠ 部分的")).toBeInTheDocument();
+    expect(screen.getByText("2.00 MB")).toBeInTheDocument();
+  });
+
+  it("handles loading error", async () => {
+    (getDownloadedArticles as jest.Mock).mockRejectedValue(new Error("Failed to load"));
+    (getStorageUsage as jest.Mock).mockRejectedValue(new Error("Failed to load"));
+
+    render(<StorageManager />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument();
+    });
+
+    expect(logger.error).toHaveBeenCalledWith("ストレージ情報の読み込みに失敗", expect.any(Error));
+  });
+
+  it("handles article deletion when confirmed", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    (getDownloadedArticles as jest.Mock).mockResolvedValueOnce(mockArticles).mockResolvedValueOnce([]);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    (deleteArticle as jest.Mock).mockResolvedValue(undefined);
+    mockShowConfirm.mockResolvedValue(true);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(deleteArticle).toHaveBeenCalledWith("https://example.com/1"));
+    await waitFor(() => expect(screen.getByText("ダウンロード済みの記事がありません")).toBeInTheDocument());
+  });
+
+  it("does not delete article if not confirmed", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    (getDownloadedArticles as jest.Mock).mockResolvedValue(mockArticles);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    mockShowConfirm.mockResolvedValue(false);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled());
+    expect(deleteArticle).not.toHaveBeenCalled();
+  });
+
+  it("handles deletion error", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    (getDownloadedArticles as jest.Mock).mockResolvedValue(mockArticles);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    (deleteArticle as jest.Mock).mockRejectedValue(new Error("Delete failed"));
+    mockShowConfirm.mockResolvedValue(true);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(screen.getByText("削除に失敗しました")).toBeInTheDocument());
+  });
+
+  it("handles clear all when confirmed", async () => {
+    const mockArticles = [{ url: "https://example.com/1", totalChunks: 3, downloadedChunks: 3, totalSize: 5242880, timestamp: 1672531200000 }];
+    (getDownloadedArticles as jest.Mock).mockResolvedValueOnce(mockArticles).mockResolvedValueOnce([]);
+    (getStorageUsage as jest.Mock).mockResolvedValue({ used: 5242880, available: 100000000 });
+    (clearAll as jest.Mock).mockResolvedValue(undefined);
+    mockShowConfirm.mockResolvedValue(true);
+
+    render(<StorageManager />);
+
+    await waitFor(() => expect(screen.queryByText("読み込み中...")).not.toBeInTheDocument());
+
+    const clearAllButton = screen.getByRole("button", { name: "全て削除" });
+    fireEvent.click(clearAllButton);
+
+    await waitFor(() => expect(clearAll).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText("ダウンロード済みの記事がありません")).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for the previously untested StorageManager component by mocking IndexedDB, logger, and ConfirmDialog.
📊 **Coverage:** Covered initial loading, empty states, article rendering, deletion flows (confirm/cancel/error), and clear-all flows.
✨ **Result:** Enhanced the test coverage and reliability for storage cache management functionality.

---
*PR created automatically by Jules for task [2180542736056800212](https://jules.google.com/task/2180542736056800212) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

StorageManager コンポーネントに対するユニットテストを新規追加した PR です。IndexedDB・logger・ConfirmDialog をモックし、初期ローディング・空状態・記事描画・個別削除・全削除の各フローを網羅しています。

- `jest.resetAllMocks()` を使用してモック実装を各テスト間でリセットし、テストの独立性を確保している。
- 個別削除・全削除のいずれも「確認」「キャンセル」「エラー」の3ケースをカバーしており、過去のレビューコメントへの対応が完了している。
- 削除エラーテストにて `logger.error` のアサーションが欠落しており、全削除エラーテストとの一貫性に欠ける点が残っている。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト専用ファイルの追加のみで、プロダクションコードへの変更はなく安全にマージ可能です。

変更はテストファイルの新規追加のみであり、プロダクションコードには一切影響しません。モック戦略・テストケース構成ともに適切で、過去のレビュー指摘もすべて対応済みです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/components/__tests__/StorageManager.test.tsx | StorageManager コンポーネントの新規テストファイル。ローディング・空状態・記事レンダリング・削除フロー（確認/キャンセル/エラー）・全削除フローを網羅。`jest.resetAllMocks()` を使用した適切なモック管理。削除エラーテストで `logger.error` のアサーションが欠落している点を除き、品質は高い。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StorageManager レンダリング] --> B[loadData呼び出し]
    B --> C{Promise.all成功?}
    C -->|成功| D[記事一覧・ストレージ使用量表示]
    C -->|失敗| E[logger.error呼び出し\nローディング終了]
    D --> F{記事あり?}
    F -->|なし| G[空状態メッセージ表示]
    F -->|あり| H[記事一覧・全て削除ボタン表示]
    H --> I[削除ボタンクリック]
    I --> J[showConfirm呼び出し]
    J -->|キャンセル| K[処理終了]
    J -->|確認| L[deleteArticle呼び出し]
    L -->|成功| M[loadData再呼び出し]
    L -->|失敗| N[エラーUI表示\nlogger.error]
    H --> O[全て削除ボタンクリック]
    O --> P[showConfirm呼び出し]
    P -->|キャンセル| Q[処理終了]
    P -->|確認| R[clearAll呼び出し]
    R -->|成功| S[loadData再呼び出し]
    R -->|失敗| T[エラーUI表示\nlogger.error]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/web-app-vercel/components/__tests__/StorageManager.test.tsx:150-165
**削除エラー時の `logger.error` アサーションが欠落**

`handles deletion error` テストではエラー UI（`"削除に失敗しました"`）の表示確認のみで、コンポーネント内の `logger.error("記事の削除に失敗", err)` が呼ばれたかどうかを検証していません。`handles clear all error` テストでは同様のケースで `logger.error` の呼び出しをアサートしているため、一貫性に欠けます。`logger.error` の呼び出しを削除しても削除エラーテストはパスしてしまいます。

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover storage manager clear all br..."](https://github.com/hiroki-org/audicle/commit/77b5c3c463c165a0dc3903277aab49d8d514f815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36382261)</sub>

<!-- /greptile_comment -->