### PR TITLE
🔒 Fix SSRF TOCTOU vulnerability via Undici custom dispatcher

### DIFF
--- a/packages/web-app-vercel/app/api/extract/route.ts
+++ b/packages/web-app-vercel/app/api/extract/route.ts
@@ -5,6 +5,8 @@ import { normalizeArticleText } from "@/lib/parseArticle";
 import { parseHTML } from "linkedom";
 import { ExtractResponse } from "@/types/api";
 import { isSafeUrl } from "@/lib/ssrf";
+import dns from "dns";
+import ipaddr from "ipaddr.js";
 
 // Node.js runtimeを明示的に指定（JSDOMはEdge Runtimeで動作しない）
 export const runtime = "nodejs";
@@ -62,7 +64,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // HTMLを取得 (with secure redirect handling)
+    // HTMLを取得 (with secure redirect handling and SSRF dispatcher)
     const html = await fetchWithTimeout(url);
 
     // linkedomでパース
@@ -144,19 +146,69 @@ export async function POST(request: NextRequest) {
 }
 
 // Configure undici agent for custom fetch behavior
-// In test/CI environments, we might need to ignore SSL errors for internal services or proxies
-import { Agent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
+import { Agent, setGlobalDispatcher } from "undici";
 
-// Initialize global dispatcher if needed (safe to call multiple times)
-// This ensures fetch uses our custom agent settings
-if (process.env.NODE_ENV === "test" || process.env.CI === "true") {
-  const agent = new Agent({
-    connect: {
-      rejectUnauthorized: false,
-    },
+// Custom DNS lookup function that checks each resolved IP to prevent DNS rebinding (TOCTOU)
+const customLookup = (
+  hostname: string,
+  options: dns.LookupOptions,
+  callback: (err: NodeJS.ErrnoException | null, address: any, family: number) => void
+) => {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) return callback(err, address, family);
+
+    let isSafe = true;
+
+    // Check if the resolved address is safe
+    if (Array.isArray(address)) {
+      for (const item of address) {
+        try {
+          const ip = ipaddr.parse(item.address);
+          if (ip.range() !== "unicast") {
+            isSafe = false;
+            break;
+          }
+        } catch {
+          isSafe = false;
+          break;
+        }
+      }
+    } else {
+      try {
+        const ip = ipaddr.parse(address as unknown as string);
+        if (ip.range() !== "unicast") {
+          isSafe = false;
+        }
+      } catch {
+        isSafe = false;
+      }
+    }
+
+    if (!isSafe) {
+      const blockError = new Error("SSRF blocked: Hostname resolved to unsafe IP during fetch");
+      blockError.name = "SSRFBlockedError";
+      return callback(blockError as NodeJS.ErrnoException, address, family);
+    }
+
+    callback(null, address, family);
   });
-  setGlobalDispatcher(agent);
+};
+
+const agentOptions: any = {
+  connect: {
+    lookup: customLookup,
+  },
+};
+
+// In test/CI environments, we might need to ignore SSL errors for internal services or proxies
+if (process.env.NODE_ENV === "test" || process.env.CI === "true") {
+  agentOptions.connect.rejectUnauthorized = false;
 }
+
+// Initialize global dispatcher using the agent with our custom lookup
+const agent = new Agent(agentOptions);
+setGlobalDispatcher(agent);
+
 
 /**
  * タイムアウト付きでURLをフェッチ
@@ -237,6 +289,10 @@ async function fetchWithTimeout(
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       throw new TimeoutError("Fetch timeout");
+    }
+    // Convert fetch custom lookup error to SSRFBlockedError if applicable
+    if (error instanceof Error && (error.name === "SSRFBlockedError" || (error.cause && (error.cause as Error).name === "SSRFBlockedError"))) {
+       throw new SSRFBlockedError("Access to the redirect URL is restricted for security reasons");
     }
     throw error;
   } finally {

--- a/packages/web-app-vercel/package-lock.json
+++ b/packages/web-app-vercel/package-lock.json
@@ -24,7 +24,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
         "glob": "^13.0.6",
-        "ipaddr.js": "^2.3.0",
+        "ipaddr.js": "^2.4.0",
         "jsonwebtoken": "^9.0.2",
         "linkedom": "^0.18.3",
         "lucide-react": "^1.14.0",
@@ -35,7 +35,7 @@
         "react-hot-toast": "^2.6.0",
         "serwist": "^10.0.0-preview.14",
         "tailwind-merge": "^3.5.0",
-        "undici": "^6.25.0",
+        "undici": "^6.26.0",
         "use-debounce": "^10.1.1"
       },
       "devDependencies": {
@@ -11014,9 +11014,9 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -16477,9 +16477,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/packages/web-app-vercel/package.json
+++ b/packages/web-app-vercel/package.json
@@ -41,7 +41,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "glob": "^13.0.6",
-    "ipaddr.js": "^2.3.0",
+    "ipaddr.js": "^2.4.0",
     "jsonwebtoken": "^9.0.2",
     "linkedom": "^0.18.3",
     "lucide-react": "^1.14.0",
@@ -52,7 +52,7 @@
     "react-hot-toast": "^2.6.0",
     "serwist": "^10.0.0-preview.14",
     "tailwind-merge": "^3.5.0",
-    "undici": "^6.25.0",
+    "undici": "^6.26.0",
     "use-debounce": "^10.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
🎯 **What:** The initial SSRF check logic verified hostnames securely but allowed subsequent fetches using DNS. This introduced a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where a hostname (like `evil.com`) could be swapped during the fetch call using DNS rebinding, redirecting to local or internal IPs.

⚠️ **Risk:** A malicious user could exploit this to scan and access local networks, loopback addresses, or protected internal AWS/Vercel metadata APIs.

🛡️ **Solution:** Implemented a custom DNS `lookup` hook via Undici's `Agent` global dispatcher for `fetch`. This ensures that exactly during the DNS resolution of the outgoing connection, the resolved IP is verified strictly against allowed unicast ranges (rejecting private and loopback addresses). This guarantees that the IP checked is identical to the IP connected to, permanently eliminating the DNS rebinding vector.

---
*PR created automatically by Jules for task [15707528621283702781](https://jules.google.com/task/15707528621283702781) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

DNS リバインディングによる TOCTOU 型 SSRF 脆弱性を修正するため、Undici のカスタム DNS `lookup` フックを使って接続時にも解決済み IP を検証する仕組みを追加しました。あわせて `ipaddr.js` と `undici` をマイナーバージョンアップしています。

- `customLookup` 関数を Undici の `Agent` に組み込み、TCP 接続確立の直前に `dns.lookup` の結果を `ipaddr.js` で unicast チェック。これにより「検証した IP と接続する IP が同一」であることが保証される。
- `setGlobalDispatcher` を全環境（本番含む）で無条件に適用するよう変更し、DNS リバインディング保護をすべての `fetch` 呼び出しに拡大。
- `Array.isArray(address)` の配列チェックブランチは Undici が `{ all: true }` を渡さないためデッドコードとなっており、多少混乱を招く可能性がある。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

SSRF/DNS リバインディング対策の核心ロジックは正しく、接続時 IP 検証によって TOCTOU が実質排除されている。ただし Array.isArray のデッドコードと setGlobalDispatcher のグローバル副作用についてマージ前に確認が望ましい。

DNS ルックアップフックの仕組み自体は機能しており、セキュリティ修正の意図通りに動作する。一方、Array.isArray(address) ブランチは Undici の呼び出し規約上デッドコードであるため複数 IP を全部チェックしているという想定が実際には成立していない点と、setGlobalDispatcher を全環境でモジュールロード時に無条件適用することで他ルートの正規内部通信を意図せず遮断するリスクが残る。

packages/web-app-vercel/app/api/extract/route.ts — customLookup の実装詳細と setGlobalDispatcher の適用範囲を重点的に確認。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/web-app-vercel/app/api/extract/route.ts | Undici のカスタム DNS ルックアップフックで DNS リバインディング TOCTOU を修正。Array.isArray ブランチはデッドコード、setGlobalDispatcher の全環境適用による副作用、SSRFBlockedError の二重ラッピングなど複数の P2 が存在する。 |
| packages/web-app-vercel/package.json | ipaddr.js を 2.3.0→2.4.0、undici を 6.25.0→6.26.0 にバージョンアップ。問題なし。 |
| packages/web-app-vercel/package-lock.json | package.json のバージョン変更に対応するロックファイルの更新。問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant POST as POST /api/extract
    participant isSafeUrl
    participant fetchWithTimeout
    participant Undici as Undici (global dispatcher)
    participant customLookup as customLookup (DNS Hook)
    participant DNS as dns.lookup
    participant Target as Target Server

    Client->>POST: "POST { url }"
    POST->>isSafeUrl: isSafeUrl(url)
    isSafeUrl->>DNS: dns.lookup(hostname)
    DNS-->>isSafeUrl: IP アドレス
    isSafeUrl-->>POST: true / false

    POST->>fetchWithTimeout: fetchWithTimeout(url)
    fetchWithTimeout->>Undici: "fetch(url, { redirect: manual })"
    Undici->>customLookup: lookup(hostname, options, cb)
    customLookup->>DNS: dns.lookup(hostname, options)
    DNS-->>customLookup: address (string)
    alt address が unicast でない
        customLookup-->>Undici: callback(SSRFBlockedError)
        Undici-->>fetchWithTimeout: throw
        fetchWithTimeout-->>POST: throw SSRFBlockedError
        POST-->>Client: 403 Forbidden
    else address が unicast
        customLookup-->>Undici: callback(null, address, family)
        Undici->>Target: TCP 接続 (検証済み IP)
        Target-->>Undici: HTTP Response
        Undici-->>fetchWithTimeout: Response
    end

    fetchWithTimeout-->>POST: HTML
    POST-->>Client: 200 ExtractResponse
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/web-app-vercel/app/api/extract/route.ts:163-175
**Array.isArray ブランチは実質デッドコード**

Undici の接続コードは `lookup` を呼び出す際に `{ all: true }` を options に含めないため、`address` は常に文字列になります（配列にはなりません）。そのため `Array.isArray(address) === true` のブランチは実行されません。

万が一 Undici が将来 `{ all: true }` を渡すようになった場合、ブロックせずに通過した場合の `callback(null, address, family)` でアドレスとして配列が渡され、Undici が文字列を期待しているため接続が壊れる可能性があります。マルチ IP 保護が実際には機能していないことを確認の上、単一 IP のみを検証する現状の実装で十分か、または `{ all: true }` を明示的に自前で渡すよう設計を変更するか検討してください。

### Issue 2 of 4
packages/web-app-vercel/app/api/extract/route.ts:208-210
**`setGlobalDispatcher` が全環境・全ルートに無条件で適用される**

以前の実装では test/CI 環境のみ `setGlobalDispatcher` を呼び出していましたが、このモジュールがロードされると本番環境でも即座にグローバルディスパッチャが書き換えられます。Next.js の開発モード（`next dev`）では複数のルートが同一プロセスを共有するため、このルート以外で内部サービス（データベース、Vercel 内部 API 等）に対して `fetch` を使っている箇所がプライベート IP 帯に解決されると、`customLookup` に遮断されて予期せず壊れます。意図的にグローバルへ適用する設計であれば、その旨をコメントで明示し、副作用の有無を確認することをお勧めします。

### Issue 3 of 4
packages/web-app-vercel/app/api/extract/route.ts:197
`agentOptions: any` は型安全性を失います。Undici の `Agent` コンストラクタが受け入れる型である `Agent.Options` を使うと、オプションの誤りをコンパイル時に検出できます。

```suggestion
const agentOptions: Agent.Options = {
```

### Issue 4 of 4
packages/web-app-vercel/app/api/extract/route.ts:293-296
**`SSRFBlockedError` の二重ラッピング**

この catch ブロックでは、リダイレクトチェック（269行目）で投げられた `SSRFBlockedError` インスタンスも `error.name === "SSRFBlockedError"` に該当するため、同一メッセージで再ラップされます。動作上の問題はありませんが、スタックトレースが上書きされるため、デバッグ時に元の例外発生箇所が分かりにくくなります。`error instanceof SSRFBlockedError` の場合は `throw error` でそのまま再スローするよう条件を絞ることを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Fix SSRF TOCTOU vulnerability via Und..."](https://github.com/hiroki-org/audicle/commit/b0a5dd6d92e9670af87128e2433712093fba8d8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36383007)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->